### PR TITLE
mpsqa.lint: Add severity level to checkable scripts

### DIFF
--- a/code/languages/org.mpsqa.build/solutions/org.mpsqa.build/models/org.mpsqa.build._080_lint_build.mps
+++ b/code/languages/org.mpsqa.build/solutions/org.mpsqa.build/models/org.mpsqa.build._080_lint_build.mps
@@ -364,6 +364,11 @@
             <ref role="3bR37D" to="ffeo:1TaHNgiIbIZ" resolve="MPS.Editor" />
           </node>
         </node>
+        <node concept="1SiIV0" id="ST9rMmXyC6" role="3bR37C">
+          <node concept="3bR9La" id="ST9rMmXyC7" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:7Kfy9QB6Lh7" resolve="jetbrains.mps.typesystemEngine" />
+          </node>
+        </node>
       </node>
       <node concept="1E1JtA" id="3ywQ_KXEkYC" role="2G$12L">
         <property role="BnDLt" value="true" />

--- a/code/languages/org.mpsqa.lint/languages/org.mpsqa.lint.generic/models/org.mpsqa.lint.generic.editor.mps
+++ b/code/languages/org.mpsqa.lint/languages/org.mpsqa.lint.generic/models/org.mpsqa.lint.generic.editor.mps
@@ -227,6 +227,17 @@
       <node concept="18a60v" id="6gY6GEDxQjQ" role="3EZMnx">
         <node concept="VPM3Z" id="6gY6GEDxQjS" role="3F10Kt" />
       </node>
+      <node concept="3EZMnI" id="1c_Dn$lN_pQ" role="3EZMnx">
+        <node concept="VPM3Z" id="1c_Dn$lN_pS" role="3F10Kt" />
+        <node concept="3XFhqQ" id="1c_Dn$lN_s7" role="3EZMnx" />
+        <node concept="3F0ifn" id="1c_Dn$lN_sd" role="3EZMnx">
+          <property role="3F0ifm" value="Report findings as:" />
+        </node>
+        <node concept="3F0A7n" id="1c_Dn$lN_sr" role="3EZMnx">
+          <ref role="1NtTu8" to="a1af:1c_Dn$lNzde" resolve="reportLevel" />
+        </node>
+        <node concept="2iRfu4" id="1c_Dn$lN_pV" role="2iSdaV" />
+      </node>
       <node concept="PMmxH" id="6gY6GEDxQkS" role="3EZMnx">
         <ref role="PMmxG" node="6gY6GEDwP_H" resolve="EnableDeltaChecks" />
       </node>
@@ -331,6 +342,17 @@
           </node>
         </node>
         <node concept="2iRfu4" id="3ibIDIklSNJ" role="2iSdaV" />
+      </node>
+      <node concept="3EZMnI" id="1c_Dn$lPNfS" role="3EZMnx">
+        <node concept="VPM3Z" id="1c_Dn$lPNfU" role="3F10Kt" />
+        <node concept="3XFhqQ" id="1c_Dn$lPNgn" role="3EZMnx" />
+        <node concept="3F0ifn" id="1c_Dn$lPNrd" role="3EZMnx">
+          <property role="3F0ifm" value="Report findings as:" />
+        </node>
+        <node concept="3F0A7n" id="1c_Dn$lPNrl" role="3EZMnx">
+          <ref role="1NtTu8" to="a1af:1c_Dn$lP6D5" resolve="reportLevel" />
+        </node>
+        <node concept="2iRfu4" id="1c_Dn$lPNfX" role="2iSdaV" />
       </node>
       <node concept="PMmxH" id="6gY6GEDxQlu" role="3EZMnx">
         <ref role="PMmxG" node="6gY6GEDwP_H" resolve="EnableDeltaChecks" />

--- a/code/languages/org.mpsqa.lint/languages/org.mpsqa.lint.generic/models/org.mpsqa.lint.generic.editor.mps
+++ b/code/languages/org.mpsqa.lint/languages/org.mpsqa.lint.generic/models/org.mpsqa.lint.generic.editor.mps
@@ -227,16 +227,8 @@
       <node concept="18a60v" id="6gY6GEDxQjQ" role="3EZMnx">
         <node concept="VPM3Z" id="6gY6GEDxQjS" role="3F10Kt" />
       </node>
-      <node concept="3EZMnI" id="1c_Dn$lN_pQ" role="3EZMnx">
-        <node concept="VPM3Z" id="1c_Dn$lN_pS" role="3F10Kt" />
-        <node concept="3XFhqQ" id="1c_Dn$lN_s7" role="3EZMnx" />
-        <node concept="3F0ifn" id="1c_Dn$lN_sd" role="3EZMnx">
-          <property role="3F0ifm" value="Report findings as:" />
-        </node>
-        <node concept="3F0A7n" id="1c_Dn$lN_sr" role="3EZMnx">
-          <ref role="1NtTu8" to="a1af:1c_Dn$lNzde" resolve="reportLevel" />
-        </node>
-        <node concept="2iRfu4" id="1c_Dn$lN_pV" role="2iSdaV" />
+      <node concept="PMmxH" id="ST9rMmWucc" role="3EZMnx">
+        <ref role="PMmxG" node="ST9rMmWg4s" resolve="SeverityLevelEditorComponent" />
       </node>
       <node concept="PMmxH" id="6gY6GEDxQkS" role="3EZMnx">
         <ref role="PMmxG" node="6gY6GEDwP_H" resolve="EnableDeltaChecks" />
@@ -343,16 +335,8 @@
         </node>
         <node concept="2iRfu4" id="3ibIDIklSNJ" role="2iSdaV" />
       </node>
-      <node concept="3EZMnI" id="1c_Dn$lPNfS" role="3EZMnx">
-        <node concept="VPM3Z" id="1c_Dn$lPNfU" role="3F10Kt" />
-        <node concept="3XFhqQ" id="1c_Dn$lPNgn" role="3EZMnx" />
-        <node concept="3F0ifn" id="1c_Dn$lPNrd" role="3EZMnx">
-          <property role="3F0ifm" value="Report findings as:" />
-        </node>
-        <node concept="3F0A7n" id="1c_Dn$lPNrl" role="3EZMnx">
-          <ref role="1NtTu8" to="a1af:1c_Dn$lP6D5" resolve="reportLevel" />
-        </node>
-        <node concept="2iRfu4" id="1c_Dn$lPNfX" role="2iSdaV" />
+      <node concept="PMmxH" id="ST9rMmWgg8" role="3EZMnx">
+        <ref role="PMmxG" node="ST9rMmWg4s" resolve="SeverityLevelEditorComponent" />
       </node>
       <node concept="PMmxH" id="6gY6GEDxQlu" role="3EZMnx">
         <ref role="PMmxG" node="6gY6GEDwP_H" resolve="EnableDeltaChecks" />
@@ -769,6 +753,21 @@
       <node concept="3F0A7n" id="78RogMCKx0I" role="3EZMnx">
         <ref role="1NtTu8" to="a1af:78RogMCGEUf" resolve="resultNodeId" />
       </node>
+    </node>
+  </node>
+  <node concept="PKFIW" id="ST9rMmWg4s">
+    <property role="TrG5h" value="SeverityLevelEditorComponent" />
+    <ref role="1XX52x" to="a1af:ST9rMmWg3T" resolve="ISeverityLevelAwareChecker" />
+    <node concept="3EZMnI" id="ST9rMmWgft" role="2wV5jI">
+      <node concept="VPM3Z" id="ST9rMmWgfu" role="3F10Kt" />
+      <node concept="3XFhqQ" id="ST9rMmWgfv" role="3EZMnx" />
+      <node concept="3F0ifn" id="ST9rMmWgfw" role="3EZMnx">
+        <property role="3F0ifm" value="Report findings as:" />
+      </node>
+      <node concept="3F0A7n" id="ST9rMmWgfx" role="3EZMnx">
+        <ref role="1NtTu8" to="a1af:ST9rMmWgfD" resolve="reportLevel" />
+      </node>
+      <node concept="2iRfu4" id="ST9rMmWgfy" role="2iSdaV" />
     </node>
   </node>
 </model>

--- a/code/languages/org.mpsqa.lint/languages/org.mpsqa.lint.generic/models/org.mpsqa.lint.generic.structure.mps
+++ b/code/languages/org.mpsqa.lint/languages/org.mpsqa.lint.generic/models/org.mpsqa.lint.generic.structure.mps
@@ -84,11 +84,6 @@
       <property role="TrG5h" value="skipEvaluation" />
       <ref role="AX2Wp" to="tpck:fKAQMTB" resolve="boolean" />
     </node>
-    <node concept="1TJgyi" id="1c_Dn$lNzde" role="1TKVEl">
-      <property role="IQ2nx" value="1379690800334385998" />
-      <property role="TrG5h" value="reportLevel" />
-      <ref role="AX2Wp" node="1c_Dn$lNzd5" resolve="EReportSeverityLevel" />
-    </node>
     <node concept="1TJgyj" id="2dSiT1hKFVo" role="1TKVEi">
       <property role="IQ2ns" value="2555875871751847640" />
       <property role="20lmBu" value="fLJjDmT/aggregation" />
@@ -106,6 +101,9 @@
     </node>
     <node concept="PrWs8" id="6gY6GEDxQkP" role="PzmwI">
       <ref role="PrY4T" node="6gY6GEDvQYV" resolve="ILinterResultsContainer" />
+    </node>
+    <node concept="PrWs8" id="ST9rMmWg3Y" role="PzmwI">
+      <ref role="PrY4T" node="ST9rMmWg3T" resolve="ISeverityLevelAwareChecker" />
     </node>
     <node concept="1irR5M" id="2dSiT1hKS3v" role="rwd14">
       <property role="2$rrk2" value="1" />
@@ -147,6 +145,9 @@
     <node concept="PrWs8" id="6gY6GEDxQl8" role="PzmwI">
       <ref role="PrY4T" node="6gY6GEDvQYV" resolve="ILinterResultsContainer" />
     </node>
+    <node concept="PrWs8" id="ST9rMmWg3U" role="PzmwI">
+      <ref role="PrY4T" node="ST9rMmWg3T" resolve="ISeverityLevelAwareChecker" />
+    </node>
     <node concept="1irR5M" id="3ibIDIkmpeS" role="rwd14">
       <property role="2$rrk2" value="2" />
       <node concept="1irPie" id="3ibIDIkmpeW" role="1irR9h">
@@ -155,11 +156,6 @@
           <property role="3PKj8l" value="FF9999" />
         </node>
       </node>
-    </node>
-    <node concept="1TJgyi" id="1c_Dn$lP6D5" role="1TKVEl">
-      <property role="IQ2nx" value="1379690800334793285" />
-      <property role="TrG5h" value="reportLevel" />
-      <ref role="AX2Wp" node="1c_Dn$lNzd5" resolve="EReportSeverityLevel" />
     </node>
   </node>
   <node concept="1TIwiD" id="6gY6GEDvQYS">
@@ -215,6 +211,15 @@
     <node concept="25R33" id="1c_Dn$lNzda" role="25R1y">
       <property role="3tVfz5" value="1379690800334385994" />
       <property role="TrG5h" value="INFO" />
+    </node>
+  </node>
+  <node concept="PlHQZ" id="ST9rMmWg3T">
+    <property role="EcuMT" value="1024891882119954681" />
+    <property role="TrG5h" value="ISeverityLevelAwareChecker" />
+    <node concept="1TJgyi" id="ST9rMmWgfD" role="1TKVEl">
+      <property role="IQ2nx" value="1024891882119955433" />
+      <property role="TrG5h" value="reportLevel" />
+      <ref role="AX2Wp" node="1c_Dn$lNzd5" resolve="EReportSeverityLevel" />
     </node>
   </node>
 </model>

--- a/code/languages/org.mpsqa.lint/languages/org.mpsqa.lint.generic/models/org.mpsqa.lint.generic.structure.mps
+++ b/code/languages/org.mpsqa.lint/languages/org.mpsqa.lint.generic/models/org.mpsqa.lint.generic.structure.mps
@@ -25,6 +25,16 @@
       </concept>
     </language>
     <language id="c72da2b9-7cce-4447-8389-f407dc1158b7" name="jetbrains.mps.lang.structure">
+      <concept id="3348158742936976480" name="jetbrains.mps.lang.structure.structure.EnumerationMemberDeclaration" flags="ng" index="25R33">
+        <property id="1421157252384165432" name="memberId" index="3tVfz5" />
+      </concept>
+      <concept id="3348158742936976479" name="jetbrains.mps.lang.structure.structure.EnumerationDeclaration" flags="ng" index="25R3W">
+        <reference id="1075010451642646892" name="defaultMember" index="1H5jkz" />
+        <child id="3348158742936976577" name="members" index="25R1y" />
+      </concept>
+      <concept id="1082978164218" name="jetbrains.mps.lang.structure.structure.DataTypeDeclaration" flags="ng" index="AxPO6">
+        <property id="7791109065626895363" name="datatypeId" index="3F6X1D" />
+      </concept>
       <concept id="1169125787135" name="jetbrains.mps.lang.structure.structure.AbstractConceptDeclaration" flags="ig" index="PkWjJ">
         <property id="6714410169261853888" name="conceptId" index="EcuMT" />
         <property id="4628067390765907488" name="conceptShortDescription" index="R4oN_" />
@@ -73,6 +83,11 @@
       <property role="IQ2nx" value="6685385159444651026" />
       <property role="TrG5h" value="skipEvaluation" />
       <ref role="AX2Wp" to="tpck:fKAQMTB" resolve="boolean" />
+    </node>
+    <node concept="1TJgyi" id="1c_Dn$lNzde" role="1TKVEl">
+      <property role="IQ2nx" value="1379690800334385998" />
+      <property role="TrG5h" value="reportLevel" />
+      <ref role="AX2Wp" node="1c_Dn$lNzd5" resolve="EReportSeverityLevel" />
     </node>
     <node concept="1TJgyj" id="2dSiT1hKFVo" role="1TKVEi">
       <property role="IQ2ns" value="2555875871751847640" />
@@ -141,6 +156,11 @@
         </node>
       </node>
     </node>
+    <node concept="1TJgyi" id="1c_Dn$lP6D5" role="1TKVEl">
+      <property role="IQ2nx" value="1379690800334793285" />
+      <property role="TrG5h" value="reportLevel" />
+      <ref role="AX2Wp" node="1c_Dn$lNzd5" resolve="EReportSeverityLevel" />
+    </node>
   </node>
   <node concept="1TIwiD" id="6gY6GEDvQYS">
     <property role="EcuMT" value="7223240310078271416" />
@@ -178,6 +198,23 @@
       <property role="20kJfa" value="violations" />
       <property role="20lbJX" value="fLJekj5/_0__n" />
       <ref role="20lvS9" node="6gY6GEDvQYS" resolve="ResultEntry" />
+    </node>
+  </node>
+  <node concept="25R3W" id="1c_Dn$lNzd5">
+    <property role="3F6X1D" value="1379690800334385989" />
+    <property role="TrG5h" value="EReportSeverityLevel" />
+    <ref role="1H5jkz" node="1c_Dn$lNzd6" resolve="ERROR" />
+    <node concept="25R33" id="1c_Dn$lNzd6" role="25R1y">
+      <property role="3tVfz5" value="1379690800334385990" />
+      <property role="TrG5h" value="ERROR" />
+    </node>
+    <node concept="25R33" id="1c_Dn$lNzd7" role="25R1y">
+      <property role="3tVfz5" value="1379690800334385991" />
+      <property role="TrG5h" value="WARNING" />
+    </node>
+    <node concept="25R33" id="1c_Dn$lNzda" role="25R1y">
+      <property role="3tVfz5" value="1379690800334385994" />
+      <property role="TrG5h" value="INFO" />
     </node>
   </node>
 </model>

--- a/code/languages/org.mpsqa.lint/languages/org.mpsqa.lint.generic/models/org.mpsqa.lint.generic.typesystem.mps
+++ b/code/languages/org.mpsqa.lint/languages/org.mpsqa.lint.generic/models/org.mpsqa.lint.generic.typesystem.mps
@@ -71,6 +71,7 @@
       <concept id="1068580123159" name="jetbrains.mps.baseLanguage.structure.IfStatement" flags="nn" index="3clFbJ">
         <child id="1068580123160" name="condition" index="3clFbw" />
         <child id="1068580123161" name="ifTrue" index="3clFbx" />
+        <child id="1206060520071" name="elsifClauses" index="3eNLev" />
       </concept>
       <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
         <child id="1068581517665" name="statement" index="3cqZAp" />
@@ -83,6 +84,10 @@
         <child id="1068581242865" name="localVariableDeclaration" index="3cpWs9" />
       </concept>
       <concept id="1068581242863" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclaration" flags="nr" index="3cpWsn" />
+      <concept id="1206060495898" name="jetbrains.mps.baseLanguage.structure.ElsifClause" flags="ng" index="3eNFk2">
+        <child id="1206060619838" name="condition" index="3eO9$A" />
+        <child id="1206060644605" name="statementList" index="3eOfB_" />
+      </concept>
       <concept id="1081516740877" name="jetbrains.mps.baseLanguage.structure.NotExpression" flags="nn" index="3fqX7Q">
         <child id="1081516765348" name="expression" index="3fr31v" />
       </concept>
@@ -111,6 +116,9 @@
       <concept id="1207055528241" name="jetbrains.mps.lang.typesystem.structure.WarningStatement" flags="nn" index="a7r0C">
         <child id="1207055552304" name="warningText" index="a7wSD" />
       </concept>
+      <concept id="1224760201579" name="jetbrains.mps.lang.typesystem.structure.InfoStatement" flags="nn" index="Dpp1Q">
+        <child id="1224760230762" name="infoText" index="Dpw9R" />
+      </concept>
       <concept id="1175517767210" name="jetbrains.mps.lang.typesystem.structure.ReportErrorStatement" flags="nn" index="2MkqsV">
         <child id="1175517851849" name="errorString" index="2MkJ7o" />
       </concept>
@@ -134,6 +142,12 @@
       </concept>
     </language>
     <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
+      <concept id="4705942098322609812" name="jetbrains.mps.lang.smodel.structure.EnumMember_IsOperation" flags="ng" index="21noJN">
+        <child id="4705942098322609813" name="member" index="21noJM" />
+      </concept>
+      <concept id="4705942098322467729" name="jetbrains.mps.lang.smodel.structure.EnumMemberReference" flags="ng" index="21nZrQ">
+        <reference id="4705942098322467736" name="decl" index="21nZrZ" />
+      </concept>
       <concept id="1179409122411" name="jetbrains.mps.lang.smodel.structure.Node_ConceptMethodCall" flags="nn" index="2qgKlT" />
       <concept id="1143226024141" name="jetbrains.mps.lang.smodel.structure.SModelType" flags="in" index="H_c77" />
       <concept id="1143234257716" name="jetbrains.mps.lang.smodel.structure.Node_GetModelOperation" flags="nn" index="I4A8Y" />
@@ -252,26 +266,129 @@
           <ref role="3cqZAo" node="2dSiT1hLkDD" resolve="results" />
         </node>
         <node concept="3clFbS" id="6gY6GEDv4vD" role="2LFqv$">
-          <node concept="2MkqsV" id="6gY6GEDv4vE" role="3cqZAp">
-            <node concept="3cpWs3" id="6gY6GEDv4vF" role="2MkJ7o">
-              <node concept="2OqwBi" id="78RogMCFqzG" role="3uHU7w">
-                <node concept="2GrUjf" id="6gY6GEDv4vG" role="2Oq$k0">
-                  <ref role="2Gs0qQ" node="6gY6GEDv4vB" resolve="res" />
+          <node concept="3clFbJ" id="1c_Dn$lOk0K" role="3cqZAp">
+            <node concept="3clFbS" id="1c_Dn$lOk0M" role="3clFbx">
+              <node concept="2MkqsV" id="6gY6GEDv4vE" role="3cqZAp">
+                <node concept="3cpWs3" id="6gY6GEDv4vF" role="2MkJ7o">
+                  <node concept="2OqwBi" id="78RogMCFqzG" role="3uHU7w">
+                    <node concept="2GrUjf" id="6gY6GEDv4vG" role="2Oq$k0">
+                      <ref role="2Gs0qQ" node="6gY6GEDv4vB" resolve="res" />
+                    </node>
+                    <node concept="2OwXpG" id="78RogMCFr36" role="2OqNvi">
+                      <ref role="2Oxat5" to="zn9m:~Pair.first" resolve="first" />
+                    </node>
+                  </node>
+                  <node concept="Xl_RD" id="6gY6GEDv4vH" role="3uHU7B">
+                    <property role="Xl_RC" value="errors found: " />
+                  </node>
                 </node>
-                <node concept="2OwXpG" id="78RogMCFr36" role="2OqNvi">
-                  <ref role="2Oxat5" to="zn9m:~Pair.first" resolve="first" />
+                <node concept="2OqwBi" id="78RogMCFrUl" role="1urrMF">
+                  <node concept="2GrUjf" id="78RogMCFrlg" role="2Oq$k0">
+                    <ref role="2Gs0qQ" node="6gY6GEDv4vB" resolve="res" />
+                  </node>
+                  <node concept="2OwXpG" id="78RogMCFsqw" role="2OqNvi">
+                    <ref role="2Oxat5" to="zn9m:~Pair.second" resolve="second" />
+                  </node>
                 </node>
-              </node>
-              <node concept="Xl_RD" id="6gY6GEDv4vH" role="3uHU7B">
-                <property role="Xl_RC" value="errors found: " />
               </node>
             </node>
-            <node concept="2OqwBi" id="78RogMCFrUl" role="1urrMF">
-              <node concept="2GrUjf" id="78RogMCFrlg" role="2Oq$k0">
-                <ref role="2Gs0qQ" node="6gY6GEDv4vB" resolve="res" />
+            <node concept="2OqwBi" id="1c_Dn$lOlVl" role="3clFbw">
+              <node concept="2OqwBi" id="1c_Dn$lOkb_" role="2Oq$k0">
+                <node concept="1YBJjd" id="1c_Dn$lOk18" role="2Oq$k0">
+                  <ref role="1YBMHb" node="2dSiT1hL2_K" resolve="checkableScript" />
+                </node>
+                <node concept="3TrcHB" id="1c_Dn$lOkYK" role="2OqNvi">
+                  <ref role="3TsBF5" to="a1af:1c_Dn$lNzde" resolve="reportLevel" />
+                </node>
               </node>
-              <node concept="2OwXpG" id="78RogMCFsqw" role="2OqNvi">
-                <ref role="2Oxat5" to="zn9m:~Pair.second" resolve="second" />
+              <node concept="21noJN" id="1c_Dn$lOmBz" role="2OqNvi">
+                <node concept="21nZrQ" id="1c_Dn$lOmB_" role="21noJM">
+                  <ref role="21nZrZ" to="a1af:1c_Dn$lNzd6" resolve="ERROR" />
+                </node>
+              </node>
+            </node>
+            <node concept="3eNFk2" id="1c_Dn$lOpK0" role="3eNLev">
+              <node concept="2OqwBi" id="1c_Dn$lOrKZ" role="3eO9$A">
+                <node concept="2OqwBi" id="1c_Dn$lOqvR" role="2Oq$k0">
+                  <node concept="1YBJjd" id="1c_Dn$lOqlq" role="2Oq$k0">
+                    <ref role="1YBMHb" node="2dSiT1hL2_K" resolve="checkableScript" />
+                  </node>
+                  <node concept="3TrcHB" id="1c_Dn$lOrld" role="2OqNvi">
+                    <ref role="3TsBF5" to="a1af:1c_Dn$lNzde" resolve="reportLevel" />
+                  </node>
+                </node>
+                <node concept="21noJN" id="1c_Dn$lOsbx" role="2OqNvi">
+                  <node concept="21nZrQ" id="1c_Dn$lOsbz" role="21noJM">
+                    <ref role="21nZrZ" to="a1af:1c_Dn$lNzd7" resolve="WARNING" />
+                  </node>
+                </node>
+              </node>
+              <node concept="3clFbS" id="1c_Dn$lOpK2" role="3eOfB_">
+                <node concept="a7r0C" id="1c_Dn$lOt5g" role="3cqZAp">
+                  <node concept="3cpWs3" id="1c_Dn$lOtnW" role="a7wSD">
+                    <node concept="2OqwBi" id="1c_Dn$lOtLm" role="3uHU7w">
+                      <node concept="2GrUjf" id="1c_Dn$lOtzW" role="2Oq$k0">
+                        <ref role="2Gs0qQ" node="6gY6GEDv4vB" resolve="res" />
+                      </node>
+                      <node concept="2OwXpG" id="1c_Dn$lOugi" role="2OqNvi">
+                        <ref role="2Oxat5" to="zn9m:~Pair.first" resolve="first" />
+                      </node>
+                    </node>
+                    <node concept="Xl_RD" id="1c_Dn$lOt5y" role="3uHU7B">
+                      <property role="Xl_RC" value="warnings found: " />
+                    </node>
+                  </node>
+                  <node concept="2OqwBi" id="1c_Dn$lOu_w" role="1urrMF">
+                    <node concept="2GrUjf" id="1c_Dn$lOurF" role="2Oq$k0">
+                      <ref role="2Gs0qQ" node="6gY6GEDv4vB" resolve="res" />
+                    </node>
+                    <node concept="2OwXpG" id="1c_Dn$lOuR5" role="2OqNvi">
+                      <ref role="2Oxat5" to="zn9m:~Pair.second" resolve="second" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3eNFk2" id="1c_Dn$lOnhA" role="3eNLev">
+              <node concept="3clFbS" id="1c_Dn$lOnhC" role="3eOfB_">
+                <node concept="Dpp1Q" id="1c_Dn$lOnW4" role="3cqZAp">
+                  <node concept="3cpWs3" id="1c_Dn$lOoeK" role="Dpw9R">
+                    <node concept="2OqwBi" id="1c_Dn$lOosr" role="3uHU7w">
+                      <node concept="2GrUjf" id="1c_Dn$lOof8" role="2Oq$k0">
+                        <ref role="2Gs0qQ" node="6gY6GEDv4vB" resolve="res" />
+                      </node>
+                      <node concept="2OwXpG" id="1c_Dn$lOoU9" role="2OqNvi">
+                        <ref role="2Oxat5" to="zn9m:~Pair.first" resolve="first" />
+                      </node>
+                    </node>
+                    <node concept="Xl_RD" id="1c_Dn$lOnWm" role="3uHU7B">
+                      <property role="Xl_RC" value="violations found: " />
+                    </node>
+                  </node>
+                  <node concept="2OqwBi" id="1c_Dn$lOp6H" role="1urrMF">
+                    <node concept="2GrUjf" id="1c_Dn$lOoYt" role="2Oq$k0">
+                      <ref role="2Gs0qQ" node="6gY6GEDv4vB" resolve="res" />
+                    </node>
+                    <node concept="2OwXpG" id="1c_Dn$lOp_n" role="2OqNvi">
+                      <ref role="2Oxat5" to="zn9m:~Pair.second" resolve="second" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="2OqwBi" id="1c_Dn$lOnVd" role="3eO9$A">
+                <node concept="2OqwBi" id="1c_Dn$lOnVe" role="2Oq$k0">
+                  <node concept="1YBJjd" id="1c_Dn$lOnVf" role="2Oq$k0">
+                    <ref role="1YBMHb" node="2dSiT1hL2_K" resolve="checkableScript" />
+                  </node>
+                  <node concept="3TrcHB" id="1c_Dn$lOnVg" role="2OqNvi">
+                    <ref role="3TsBF5" to="a1af:1c_Dn$lNzde" resolve="reportLevel" />
+                  </node>
+                </node>
+                <node concept="21noJN" id="1c_Dn$lOnVh" role="2OqNvi">
+                  <node concept="21nZrQ" id="1c_Dn$lOnVi" role="21noJM">
+                    <ref role="21nZrZ" to="a1af:1c_Dn$lNzda" resolve="INFO" />
+                  </node>
+                </node>
               </node>
             </node>
           </node>
@@ -429,29 +546,133 @@
           <ref role="3cqZAo" node="6gY6GEDxQPm" resolve="results" />
         </node>
         <node concept="3clFbS" id="6gY6GEDv42v" role="2LFqv$">
-          <node concept="2MkqsV" id="3ibIDIkmkcp" role="3cqZAp">
-            <node concept="3cpWs3" id="3ibIDIkmkcq" role="2MkJ7o">
-              <node concept="2OqwBi" id="78RogMCFt1P" role="3uHU7w">
-                <node concept="2GrUjf" id="6gY6GEDv4mE" role="2Oq$k0">
-                  <ref role="2Gs0qQ" node="6gY6GEDv42r" resolve="res" />
+          <node concept="3clFbJ" id="1c_Dn$lP8yS" role="3cqZAp">
+            <node concept="3clFbS" id="1c_Dn$lP8yT" role="3clFbx">
+              <node concept="2MkqsV" id="1c_Dn$lP8yU" role="3cqZAp">
+                <node concept="3cpWs3" id="1c_Dn$lP8yV" role="2MkJ7o">
+                  <node concept="2OqwBi" id="1c_Dn$lP8yW" role="3uHU7w">
+                    <node concept="2GrUjf" id="1c_Dn$lP8yX" role="2Oq$k0">
+                      <ref role="2Gs0qQ" node="6gY6GEDv42r" resolve="res" />
+                    </node>
+                    <node concept="2OwXpG" id="1c_Dn$lP8yY" role="2OqNvi">
+                      <ref role="2Oxat5" to="zn9m:~Pair.first" resolve="first" />
+                    </node>
+                  </node>
+                  <node concept="Xl_RD" id="1c_Dn$lP8yZ" role="3uHU7B">
+                    <property role="Xl_RC" value="errors found: " />
+                  </node>
                 </node>
-                <node concept="2OwXpG" id="78RogMCFtxu" role="2OqNvi">
-                  <ref role="2Oxat5" to="zn9m:~Pair.first" resolve="first" />
+                <node concept="2OqwBi" id="1c_Dn$lP8z0" role="1urrMF">
+                  <node concept="2GrUjf" id="1c_Dn$lP8z1" role="2Oq$k0">
+                    <ref role="2Gs0qQ" node="6gY6GEDv42r" resolve="res" />
+                  </node>
+                  <node concept="2OwXpG" id="1c_Dn$lP8z2" role="2OqNvi">
+                    <ref role="2Oxat5" to="zn9m:~Pair.second" resolve="second" />
+                  </node>
                 </node>
-              </node>
-              <node concept="Xl_RD" id="3ibIDIkmkcs" role="3uHU7B">
-                <property role="Xl_RC" value="errors found: " />
               </node>
             </node>
-            <node concept="2OqwBi" id="78RogMCFua3" role="1urrMF">
-              <node concept="2GrUjf" id="78RogMCFtVd" role="2Oq$k0">
-                <ref role="2Gs0qQ" node="6gY6GEDv42r" resolve="res" />
+            <node concept="2OqwBi" id="1c_Dn$lP8z3" role="3clFbw">
+              <node concept="2OqwBi" id="1c_Dn$lP8z4" role="2Oq$k0">
+                <node concept="1YBJjd" id="1c_Dn$lP8z5" role="2Oq$k0">
+                  <ref role="1YBMHb" node="3ibIDIkmjX4" resolve="reuseCheckableScript" />
+                </node>
+                <node concept="3TrcHB" id="1c_Dn$lP8z6" role="2OqNvi">
+                  <ref role="3TsBF5" to="a1af:1c_Dn$lP6D5" resolve="reportLevel" />
+                </node>
               </node>
-              <node concept="2OwXpG" id="78RogMCFuEe" role="2OqNvi">
-                <ref role="2Oxat5" to="zn9m:~Pair.second" resolve="second" />
+              <node concept="21noJN" id="1c_Dn$lP8z7" role="2OqNvi">
+                <node concept="21nZrQ" id="1c_Dn$lP8z8" role="21noJM">
+                  <ref role="21nZrZ" to="a1af:1c_Dn$lNzd6" resolve="ERROR" />
+                </node>
+              </node>
+            </node>
+            <node concept="3eNFk2" id="1c_Dn$lP8z9" role="3eNLev">
+              <node concept="2OqwBi" id="1c_Dn$lP8za" role="3eO9$A">
+                <node concept="2OqwBi" id="1c_Dn$lP8zb" role="2Oq$k0">
+                  <node concept="1YBJjd" id="1c_Dn$lP8zc" role="2Oq$k0">
+                    <ref role="1YBMHb" node="3ibIDIkmjX4" resolve="reuseCheckableScript" />
+                  </node>
+                  <node concept="3TrcHB" id="1c_Dn$lP8zd" role="2OqNvi">
+                    <ref role="3TsBF5" to="a1af:1c_Dn$lP6D5" resolve="reportLevel" />
+                  </node>
+                </node>
+                <node concept="21noJN" id="1c_Dn$lP8ze" role="2OqNvi">
+                  <node concept="21nZrQ" id="1c_Dn$lP8zf" role="21noJM">
+                    <ref role="21nZrZ" to="a1af:1c_Dn$lNzd7" resolve="WARNING" />
+                  </node>
+                </node>
+              </node>
+              <node concept="3clFbS" id="1c_Dn$lP8zg" role="3eOfB_">
+                <node concept="a7r0C" id="1c_Dn$lP8zh" role="3cqZAp">
+                  <node concept="3cpWs3" id="1c_Dn$lP8zi" role="a7wSD">
+                    <node concept="2OqwBi" id="1c_Dn$lP8zj" role="3uHU7w">
+                      <node concept="2GrUjf" id="1c_Dn$lP8zk" role="2Oq$k0">
+                        <ref role="2Gs0qQ" node="6gY6GEDv42r" resolve="res" />
+                      </node>
+                      <node concept="2OwXpG" id="1c_Dn$lP8zl" role="2OqNvi">
+                        <ref role="2Oxat5" to="zn9m:~Pair.first" resolve="first" />
+                      </node>
+                    </node>
+                    <node concept="Xl_RD" id="1c_Dn$lP8zm" role="3uHU7B">
+                      <property role="Xl_RC" value="warnings found: " />
+                    </node>
+                  </node>
+                  <node concept="2OqwBi" id="1c_Dn$lP8zn" role="1urrMF">
+                    <node concept="2GrUjf" id="1c_Dn$lP8zo" role="2Oq$k0">
+                      <ref role="2Gs0qQ" node="6gY6GEDv42r" resolve="res" />
+                    </node>
+                    <node concept="2OwXpG" id="1c_Dn$lP8zp" role="2OqNvi">
+                      <ref role="2Oxat5" to="zn9m:~Pair.second" resolve="second" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3eNFk2" id="1c_Dn$lP8zq" role="3eNLev">
+              <node concept="3clFbS" id="1c_Dn$lP8zr" role="3eOfB_">
+                <node concept="Dpp1Q" id="1c_Dn$lP8zs" role="3cqZAp">
+                  <node concept="3cpWs3" id="1c_Dn$lP8zt" role="Dpw9R">
+                    <node concept="2OqwBi" id="1c_Dn$lP8zu" role="3uHU7w">
+                      <node concept="2GrUjf" id="1c_Dn$lP8zv" role="2Oq$k0">
+                        <ref role="2Gs0qQ" node="6gY6GEDv42r" resolve="res" />
+                      </node>
+                      <node concept="2OwXpG" id="1c_Dn$lP8zw" role="2OqNvi">
+                        <ref role="2Oxat5" to="zn9m:~Pair.first" resolve="first" />
+                      </node>
+                    </node>
+                    <node concept="Xl_RD" id="1c_Dn$lP8zx" role="3uHU7B">
+                      <property role="Xl_RC" value="violations found: " />
+                    </node>
+                  </node>
+                  <node concept="2OqwBi" id="1c_Dn$lP8zy" role="1urrMF">
+                    <node concept="2GrUjf" id="1c_Dn$lP8zz" role="2Oq$k0">
+                      <ref role="2Gs0qQ" node="6gY6GEDv42r" resolve="res" />
+                    </node>
+                    <node concept="2OwXpG" id="1c_Dn$lP8z$" role="2OqNvi">
+                      <ref role="2Oxat5" to="zn9m:~Pair.second" resolve="second" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="2OqwBi" id="1c_Dn$lP8z_" role="3eO9$A">
+                <node concept="2OqwBi" id="1c_Dn$lP8zA" role="2Oq$k0">
+                  <node concept="1YBJjd" id="1c_Dn$lP8zB" role="2Oq$k0">
+                    <ref role="1YBMHb" node="3ibIDIkmjX4" resolve="reuseCheckableScript" />
+                  </node>
+                  <node concept="3TrcHB" id="1c_Dn$lP8zC" role="2OqNvi">
+                    <ref role="3TsBF5" to="a1af:1c_Dn$lP6D5" resolve="reportLevel" />
+                  </node>
+                </node>
+                <node concept="21noJN" id="1c_Dn$lP8zD" role="2OqNvi">
+                  <node concept="21nZrQ" id="1c_Dn$lP8zE" role="21noJM">
+                    <ref role="21nZrZ" to="a1af:1c_Dn$lNzda" resolve="INFO" />
+                  </node>
+                </node>
               </node>
             </node>
           </node>
+          <node concept="3clFbH" id="1c_Dn$lP8yH" role="3cqZAp" />
         </node>
       </node>
       <node concept="3clFbH" id="6gY6GEDxTKa" role="3cqZAp" />

--- a/code/languages/org.mpsqa.lint/languages/org.mpsqa.lint.generic/models/org.mpsqa.lint.generic.typesystem.mps
+++ b/code/languages/org.mpsqa.lint/languages/org.mpsqa.lint.generic/models/org.mpsqa.lint.generic.typesystem.mps
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <model ref="r:608506d3-3472-4b1d-929c-779e49cabb27(org.mpsqa.lint.generic.typesystem)">
   <persistence version="9" />
+  <attribute name="doNotGenerate" value="false" />
   <languages>
     <use id="7a5dda62-9140-4668-ab76-d5ed1746f2b2" name="jetbrains.mps.lang.typesystem" version="5" />
     <use id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage" version="11" />
@@ -16,6 +17,7 @@
     <import index="zn9m" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.openapi.util(MPS.IDEA/)" />
     <import index="b659" ref="r:654c665e-d426-4acf-8be1-49f83baabbb4(org.mpsqa.lint.generic.behavior)" />
     <import index="a1af" ref="r:839ac015-7de1-49f3-ac8f-8d7c6d47259d(org.mpsqa.lint.generic.structure)" />
+    <import index="tpd5" ref="r:00000000-0000-4000-0000-011c895902b5(jetbrains.mps.lang.typesystem.dependencies)" />
   </imports>
   <registry>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
@@ -25,6 +27,12 @@
       </concept>
       <concept id="1202948039474" name="jetbrains.mps.baseLanguage.structure.InstanceMethodCallOperation" flags="nn" index="liA8E" />
       <concept id="1465982738277781862" name="jetbrains.mps.baseLanguage.structure.PlaceholderMember" flags="nn" index="2tJIrI" />
+      <concept id="1188207840427" name="jetbrains.mps.baseLanguage.structure.AnnotationInstance" flags="nn" index="2AHcQZ">
+        <reference id="1188208074048" name="annotation" index="2AI5Lk" />
+      </concept>
+      <concept id="1188208481402" name="jetbrains.mps.baseLanguage.structure.HasAnnotation" flags="ng" index="2AJDlI">
+        <child id="1188208488637" name="annotation" index="2AJF6D" />
+      </concept>
       <concept id="1154032098014" name="jetbrains.mps.baseLanguage.structure.AbstractLoopStatement" flags="nn" index="2LF5Ji">
         <child id="1154032183016" name="body" index="2LFqv$" />
       </concept>
@@ -84,6 +92,7 @@
         <child id="1068581242865" name="localVariableDeclaration" index="3cpWs9" />
       </concept>
       <concept id="1068581242863" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclaration" flags="nr" index="3cpWsn" />
+      <concept id="1068581517677" name="jetbrains.mps.baseLanguage.structure.VoidType" flags="in" index="3cqZAl" />
       <concept id="1206060495898" name="jetbrains.mps.baseLanguage.structure.ElsifClause" flags="ng" index="3eNFk2">
         <child id="1206060619838" name="condition" index="3eO9$A" />
         <child id="1206060644605" name="statementList" index="3eOfB_" />
@@ -266,129 +275,15 @@
           <ref role="3cqZAo" node="2dSiT1hLkDD" resolve="results" />
         </node>
         <node concept="3clFbS" id="6gY6GEDv4vD" role="2LFqv$">
-          <node concept="3clFbJ" id="1c_Dn$lOk0K" role="3cqZAp">
-            <node concept="3clFbS" id="1c_Dn$lOk0M" role="3clFbx">
-              <node concept="2MkqsV" id="6gY6GEDv4vE" role="3cqZAp">
-                <node concept="3cpWs3" id="6gY6GEDv4vF" role="2MkJ7o">
-                  <node concept="2OqwBi" id="78RogMCFqzG" role="3uHU7w">
-                    <node concept="2GrUjf" id="6gY6GEDv4vG" role="2Oq$k0">
-                      <ref role="2Gs0qQ" node="6gY6GEDv4vB" resolve="res" />
-                    </node>
-                    <node concept="2OwXpG" id="78RogMCFr36" role="2OqNvi">
-                      <ref role="2Oxat5" to="zn9m:~Pair.first" resolve="first" />
-                    </node>
-                  </node>
-                  <node concept="Xl_RD" id="6gY6GEDv4vH" role="3uHU7B">
-                    <property role="Xl_RC" value="errors found: " />
-                  </node>
-                </node>
-                <node concept="2OqwBi" id="78RogMCFrUl" role="1urrMF">
-                  <node concept="2GrUjf" id="78RogMCFrlg" role="2Oq$k0">
-                    <ref role="2Gs0qQ" node="6gY6GEDv4vB" resolve="res" />
-                  </node>
-                  <node concept="2OwXpG" id="78RogMCFsqw" role="2OqNvi">
-                    <ref role="2Oxat5" to="zn9m:~Pair.second" resolve="second" />
-                  </node>
-                </node>
+          <node concept="3clFbF" id="ST9rMmWuBS" role="3cqZAp">
+            <node concept="2YIFZM" id="ST9rMmWuD4" role="3clFbG">
+              <ref role="37wK5l" node="ST9rMmWh0f" resolve="reportViolations" />
+              <ref role="1Pybhc" node="ST9rMmWgYw" resolve="ViolationsReporterUtils" />
+              <node concept="1YBJjd" id="ST9rMmWuDg" role="37wK5m">
+                <ref role="1YBMHb" node="2dSiT1hL2_K" resolve="checkableScript" />
               </node>
-            </node>
-            <node concept="2OqwBi" id="1c_Dn$lOlVl" role="3clFbw">
-              <node concept="2OqwBi" id="1c_Dn$lOkb_" role="2Oq$k0">
-                <node concept="1YBJjd" id="1c_Dn$lOk18" role="2Oq$k0">
-                  <ref role="1YBMHb" node="2dSiT1hL2_K" resolve="checkableScript" />
-                </node>
-                <node concept="3TrcHB" id="1c_Dn$lOkYK" role="2OqNvi">
-                  <ref role="3TsBF5" to="a1af:1c_Dn$lNzde" resolve="reportLevel" />
-                </node>
-              </node>
-              <node concept="21noJN" id="1c_Dn$lOmBz" role="2OqNvi">
-                <node concept="21nZrQ" id="1c_Dn$lOmB_" role="21noJM">
-                  <ref role="21nZrZ" to="a1af:1c_Dn$lNzd6" resolve="ERROR" />
-                </node>
-              </node>
-            </node>
-            <node concept="3eNFk2" id="1c_Dn$lOpK0" role="3eNLev">
-              <node concept="2OqwBi" id="1c_Dn$lOrKZ" role="3eO9$A">
-                <node concept="2OqwBi" id="1c_Dn$lOqvR" role="2Oq$k0">
-                  <node concept="1YBJjd" id="1c_Dn$lOqlq" role="2Oq$k0">
-                    <ref role="1YBMHb" node="2dSiT1hL2_K" resolve="checkableScript" />
-                  </node>
-                  <node concept="3TrcHB" id="1c_Dn$lOrld" role="2OqNvi">
-                    <ref role="3TsBF5" to="a1af:1c_Dn$lNzde" resolve="reportLevel" />
-                  </node>
-                </node>
-                <node concept="21noJN" id="1c_Dn$lOsbx" role="2OqNvi">
-                  <node concept="21nZrQ" id="1c_Dn$lOsbz" role="21noJM">
-                    <ref role="21nZrZ" to="a1af:1c_Dn$lNzd7" resolve="WARNING" />
-                  </node>
-                </node>
-              </node>
-              <node concept="3clFbS" id="1c_Dn$lOpK2" role="3eOfB_">
-                <node concept="a7r0C" id="1c_Dn$lOt5g" role="3cqZAp">
-                  <node concept="3cpWs3" id="1c_Dn$lOtnW" role="a7wSD">
-                    <node concept="2OqwBi" id="1c_Dn$lOtLm" role="3uHU7w">
-                      <node concept="2GrUjf" id="1c_Dn$lOtzW" role="2Oq$k0">
-                        <ref role="2Gs0qQ" node="6gY6GEDv4vB" resolve="res" />
-                      </node>
-                      <node concept="2OwXpG" id="1c_Dn$lOugi" role="2OqNvi">
-                        <ref role="2Oxat5" to="zn9m:~Pair.first" resolve="first" />
-                      </node>
-                    </node>
-                    <node concept="Xl_RD" id="1c_Dn$lOt5y" role="3uHU7B">
-                      <property role="Xl_RC" value="warnings found: " />
-                    </node>
-                  </node>
-                  <node concept="2OqwBi" id="1c_Dn$lOu_w" role="1urrMF">
-                    <node concept="2GrUjf" id="1c_Dn$lOurF" role="2Oq$k0">
-                      <ref role="2Gs0qQ" node="6gY6GEDv4vB" resolve="res" />
-                    </node>
-                    <node concept="2OwXpG" id="1c_Dn$lOuR5" role="2OqNvi">
-                      <ref role="2Oxat5" to="zn9m:~Pair.second" resolve="second" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3eNFk2" id="1c_Dn$lOnhA" role="3eNLev">
-              <node concept="3clFbS" id="1c_Dn$lOnhC" role="3eOfB_">
-                <node concept="Dpp1Q" id="1c_Dn$lOnW4" role="3cqZAp">
-                  <node concept="3cpWs3" id="1c_Dn$lOoeK" role="Dpw9R">
-                    <node concept="2OqwBi" id="1c_Dn$lOosr" role="3uHU7w">
-                      <node concept="2GrUjf" id="1c_Dn$lOof8" role="2Oq$k0">
-                        <ref role="2Gs0qQ" node="6gY6GEDv4vB" resolve="res" />
-                      </node>
-                      <node concept="2OwXpG" id="1c_Dn$lOoU9" role="2OqNvi">
-                        <ref role="2Oxat5" to="zn9m:~Pair.first" resolve="first" />
-                      </node>
-                    </node>
-                    <node concept="Xl_RD" id="1c_Dn$lOnWm" role="3uHU7B">
-                      <property role="Xl_RC" value="violations found: " />
-                    </node>
-                  </node>
-                  <node concept="2OqwBi" id="1c_Dn$lOp6H" role="1urrMF">
-                    <node concept="2GrUjf" id="1c_Dn$lOoYt" role="2Oq$k0">
-                      <ref role="2Gs0qQ" node="6gY6GEDv4vB" resolve="res" />
-                    </node>
-                    <node concept="2OwXpG" id="1c_Dn$lOp_n" role="2OqNvi">
-                      <ref role="2Oxat5" to="zn9m:~Pair.second" resolve="second" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-              <node concept="2OqwBi" id="1c_Dn$lOnVd" role="3eO9$A">
-                <node concept="2OqwBi" id="1c_Dn$lOnVe" role="2Oq$k0">
-                  <node concept="1YBJjd" id="1c_Dn$lOnVf" role="2Oq$k0">
-                    <ref role="1YBMHb" node="2dSiT1hL2_K" resolve="checkableScript" />
-                  </node>
-                  <node concept="3TrcHB" id="1c_Dn$lOnVg" role="2OqNvi">
-                    <ref role="3TsBF5" to="a1af:1c_Dn$lNzde" resolve="reportLevel" />
-                  </node>
-                </node>
-                <node concept="21noJN" id="1c_Dn$lOnVh" role="2OqNvi">
-                  <node concept="21nZrQ" id="1c_Dn$lOnVi" role="21noJM">
-                    <ref role="21nZrZ" to="a1af:1c_Dn$lNzda" resolve="INFO" />
-                  </node>
-                </node>
+              <node concept="2GrUjf" id="ST9rMmWuFN" role="37wK5m">
+                <ref role="2Gs0qQ" node="6gY6GEDv4vB" resolve="res" />
               </node>
             </node>
           </node>
@@ -546,133 +441,18 @@
           <ref role="3cqZAo" node="6gY6GEDxQPm" resolve="results" />
         </node>
         <node concept="3clFbS" id="6gY6GEDv42v" role="2LFqv$">
-          <node concept="3clFbJ" id="1c_Dn$lP8yS" role="3cqZAp">
-            <node concept="3clFbS" id="1c_Dn$lP8yT" role="3clFbx">
-              <node concept="2MkqsV" id="1c_Dn$lP8yU" role="3cqZAp">
-                <node concept="3cpWs3" id="1c_Dn$lP8yV" role="2MkJ7o">
-                  <node concept="2OqwBi" id="1c_Dn$lP8yW" role="3uHU7w">
-                    <node concept="2GrUjf" id="1c_Dn$lP8yX" role="2Oq$k0">
-                      <ref role="2Gs0qQ" node="6gY6GEDv42r" resolve="res" />
-                    </node>
-                    <node concept="2OwXpG" id="1c_Dn$lP8yY" role="2OqNvi">
-                      <ref role="2Oxat5" to="zn9m:~Pair.first" resolve="first" />
-                    </node>
-                  </node>
-                  <node concept="Xl_RD" id="1c_Dn$lP8yZ" role="3uHU7B">
-                    <property role="Xl_RC" value="errors found: " />
-                  </node>
-                </node>
-                <node concept="2OqwBi" id="1c_Dn$lP8z0" role="1urrMF">
-                  <node concept="2GrUjf" id="1c_Dn$lP8z1" role="2Oq$k0">
-                    <ref role="2Gs0qQ" node="6gY6GEDv42r" resolve="res" />
-                  </node>
-                  <node concept="2OwXpG" id="1c_Dn$lP8z2" role="2OqNvi">
-                    <ref role="2Oxat5" to="zn9m:~Pair.second" resolve="second" />
-                  </node>
-                </node>
+          <node concept="3clFbF" id="ST9rMmWt4q" role="3cqZAp">
+            <node concept="2YIFZM" id="ST9rMmWt5B" role="3clFbG">
+              <ref role="37wK5l" node="ST9rMmWh0f" resolve="reportViolations" />
+              <ref role="1Pybhc" node="ST9rMmWgYw" resolve="ViolationsReporterUtils" />
+              <node concept="1YBJjd" id="ST9rMmWt5Q" role="37wK5m">
+                <ref role="1YBMHb" node="3ibIDIkmjX4" resolve="reuseCheckableScript" />
               </node>
-            </node>
-            <node concept="2OqwBi" id="1c_Dn$lP8z3" role="3clFbw">
-              <node concept="2OqwBi" id="1c_Dn$lP8z4" role="2Oq$k0">
-                <node concept="1YBJjd" id="1c_Dn$lP8z5" role="2Oq$k0">
-                  <ref role="1YBMHb" node="3ibIDIkmjX4" resolve="reuseCheckableScript" />
-                </node>
-                <node concept="3TrcHB" id="1c_Dn$lP8z6" role="2OqNvi">
-                  <ref role="3TsBF5" to="a1af:1c_Dn$lP6D5" resolve="reportLevel" />
-                </node>
-              </node>
-              <node concept="21noJN" id="1c_Dn$lP8z7" role="2OqNvi">
-                <node concept="21nZrQ" id="1c_Dn$lP8z8" role="21noJM">
-                  <ref role="21nZrZ" to="a1af:1c_Dn$lNzd6" resolve="ERROR" />
-                </node>
-              </node>
-            </node>
-            <node concept="3eNFk2" id="1c_Dn$lP8z9" role="3eNLev">
-              <node concept="2OqwBi" id="1c_Dn$lP8za" role="3eO9$A">
-                <node concept="2OqwBi" id="1c_Dn$lP8zb" role="2Oq$k0">
-                  <node concept="1YBJjd" id="1c_Dn$lP8zc" role="2Oq$k0">
-                    <ref role="1YBMHb" node="3ibIDIkmjX4" resolve="reuseCheckableScript" />
-                  </node>
-                  <node concept="3TrcHB" id="1c_Dn$lP8zd" role="2OqNvi">
-                    <ref role="3TsBF5" to="a1af:1c_Dn$lP6D5" resolve="reportLevel" />
-                  </node>
-                </node>
-                <node concept="21noJN" id="1c_Dn$lP8ze" role="2OqNvi">
-                  <node concept="21nZrQ" id="1c_Dn$lP8zf" role="21noJM">
-                    <ref role="21nZrZ" to="a1af:1c_Dn$lNzd7" resolve="WARNING" />
-                  </node>
-                </node>
-              </node>
-              <node concept="3clFbS" id="1c_Dn$lP8zg" role="3eOfB_">
-                <node concept="a7r0C" id="1c_Dn$lP8zh" role="3cqZAp">
-                  <node concept="3cpWs3" id="1c_Dn$lP8zi" role="a7wSD">
-                    <node concept="2OqwBi" id="1c_Dn$lP8zj" role="3uHU7w">
-                      <node concept="2GrUjf" id="1c_Dn$lP8zk" role="2Oq$k0">
-                        <ref role="2Gs0qQ" node="6gY6GEDv42r" resolve="res" />
-                      </node>
-                      <node concept="2OwXpG" id="1c_Dn$lP8zl" role="2OqNvi">
-                        <ref role="2Oxat5" to="zn9m:~Pair.first" resolve="first" />
-                      </node>
-                    </node>
-                    <node concept="Xl_RD" id="1c_Dn$lP8zm" role="3uHU7B">
-                      <property role="Xl_RC" value="warnings found: " />
-                    </node>
-                  </node>
-                  <node concept="2OqwBi" id="1c_Dn$lP8zn" role="1urrMF">
-                    <node concept="2GrUjf" id="1c_Dn$lP8zo" role="2Oq$k0">
-                      <ref role="2Gs0qQ" node="6gY6GEDv42r" resolve="res" />
-                    </node>
-                    <node concept="2OwXpG" id="1c_Dn$lP8zp" role="2OqNvi">
-                      <ref role="2Oxat5" to="zn9m:~Pair.second" resolve="second" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3eNFk2" id="1c_Dn$lP8zq" role="3eNLev">
-              <node concept="3clFbS" id="1c_Dn$lP8zr" role="3eOfB_">
-                <node concept="Dpp1Q" id="1c_Dn$lP8zs" role="3cqZAp">
-                  <node concept="3cpWs3" id="1c_Dn$lP8zt" role="Dpw9R">
-                    <node concept="2OqwBi" id="1c_Dn$lP8zu" role="3uHU7w">
-                      <node concept="2GrUjf" id="1c_Dn$lP8zv" role="2Oq$k0">
-                        <ref role="2Gs0qQ" node="6gY6GEDv42r" resolve="res" />
-                      </node>
-                      <node concept="2OwXpG" id="1c_Dn$lP8zw" role="2OqNvi">
-                        <ref role="2Oxat5" to="zn9m:~Pair.first" resolve="first" />
-                      </node>
-                    </node>
-                    <node concept="Xl_RD" id="1c_Dn$lP8zx" role="3uHU7B">
-                      <property role="Xl_RC" value="violations found: " />
-                    </node>
-                  </node>
-                  <node concept="2OqwBi" id="1c_Dn$lP8zy" role="1urrMF">
-                    <node concept="2GrUjf" id="1c_Dn$lP8zz" role="2Oq$k0">
-                      <ref role="2Gs0qQ" node="6gY6GEDv42r" resolve="res" />
-                    </node>
-                    <node concept="2OwXpG" id="1c_Dn$lP8z$" role="2OqNvi">
-                      <ref role="2Oxat5" to="zn9m:~Pair.second" resolve="second" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-              <node concept="2OqwBi" id="1c_Dn$lP8z_" role="3eO9$A">
-                <node concept="2OqwBi" id="1c_Dn$lP8zA" role="2Oq$k0">
-                  <node concept="1YBJjd" id="1c_Dn$lP8zB" role="2Oq$k0">
-                    <ref role="1YBMHb" node="3ibIDIkmjX4" resolve="reuseCheckableScript" />
-                  </node>
-                  <node concept="3TrcHB" id="1c_Dn$lP8zC" role="2OqNvi">
-                    <ref role="3TsBF5" to="a1af:1c_Dn$lP6D5" resolve="reportLevel" />
-                  </node>
-                </node>
-                <node concept="21noJN" id="1c_Dn$lP8zD" role="2OqNvi">
-                  <node concept="21nZrQ" id="1c_Dn$lP8zE" role="21noJM">
-                    <ref role="21nZrZ" to="a1af:1c_Dn$lNzda" resolve="INFO" />
-                  </node>
-                </node>
+              <node concept="2GrUjf" id="ST9rMmWt8s" role="37wK5m">
+                <ref role="2Gs0qQ" node="6gY6GEDv42r" resolve="res" />
               </node>
             </node>
           </node>
-          <node concept="3clFbH" id="1c_Dn$lP8yH" role="3cqZAp" />
         </node>
       </node>
       <node concept="3clFbH" id="6gY6GEDxTKa" role="3cqZAp" />
@@ -1026,6 +806,162 @@
     </node>
     <node concept="2tJIrI" id="6gY6GEDvSKA" role="jymVt" />
     <node concept="3Tm1VV" id="6gY6GEDvRz5" role="1B3o_S" />
+  </node>
+  <node concept="312cEu" id="ST9rMmWgYw">
+    <property role="TrG5h" value="ViolationsReporterUtils" />
+    <node concept="2tJIrI" id="ST9rMmWgZw" role="jymVt" />
+    <node concept="2YIFZL" id="ST9rMmWh0f" role="jymVt">
+      <property role="TrG5h" value="reportViolations" />
+      <node concept="3clFbS" id="ST9rMmWh0i" role="3clF47">
+        <node concept="3clFbJ" id="ST9rMmWih_" role="3cqZAp">
+          <node concept="3clFbS" id="ST9rMmWihA" role="3clFbx">
+            <node concept="2MkqsV" id="ST9rMmWihB" role="3cqZAp">
+              <node concept="3cpWs3" id="ST9rMmWihC" role="2MkJ7o">
+                <node concept="2OqwBi" id="ST9rMmWihD" role="3uHU7w">
+                  <node concept="37vLTw" id="ST9rMmWm_S" role="2Oq$k0">
+                    <ref role="3cqZAo" node="ST9rMmWlmc" resolve="res" />
+                  </node>
+                  <node concept="2OwXpG" id="ST9rMmWihF" role="2OqNvi">
+                    <ref role="2Oxat5" to="zn9m:~Pair.first" resolve="first" />
+                  </node>
+                </node>
+                <node concept="Xl_RD" id="ST9rMmWihG" role="3uHU7B">
+                  <property role="Xl_RC" value="errors found: " />
+                </node>
+              </node>
+              <node concept="2OqwBi" id="ST9rMmWihH" role="1urrMF">
+                <node concept="37vLTw" id="ST9rMmWms6" role="2Oq$k0">
+                  <ref role="3cqZAo" node="ST9rMmWlmc" resolve="res" />
+                </node>
+                <node concept="2OwXpG" id="ST9rMmWihJ" role="2OqNvi">
+                  <ref role="2Oxat5" to="zn9m:~Pair.second" resolve="second" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="2OqwBi" id="ST9rMmWihK" role="3clFbw">
+            <node concept="2OqwBi" id="ST9rMmWihL" role="2Oq$k0">
+              <node concept="37vLTw" id="ST9rMmWkwN" role="2Oq$k0">
+                <ref role="3cqZAo" node="ST9rMmWjAl" resolve="checker" />
+              </node>
+              <node concept="3TrcHB" id="ST9rMmWihN" role="2OqNvi">
+                <ref role="3TsBF5" to="a1af:ST9rMmWgfD" resolve="reportLevel" />
+              </node>
+            </node>
+            <node concept="21noJN" id="ST9rMmWihO" role="2OqNvi">
+              <node concept="21nZrQ" id="ST9rMmWihP" role="21noJM">
+                <ref role="21nZrZ" to="a1af:1c_Dn$lNzd6" resolve="ERROR" />
+              </node>
+            </node>
+          </node>
+          <node concept="3eNFk2" id="ST9rMmWihQ" role="3eNLev">
+            <node concept="2OqwBi" id="ST9rMmWihR" role="3eO9$A">
+              <node concept="2OqwBi" id="ST9rMmWihS" role="2Oq$k0">
+                <node concept="37vLTw" id="ST9rMmWl1p" role="2Oq$k0">
+                  <ref role="3cqZAo" node="ST9rMmWjAl" resolve="checker" />
+                </node>
+                <node concept="3TrcHB" id="ST9rMmWihU" role="2OqNvi">
+                  <ref role="3TsBF5" to="a1af:ST9rMmWgfD" resolve="reportLevel" />
+                </node>
+              </node>
+              <node concept="21noJN" id="ST9rMmWihV" role="2OqNvi">
+                <node concept="21nZrQ" id="ST9rMmWihW" role="21noJM">
+                  <ref role="21nZrZ" to="a1af:1c_Dn$lNzd7" resolve="WARNING" />
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbS" id="ST9rMmWihX" role="3eOfB_">
+              <node concept="a7r0C" id="ST9rMmWihY" role="3cqZAp">
+                <node concept="3cpWs3" id="ST9rMmWihZ" role="a7wSD">
+                  <node concept="2OqwBi" id="ST9rMmWii0" role="3uHU7w">
+                    <node concept="37vLTw" id="ST9rMmWmTs" role="2Oq$k0">
+                      <ref role="3cqZAo" node="ST9rMmWlmc" resolve="res" />
+                    </node>
+                    <node concept="2OwXpG" id="ST9rMmWii2" role="2OqNvi">
+                      <ref role="2Oxat5" to="zn9m:~Pair.first" resolve="first" />
+                    </node>
+                  </node>
+                  <node concept="Xl_RD" id="ST9rMmWii3" role="3uHU7B">
+                    <property role="Xl_RC" value="warnings found: " />
+                  </node>
+                </node>
+                <node concept="2OqwBi" id="ST9rMmWii4" role="1urrMF">
+                  <node concept="37vLTw" id="ST9rMmWmJE" role="2Oq$k0">
+                    <ref role="3cqZAo" node="ST9rMmWlmc" resolve="res" />
+                  </node>
+                  <node concept="2OwXpG" id="ST9rMmWii6" role="2OqNvi">
+                    <ref role="2Oxat5" to="zn9m:~Pair.second" resolve="second" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3eNFk2" id="ST9rMmWii7" role="3eNLev">
+            <node concept="3clFbS" id="ST9rMmWii8" role="3eOfB_">
+              <node concept="Dpp1Q" id="ST9rMmWii9" role="3cqZAp">
+                <node concept="3cpWs3" id="ST9rMmWiia" role="Dpw9R">
+                  <node concept="2OqwBi" id="ST9rMmWiib" role="3uHU7w">
+                    <node concept="37vLTw" id="ST9rMmWn3e" role="2Oq$k0">
+                      <ref role="3cqZAo" node="ST9rMmWlmc" resolve="res" />
+                    </node>
+                    <node concept="2OwXpG" id="ST9rMmWiid" role="2OqNvi">
+                      <ref role="2Oxat5" to="zn9m:~Pair.first" resolve="first" />
+                    </node>
+                  </node>
+                  <node concept="Xl_RD" id="ST9rMmWiie" role="3uHU7B">
+                    <property role="Xl_RC" value="violations found: " />
+                  </node>
+                </node>
+                <node concept="2OqwBi" id="ST9rMmWiif" role="1urrMF">
+                  <node concept="37vLTw" id="ST9rMmWnd0" role="2Oq$k0">
+                    <ref role="3cqZAo" node="ST9rMmWlmc" resolve="res" />
+                  </node>
+                  <node concept="2OwXpG" id="ST9rMmWiih" role="2OqNvi">
+                    <ref role="2Oxat5" to="zn9m:~Pair.second" resolve="second" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="2OqwBi" id="ST9rMmWiii" role="3eO9$A">
+              <node concept="2OqwBi" id="ST9rMmWiij" role="2Oq$k0">
+                <node concept="37vLTw" id="ST9rMmWkOa" role="2Oq$k0">
+                  <ref role="3cqZAo" node="ST9rMmWjAl" resolve="checker" />
+                </node>
+                <node concept="3TrcHB" id="ST9rMmWiil" role="2OqNvi">
+                  <ref role="3TsBF5" to="a1af:ST9rMmWgfD" resolve="reportLevel" />
+                </node>
+              </node>
+              <node concept="21noJN" id="ST9rMmWiim" role="2OqNvi">
+                <node concept="21nZrQ" id="ST9rMmWiin" role="21noJM">
+                  <ref role="21nZrZ" to="a1af:1c_Dn$lNzda" resolve="INFO" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="ST9rMmWgZN" role="1B3o_S" />
+      <node concept="3cqZAl" id="ST9rMmWh04" role="3clF45" />
+      <node concept="37vLTG" id="ST9rMmWjAl" role="3clF46">
+        <property role="TrG5h" value="checker" />
+        <node concept="3Tqbb2" id="ST9rMmWjAk" role="1tU5fm">
+          <ref role="ehGHo" to="a1af:ST9rMmWg3T" resolve="ISeverityLevelAwareChecker" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="ST9rMmWlmc" role="3clF46">
+        <property role="TrG5h" value="res" />
+        <node concept="3uibUv" id="ST9rMmWlVD" role="1tU5fm">
+          <ref role="3uigEE" to="zn9m:~Pair" resolve="Pair" />
+          <node concept="17QB3L" id="ST9rMmWlVE" role="11_B2D" />
+          <node concept="3Tqbb2" id="ST9rMmWlVF" role="11_B2D" />
+        </node>
+      </node>
+      <node concept="2AHcQZ" id="ST9rMmWrgB" role="2AJF6D">
+        <ref role="2AI5Lk" to="tpd5:hNAUp6x" resolve="CheckingMethod" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="ST9rMmWgZ_" role="jymVt" />
+    <node concept="3Tm1VV" id="ST9rMmWgYx" role="1B3o_S" />
   </node>
 </model>
 

--- a/code/languages/org.mpsqa.lint/languages/org.mpsqa.lint.generic/org.mpsqa.lint.generic.mpl
+++ b/code/languages/org.mpsqa.lint/languages/org.mpsqa.lint.generic/org.mpsqa.lint.generic.mpl
@@ -78,6 +78,7 @@
     <dependency reexport="false">498d89d2-c2e9-11e2-ad49-6cf049e62fe5(MPS.IDEA)</dependency>
     <dependency reexport="false">7a5dda62-9140-4668-ab76-d5ed1746f2b2(jetbrains.mps.lang.typesystem)</dependency>
     <dependency reexport="false">1ed103c3-3aa6-49b7-9c21-6765ee11f224(MPS.Editor)</dependency>
+    <dependency reexport="false">20c6e580-bdc5-4067-8049-d7e3265a86de(jetbrains.mps.typesystemEngine)</dependency>
   </dependencies>
   <languageVersions>
     <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="11" />
@@ -136,6 +137,7 @@
     <module reference="c7fb639f-be78-4307-89b0-b5959c3fa8c8(jetbrains.mps.lang.text)" version="0" />
     <module reference="9ded098b-ad6a-4657-bfd9-48636cfe8bc3(jetbrains.mps.lang.traceable)" version="0" />
     <module reference="7a5dda62-9140-4668-ab76-d5ed1746f2b2(jetbrains.mps.lang.typesystem)" version="0" />
+    <module reference="20c6e580-bdc5-4067-8049-d7e3265a86de(jetbrains.mps.typesystemEngine)" version="0" />
     <module reference="40ab19e9-751a-4433-b645-0e65160e58a0(org.mpsqa.lint.generic)" version="0" />
   </dependencyVersions>
   <extendedLanguages>


### PR DESCRIPTION
Enabled Checkable and ReuseCheckable scripts to have level of severity level: ERROR, WARNING, INFO

Changed in org.mpsqa.lint:
`org.mpsqa.lint.generic`: concept, editor and typesystem of Checkable and ReuseCheckable scripts.