### PR TITLE
Migrate to 2022.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ buildscript {
         }
     }
     dependencies {
-        classpath 'de.itemis.mps:mps-gradle-plugin:1.5.+'
+        classpath 'de.itemis.mps:mps-gradle-plugin:1.16.+'
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,7 @@ plugins {
 
 apply plugin: 'download-jbr'
 
-ext.jbrVers = '11_0_10-b1145.96'
+ext.jbrVers = '17.0.3-b469.32'
 
 downloadJbr {
     jbrVersion = jbrVers
@@ -75,11 +75,11 @@ ext.dependencyRepositories = [
 ]
 
 // Dependency versions
-ext.mpsVersion =  '2021.3.+'
+ext.mpsVersion =  '2022.2'
 
 // Project versions
-ext.major = '2021'
-ext.minor = '3'
+ext.major = '2022'
+ext.minor = '2'
 
 if (ciBuild) {
     String branch = GitBasedVersioning.gitBranch

--- a/build.gradle
+++ b/build.gradle
@@ -96,7 +96,7 @@ if (ciBuild) {
     version = "$major.$minor-SNAPSHOT"
 }
 
-ext.publishingRepository = 'https://projects.itemis.de/nexus/content/repositories/mbeddr'
+ext.publishingRepository = 'https://artifacts.itemis.cloud/repository/maven-mps'
 
 
 configurations {

--- a/build/scripts/build_all_scripts.xml
+++ b/build/scripts/build_all_scripts.xml
@@ -171,6 +171,7 @@
       <library file="${artifacts.mps}/languages/languageDesign/jetbrains.mps.lang.context.jar" />
       <library file="${artifacts.mps}/languages/languageDesign/jetbrains.mps.lang.core.jar" />
       <library file="${artifacts.mps}/languages/languageDesign/jetbrains.mps.lang.dataFlow.jar" />
+      <library file="${artifacts.mps}/languages/languageDesign/jetbrains.mps.lang.descriptor.jar" />
       <library file="${artifacts.mps}/languages/languageDesign/jetbrains.mps.lang.editor.jar" />
       <library file="${artifacts.mps}/languages/languageDesign/jetbrains.mps.lang.findUsages.jar" />
       <library file="${artifacts.mps}/languages/languageDesign/jetbrains.mps.lang.generator.generationContext.jar" />

--- a/code/languages/org.mpsqa.arch/.mps/migration.xml
+++ b/code/languages/org.mpsqa.arch/.mps/migration.xml
@@ -7,6 +7,6 @@
     <entry key="jetbrains.mps.ide.mpsmigration.v_2019_3.DefaultFacetExplicitPersistence" value="executed" />
     <entry key="jetbrains.mps.ide.mpsmigration.v_2021_2.SplitMPSCoreStub" value="executed" />
     <entry key="jetbrains.mps.ide.mpsmigration.v_2021_3.ExtractMPSBootStubs" value="executed" />
-    <entry key="project.migrated.version" value="213" />
+    <entry key="project.migrated.version" value="222" />
   </component>
 </project>

--- a/code/languages/org.mpsqa.arch/languages/org.mpsqa.arch/models/org.mpsqa.arch.intentions.mps
+++ b/code/languages/org.mpsqa.arch/languages/org.mpsqa.arch/models/org.mpsqa.arch.intentions.mps
@@ -418,7 +418,7 @@
             </node>
           </node>
           <node concept="2YIFZM" id="5enppyYD8xa" role="2GsD0m">
-            <ref role="37wK5l" to="u41u:5enppyYCuMW" resolve="getProjectLanguagesNotPartOfArchitectureDescription" />
+            <ref role="37wK5l" to="u41u:5enppyYCuMW" resolve="getProjectModulesNotPartOfArchitectureDescription" />
             <ref role="1Pybhc" to="u41u:5enppyYCuym" resolve="ArchitectureUtils" />
             <node concept="37vLTw" id="5enppyYD8xb" role="37wK5m">
               <ref role="3cqZAo" node="72dZnKNhsj6" resolve="project" />

--- a/code/languages/org.mpsqa.arch/solutions/test.org.mpsqa.arch/models/test.org.mpsqa.arch._010_simple_dependencies@tests.mps
+++ b/code/languages/org.mpsqa.arch/solutions/test.org.mpsqa.arch/models/test.org.mpsqa.arch._010_simple_dependencies@tests.mps
@@ -2,7 +2,7 @@
 <model ref="r:3110d016-f3ba-4aca-9ff2-46e80bc71496(test.org.mpsqa.arch._010_simple_dependencies@tests)">
   <persistence version="9" />
   <languages>
-    <use id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test" version="5" />
+    <use id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test" version="6" />
     <use id="f61473f9-130f-42f6-b98d-6c438812c2f6" name="jetbrains.mps.baseLanguage.unitTest" version="1" />
     <use id="6c101563-ba1f-458d-b298-a75634941e0c" name="org.mpsqa.arch" version="0" />
     <use id="446c26eb-2b7b-4bf0-9b35-f83fa582753e" name="jetbrains.mps.lang.modelapi" version="0" />
@@ -21,6 +21,7 @@
         <property id="5097124989038916363" name="projectPath" index="2XOHcw" />
       </concept>
       <concept id="1216913645126" name="jetbrains.mps.lang.test.structure.NodesTestCase" flags="lg" index="1lH9Xt">
+        <property id="2616911529524314943" name="accessMode" index="3DII0k" />
         <child id="1217501822150" name="nodesToCheck" index="1SKRRt" />
       </concept>
       <concept id="1216989428737" name="jetbrains.mps.lang.test.structure.TestNode" flags="ng" index="1qefOq">
@@ -72,6 +73,7 @@
   </node>
   <node concept="1lH9Xt" id="6ESRMYIDk5p">
     <property role="TrG5h" value="_010_simple_tests" />
+    <property role="3DII0k" value="2hh8MJdVwqX/command" />
     <node concept="1qefOq" id="6ESRMYIDk5r" role="1SKRRt">
       <node concept="mXAGR" id="6ESRMYIDk5q" role="1qenE9">
         <property role="TrG5h" value="_010_simple" />

--- a/code/languages/org.mpsqa.arch/solutions/test.org.mpsqa.arch/test.org.mpsqa.arch.msd
+++ b/code/languages/org.mpsqa.arch/solutions/test.org.mpsqa.arch/test.org.mpsqa.arch.msd
@@ -17,7 +17,7 @@
     <language slang="l:f61473f9-130f-42f6-b98d-6c438812c2f6:jetbrains.mps.baseLanguage.unitTest" version="1" />
     <language slang="l:ceab5195-25ea-4f22-9b92-103b95ca8c0c:jetbrains.mps.lang.core" version="2" />
     <language slang="l:446c26eb-2b7b-4bf0-9b35-f83fa582753e:jetbrains.mps.lang.modelapi" version="0" />
-    <language slang="l:8585453e-6bfb-4d80-98de-b16074f1d86c:jetbrains.mps.lang.test" version="5" />
+    <language slang="l:8585453e-6bfb-4d80-98de-b16074f1d86c:jetbrains.mps.lang.test" version="6" />
     <language slang="l:9ded098b-ad6a-4657-bfd9-48636cfe8bc3:jetbrains.mps.lang.traceable" version="0" />
     <language slang="l:6c101563-ba1f-458d-b298-a75634941e0c:org.mpsqa.arch" version="0" />
   </languageVersions>

--- a/code/languages/org.mpsqa.clones/.mps/migration.xml
+++ b/code/languages/org.mpsqa.clones/.mps/migration.xml
@@ -7,6 +7,6 @@
     <entry key="jetbrains.mps.ide.mpsmigration.v_2019_3.DefaultFacetExplicitPersistence" value="executed" />
     <entry key="jetbrains.mps.ide.mpsmigration.v_2021_2.SplitMPSCoreStub" value="executed" />
     <entry key="jetbrains.mps.ide.mpsmigration.v_2021_3.ExtractMPSBootStubs" value="executed" />
-    <entry key="project.migrated.version" value="213" />
+    <entry key="project.migrated.version" value="222" />
   </component>
 </project>

--- a/code/languages/org.mpsqa.clones/tests/test.org.mpsqa.clones.headless/models/_010_headless_runner_1@tests.mps
+++ b/code/languages/org.mpsqa.clones/tests/test.org.mpsqa.clones.headless/models/_010_headless_runner_1@tests.mps
@@ -2,7 +2,7 @@
 <model ref="r:ea4ccff6-b739-4afd-850a-000fa0a10cfd(test.org.mpsqa.clones.headless._010_headless_runner_1@tests)">
   <persistence version="9" />
   <languages>
-    <use id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test" version="2" />
+    <use id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test" version="6" />
     <use id="f61473f9-130f-42f6-b98d-6c438812c2f6" name="jetbrains.mps.baseLanguage.unitTest" version="1" />
     <use id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel" version="19" />
     <use id="28f9e497-3b42-4291-aeba-0a1039153ab1" name="jetbrains.mps.lang.plugin" version="5" />
@@ -22,6 +22,7 @@
       </concept>
       <concept id="1225467090849" name="jetbrains.mps.lang.test.structure.ProjectExpression" flags="nn" index="1jxXqW" />
       <concept id="1216913645126" name="jetbrains.mps.lang.test.structure.NodesTestCase" flags="lg" index="1lH9Xt">
+        <property id="2616911529524314943" name="accessMode" index="3DII0k" />
         <child id="1217501895093" name="testMethods" index="1SL9yI" />
       </concept>
       <concept id="1225978065297" name="jetbrains.mps.lang.test.structure.SimpleNodeTest" flags="ng" index="1LZb2c" />
@@ -132,6 +133,7 @@
   </node>
   <node concept="1lH9Xt" id="2KLGrfl1HUl">
     <property role="TrG5h" value="TestRunHeadless" />
+    <property role="3DII0k" value="2hh8MJdVwqX/command" />
     <node concept="1LZb2c" id="2KLGrfl1HU$" role="1SL9yI">
       <property role="TrG5h" value="run_clones_headless" />
       <node concept="3cqZAl" id="2KLGrfl1HU_" role="3clF45" />

--- a/code/languages/org.mpsqa.clones/tests/test.org.mpsqa.clones.headless/test.org.mpsqa.clones.headless.msd
+++ b/code/languages/org.mpsqa.clones/tests/test.org.mpsqa.clones.headless/test.org.mpsqa.clones.headless.msd
@@ -30,7 +30,7 @@
     <language slang="l:446c26eb-2b7b-4bf0-9b35-f83fa582753e:jetbrains.mps.lang.modelapi" version="0" />
     <language slang="l:28f9e497-3b42-4291-aeba-0a1039153ab1:jetbrains.mps.lang.plugin" version="5" />
     <language slang="l:7866978e-a0f0-4cc7-81bc-4d213d9375e1:jetbrains.mps.lang.smodel" version="19" />
-    <language slang="l:8585453e-6bfb-4d80-98de-b16074f1d86c:jetbrains.mps.lang.test" version="5" />
+    <language slang="l:8585453e-6bfb-4d80-98de-b16074f1d86c:jetbrains.mps.lang.test" version="6" />
     <language slang="l:9ded098b-ad6a-4657-bfd9-48636cfe8bc3:jetbrains.mps.lang.traceable" version="0" />
     <language slang="l:56cfcf05-92e4-4822-8126-2ea0e0cece6b:org.mpsqa.clones.config" version="0" />
   </languageVersions>

--- a/code/languages/org.mpsqa.clones/tests/test.org.mpsqa.clones/models/_000_infrastructure@tests.mps
+++ b/code/languages/org.mpsqa.clones/tests/test.org.mpsqa.clones/models/_000_infrastructure@tests.mps
@@ -2,7 +2,7 @@
 <model ref="r:5dcb623a-97f0-43f0-b9b0-0f00fc91af1a(test.org.mpsqa.clones._000_infrastructure@tests)">
   <persistence version="9" />
   <languages>
-    <use id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test" version="5" />
+    <use id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test" version="6" />
     <use id="f61473f9-130f-42f6-b98d-6c438812c2f6" name="jetbrains.mps.baseLanguage.unitTest" version="1" />
     <use id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel" version="19" />
     <use id="83888646-71ce-4f1c-9c53-c54016f6ad4f" name="jetbrains.mps.baseLanguage.collections" version="1" />
@@ -25,6 +25,7 @@
       </concept>
       <concept id="1225467090849" name="jetbrains.mps.lang.test.structure.ProjectExpression" flags="nn" index="1jxXqW" />
       <concept id="1216913645126" name="jetbrains.mps.lang.test.structure.NodesTestCase" flags="lg" index="1lH9Xt">
+        <property id="2616911529524314943" name="accessMode" index="3DII0k" />
         <child id="1217501822150" name="nodesToCheck" index="1SKRRt" />
         <child id="1217501895093" name="testMethods" index="1SL9yI" />
       </concept>
@@ -154,6 +155,7 @@
   </node>
   <node concept="1lH9Xt" id="5dW8pSKf75r">
     <property role="TrG5h" value="_010_hashcode" />
+    <property role="3DII0k" value="2hh8MJdVwqX/command" />
     <node concept="1LZb2c" id="5dW8pSKf75t" role="1SL9yI">
       <property role="TrG5h" value="_010_hashcode_of_primitive_properties" />
       <node concept="3cqZAl" id="5dW8pSKf75u" role="3clF45" />

--- a/code/languages/org.mpsqa.clones/tests/test.org.mpsqa.clones/models/_010_identical_java_statements@tests.mps
+++ b/code/languages/org.mpsqa.clones/tests/test.org.mpsqa.clones/models/_010_identical_java_statements@tests.mps
@@ -2,7 +2,7 @@
 <model ref="r:2300b946-2889-4051-9431-762ec90e752a(test.org.mpsqa.clones._010_identical_java_statements@tests)">
   <persistence version="9" />
   <languages>
-    <use id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test" version="5" />
+    <use id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test" version="6" />
     <use id="f61473f9-130f-42f6-b98d-6c438812c2f6" name="jetbrains.mps.baseLanguage.unitTest" version="1" />
     <use id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel" version="19" />
   </languages>
@@ -19,6 +19,7 @@
       </concept>
       <concept id="1225467090849" name="jetbrains.mps.lang.test.structure.ProjectExpression" flags="nn" index="1jxXqW" />
       <concept id="1216913645126" name="jetbrains.mps.lang.test.structure.NodesTestCase" flags="lg" index="1lH9Xt">
+        <property id="2616911529524314943" name="accessMode" index="3DII0k" />
         <child id="1217501895093" name="testMethods" index="1SL9yI" />
       </concept>
       <concept id="1225978065297" name="jetbrains.mps.lang.test.structure.SimpleNodeTest" flags="ng" index="1LZb2c" />
@@ -105,6 +106,7 @@
   </registry>
   <node concept="1lH9Xt" id="5dW8pSKf75r">
     <property role="TrG5h" value="_010_identical_java_statements" />
+    <property role="3DII0k" value="2hh8MJdVwqX/command" />
     <node concept="1LZb2c" id="5dW8pSKf75t" role="1SL9yI">
       <property role="TrG5h" value="_010_smoke" />
       <node concept="3cqZAl" id="5dW8pSKf75u" role="3clF45" />

--- a/code/languages/org.mpsqa.clones/tests/test.org.mpsqa.clones/models/_020_overlapping_clones@tests.mps
+++ b/code/languages/org.mpsqa.clones/tests/test.org.mpsqa.clones/models/_020_overlapping_clones@tests.mps
@@ -2,7 +2,7 @@
 <model ref="r:8adceaa9-7768-4497-aa0f-fda6fdac3b15(test.org.mpsqa.clones._020_overlapping_clones@tests)">
   <persistence version="9" />
   <languages>
-    <use id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test" version="5" />
+    <use id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test" version="6" />
     <use id="f61473f9-130f-42f6-b98d-6c438812c2f6" name="jetbrains.mps.baseLanguage.unitTest" version="1" />
     <use id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel" version="19" />
   </languages>
@@ -19,6 +19,7 @@
       </concept>
       <concept id="1225467090849" name="jetbrains.mps.lang.test.structure.ProjectExpression" flags="nn" index="1jxXqW" />
       <concept id="1216913645126" name="jetbrains.mps.lang.test.structure.NodesTestCase" flags="lg" index="1lH9Xt">
+        <property id="2616911529524314943" name="accessMode" index="3DII0k" />
         <child id="1217501895093" name="testMethods" index="1SL9yI" />
       </concept>
       <concept id="1225978065297" name="jetbrains.mps.lang.test.structure.SimpleNodeTest" flags="ng" index="1LZb2c" />
@@ -105,6 +106,7 @@
   </registry>
   <node concept="1lH9Xt" id="5YQNmM9b6pe">
     <property role="TrG5h" value="_020_overlapping_clones" />
+    <property role="3DII0k" value="2hh8MJdVwqX/command" />
     <node concept="1LZb2c" id="5YQNmM9b6pg" role="1SL9yI">
       <property role="TrG5h" value="_010_ignore_overlapping" />
       <node concept="3cqZAl" id="5YQNmM9b6pj" role="3clF45" />

--- a/code/languages/org.mpsqa.clones/tests/test.org.mpsqa.clones/models/_200_save_load_filter_clones@tests.mps
+++ b/code/languages/org.mpsqa.clones/tests/test.org.mpsqa.clones/models/_200_save_load_filter_clones@tests.mps
@@ -2,7 +2,7 @@
 <model ref="r:58f16ec6-c72c-4f1f-aad3-d330a651f9dd(test.org.mpsqa.clones._200_save_load_filter_clones@tests)">
   <persistence version="9" />
   <languages>
-    <use id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test" version="5" />
+    <use id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test" version="6" />
     <use id="f61473f9-130f-42f6-b98d-6c438812c2f6" name="jetbrains.mps.baseLanguage.unitTest" version="1" />
     <use id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel" version="19" />
   </languages>
@@ -22,6 +22,7 @@
       </concept>
       <concept id="1225467090849" name="jetbrains.mps.lang.test.structure.ProjectExpression" flags="nn" index="1jxXqW" />
       <concept id="1216913645126" name="jetbrains.mps.lang.test.structure.NodesTestCase" flags="lg" index="1lH9Xt">
+        <property id="2616911529524314943" name="accessMode" index="3DII0k" />
         <child id="1217501895093" name="testMethods" index="1SL9yI" />
       </concept>
       <concept id="1225978065297" name="jetbrains.mps.lang.test.structure.SimpleNodeTest" flags="ng" index="1LZb2c" />
@@ -145,6 +146,7 @@
   </registry>
   <node concept="1lH9Xt" id="16s82eEm5FZ">
     <property role="TrG5h" value="_010_save_load_clones" />
+    <property role="3DII0k" value="2hh8MJdVwqX/command" />
     <node concept="1LZb2c" id="16s82eEm5G0" role="1SL9yI">
       <property role="TrG5h" value="_010_save_load_clones" />
       <node concept="3cqZAl" id="16s82eEm5G1" role="3clF45" />

--- a/code/languages/org.mpsqa.clones/tests/test.org.mpsqa.clones/test.org.mpsqa.clones.msd
+++ b/code/languages/org.mpsqa.clones/tests/test.org.mpsqa.clones/test.org.mpsqa.clones.msd
@@ -27,7 +27,7 @@
     <language slang="l:ceab5195-25ea-4f22-9b92-103b95ca8c0c:jetbrains.mps.lang.core" version="2" />
     <language slang="l:446c26eb-2b7b-4bf0-9b35-f83fa582753e:jetbrains.mps.lang.modelapi" version="0" />
     <language slang="l:7866978e-a0f0-4cc7-81bc-4d213d9375e1:jetbrains.mps.lang.smodel" version="19" />
-    <language slang="l:8585453e-6bfb-4d80-98de-b16074f1d86c:jetbrains.mps.lang.test" version="5" />
+    <language slang="l:8585453e-6bfb-4d80-98de-b16074f1d86c:jetbrains.mps.lang.test" version="6" />
     <language slang="l:9ded098b-ad6a-4657-bfd9-48636cfe8bc3:jetbrains.mps.lang.traceable" version="0" />
   </languageVersions>
   <dependencyVersions>

--- a/code/languages/org.mpsqa.deprecated/.mps/migration.xml
+++ b/code/languages/org.mpsqa.deprecated/.mps/migration.xml
@@ -7,6 +7,6 @@
     <entry key="jetbrains.mps.ide.mpsmigration.v_2019_3.DefaultFacetExplicitPersistence" value="executed" />
     <entry key="jetbrains.mps.ide.mpsmigration.v_2021_2.SplitMPSCoreStub" value="executed" />
     <entry key="jetbrains.mps.ide.mpsmigration.v_2021_3.ExtractMPSBootStubs" value="executed" />
-    <entry key="project.migrated.version" value="213" />
+    <entry key="project.migrated.version" value="222" />
   </component>
 </project>

--- a/code/languages/org.mpsqa.deprecated/languages/org.mpsqa.deprecated/models/org.mpsqa.deprecated.typesystem.mps
+++ b/code/languages/org.mpsqa.deprecated/languages/org.mpsqa.deprecated/models/org.mpsqa.deprecated.typesystem.mps
@@ -4,6 +4,11 @@
   <languages>
     <use id="7a5dda62-9140-4668-ab76-d5ed1746f2b2" name="jetbrains.mps.lang.typesystem" version="5" />
     <use id="1a8554c4-eb84-43ba-8c34-6f0d90c6e75a" name="jetbrains.mps.lang.smodel.query" version="3" />
+    <use id="760a0a8c-eabb-4521-8bfd-65db761a9ba3" name="jetbrains.mps.baseLanguage.logging" version="0" />
+    <use id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel" version="19" />
+    <use id="83888646-71ce-4f1c-9c53-c54016f6ad4f" name="jetbrains.mps.baseLanguage.collections" version="1" />
+    <use id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage" version="12" />
+    <use id="fd392034-7849-419d-9071-12563d152375" name="jetbrains.mps.baseLanguage.closures" version="0" />
   </languages>
   <imports>
     <import index="z1c3" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.project(MPS.Core/)" />
@@ -12,13 +17,23 @@
     <import index="mhbf" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.model(MPS.OpenAPI/)" />
     <import index="28m1" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.time(JDK/)" />
     <import index="tpce" ref="r:00000000-0000-4000-0000-011c89590292(jetbrains.mps.lang.structure.structure)" />
-    <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" implicit="true" />
-    <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" implicit="true" />
-    <import index="3idh" ref="r:aa500632-603e-417c-bfa3-e659894cddd2(org.mpsqa.deprecated.structure)" implicit="true" />
+    <import index="3idh" ref="r:aa500632-603e-417c-bfa3-e659894cddd2(org.mpsqa.deprecated.structure)" />
+    <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" />
+    <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" />
+    <import index="z60i" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.awt(JDK/)" />
+    <import index="b9kz" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.openapi.wm.ex(MPS.IDEA/)" />
+    <import index="jkny" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.openapi.wm(MPS.IDEA/)" />
+    <import index="e8no" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.util.containers(MPS.IDEA/)" />
+    <import index="4nm9" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.openapi.project(MPS.IDEA/)" />
+    <import index="alof" ref="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61/java:jetbrains.mps.ide.project(MPS.Platform/)" />
   </imports>
   <registry>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
       <concept id="1080223426719" name="jetbrains.mps.baseLanguage.structure.OrExpression" flags="nn" index="22lmx$" />
+      <concept id="1215693861676" name="jetbrains.mps.baseLanguage.structure.BaseAssignmentExpression" flags="nn" index="d038R">
+        <child id="1068498886297" name="rValue" index="37vLTx" />
+        <child id="1068498886295" name="lValue" index="37vLTJ" />
+      </concept>
       <concept id="1202948039474" name="jetbrains.mps.baseLanguage.structure.InstanceMethodCallOperation" flags="nn" index="liA8E" />
       <concept id="1465982738277781862" name="jetbrains.mps.baseLanguage.structure.PlaceholderMember" flags="nn" index="2tJIrI" />
       <concept id="1154032098014" name="jetbrains.mps.baseLanguage.structure.AbstractLoopStatement" flags="nn" index="2LF5Ji">
@@ -35,10 +50,18 @@
       <concept id="1081236700937" name="jetbrains.mps.baseLanguage.structure.StaticMethodCall" flags="nn" index="2YIFZM">
         <reference id="1144433194310" name="classConcept" index="1Pybhc" />
       </concept>
+      <concept id="1081256982272" name="jetbrains.mps.baseLanguage.structure.InstanceOfExpression" flags="nn" index="2ZW3vV">
+        <child id="1081256993305" name="classType" index="2ZW6by" />
+        <child id="1081256993304" name="leftExpression" index="2ZW6bz" />
+      </concept>
       <concept id="1070533707846" name="jetbrains.mps.baseLanguage.structure.StaticFieldReference" flags="nn" index="10M0yZ">
         <reference id="1144433057691" name="classifier" index="1PxDUh" />
       </concept>
       <concept id="1070534058343" name="jetbrains.mps.baseLanguage.structure.NullLiteral" flags="nn" index="10Nm6u" />
+      <concept id="1070534934090" name="jetbrains.mps.baseLanguage.structure.CastExpression" flags="nn" index="10QFUN">
+        <child id="1070534934091" name="type" index="10QFUM" />
+        <child id="1070534934092" name="expression" index="10QFUP" />
+      </concept>
       <concept id="1068390468198" name="jetbrains.mps.baseLanguage.structure.ClassConcept" flags="ig" index="312cEu" />
       <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
         <child id="1068431790190" name="initializer" index="33vP2m" />
@@ -47,6 +70,7 @@
         <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
       </concept>
       <concept id="1068498886292" name="jetbrains.mps.baseLanguage.structure.ParameterDeclaration" flags="ir" index="37vLTG" />
+      <concept id="1068498886294" name="jetbrains.mps.baseLanguage.structure.AssignmentExpression" flags="nn" index="37vLTI" />
       <concept id="1225271369338" name="jetbrains.mps.baseLanguage.structure.IsEmptyOperation" flags="nn" index="17RlXB" />
       <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
         <child id="5680397130376446158" name="type" index="1tU5fm" />
@@ -55,6 +79,10 @@
         <child id="1068580123133" name="returnType" index="3clF45" />
         <child id="1068580123134" name="parameter" index="3clF46" />
         <child id="1068580123135" name="body" index="3clF47" />
+      </concept>
+      <concept id="1068580123152" name="jetbrains.mps.baseLanguage.structure.EqualsExpression" flags="nn" index="3clFbC" />
+      <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
+        <child id="1068580123156" name="expression" index="3clFbG" />
       </concept>
       <concept id="1068580123157" name="jetbrains.mps.baseLanguage.structure.Statement" flags="nn" index="3clFbH" />
       <concept id="1068580123159" name="jetbrains.mps.baseLanguage.structure.IfStatement" flags="nn" index="3clFbJ">
@@ -71,6 +99,9 @@
         <child id="1068581242865" name="localVariableDeclaration" index="3cpWs9" />
       </concept>
       <concept id="1068581242863" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclaration" flags="nr" index="3cpWsn" />
+      <concept id="1079359253375" name="jetbrains.mps.baseLanguage.structure.ParenthesizedExpression" flags="nn" index="1eOMI4">
+        <child id="1079359253376" name="expression" index="1eOMHV" />
+      </concept>
       <concept id="1081516740877" name="jetbrains.mps.baseLanguage.structure.NotExpression" flags="nn" index="3fqX7Q">
         <child id="1081516765348" name="expression" index="3fr31v" />
       </concept>
@@ -320,6 +351,13 @@
               </node>
               <node concept="3clFbS" id="5ruws_4EDgj" role="2LFqv$">
                 <node concept="3clFbJ" id="5ruws_4EDqi" role="3cqZAp">
+                  <node concept="3clFbS" id="5ruws_4EDqk" role="3clFbx">
+                    <node concept="3cpWs6" id="5ruws_4EFfV" role="3cqZAp">
+                      <node concept="2GrUjf" id="5ruws_4EFgz" role="3cqZAk">
+                        <ref role="2Gs0qQ" node="5ruws_4EC16" resolve="op" />
+                      </node>
+                    </node>
+                  </node>
                   <node concept="2OqwBi" id="5ruws_4EE2y" role="3clFbw">
                     <node concept="2GrUjf" id="5ruws_4EDqV" role="2Oq$k0">
                       <ref role="2Gs0qQ" node="5ruws_4EDg9" resolve="pm" />
@@ -328,13 +366,6 @@
                       <ref role="37wK5l" to="wyt6:~Object.equals(java.lang.Object)" resolve="equals" />
                       <node concept="37vLTw" id="5ruws_4EF5s" role="37wK5m">
                         <ref role="3cqZAo" node="5ruws_4EDyr" resolve="myModel" />
-                      </node>
-                    </node>
-                  </node>
-                  <node concept="3clFbS" id="5ruws_4EDqk" role="3clFbx">
-                    <node concept="3cpWs6" id="5ruws_4EFfV" role="3cqZAp">
-                      <node concept="2GrUjf" id="5ruws_4EFgz" role="3cqZAk">
-                        <ref role="2Gs0qQ" node="5ruws_4EC16" resolve="op" />
                       </node>
                     </node>
                   </node>
@@ -408,10 +439,11 @@
           </node>
         </node>
       </node>
-      <node concept="3cpWs8" id="45IuY9n8txb" role="3cqZAp">
-        <node concept="3cpWsn" id="45IuY9n8txc" role="3cpWs9">
+      <node concept="3clFbH" id="198j$VvEGRb" role="3cqZAp" />
+      <node concept="3cpWs8" id="198j$VvF2I2" role="3cqZAp">
+        <node concept="3cpWsn" id="198j$VvF2I5" role="3cpWs9">
           <property role="TrG5h" value="project" />
-          <node concept="3uibUv" id="45IuY9n8twE" role="1tU5fm">
+          <node concept="3uibUv" id="198j$VvF2I6" role="1tU5fm">
             <ref role="3uigEE" to="z1c3:~Project" resolve="Project" />
           </node>
           <node concept="2YIFZM" id="45IuY9n8txd" role="33vP2m">
@@ -433,13 +465,102 @@
           </node>
         </node>
       </node>
+      <node concept="3clFbJ" id="198j$VvF37r" role="3cqZAp">
+        <node concept="3clFbS" id="198j$VvF37t" role="3clFbx">
+          <node concept="3cpWs8" id="198j$VvEGU8" role="3cqZAp">
+            <node concept="3cpWsn" id="198j$VvEGU7" role="3cpWs9">
+              <property role="TrG5h" value="recentFocusedWindow" />
+              <node concept="3uibUv" id="198j$VvEGU9" role="1tU5fm">
+                <ref role="3uigEE" to="z60i:~Window" resolve="Window" />
+              </node>
+              <node concept="2OqwBi" id="198j$VvEHvz" role="33vP2m">
+                <node concept="2YIFZM" id="198j$VvEHtI" role="2Oq$k0">
+                  <ref role="1Pybhc" to="b9kz:~WindowManagerEx" resolve="WindowManagerEx" />
+                  <ref role="37wK5l" to="b9kz:~WindowManagerEx.getInstanceEx()" resolve="getInstanceEx" />
+                </node>
+                <node concept="liA8E" id="198j$VvEHv$" role="2OqNvi">
+                  <ref role="37wK5l" to="jkny:~WindowManager.getMostRecentFocusedWindow()" resolve="getMostRecentFocusedWindow" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbJ" id="198j$VvEGUc" role="3cqZAp">
+            <node concept="2ZW3vV" id="198j$VvEGUf" role="3clFbw">
+              <node concept="37vLTw" id="198j$VvEGUd" role="2ZW6bz">
+                <ref role="3cqZAo" node="198j$VvEGU7" resolve="recentFocusedWindow" />
+              </node>
+              <node concept="3uibUv" id="198j$VvEGUe" role="2ZW6by">
+                <ref role="3uigEE" to="jkny:~IdeFrame" resolve="IdeFrame" />
+              </node>
+            </node>
+            <node concept="3clFbS" id="198j$VvEGUh" role="3clFbx">
+              <node concept="3cpWs8" id="198j$VvEGUj" role="3cqZAp">
+                <node concept="3cpWsn" id="198j$VvEGUi" role="3cpWs9">
+                  <property role="TrG5h" value="recentFocusedProject" />
+                  <node concept="3uibUv" id="198j$VvEGUk" role="1tU5fm">
+                    <ref role="3uigEE" to="4nm9:~Project" resolve="Project" />
+                  </node>
+                  <node concept="2OqwBi" id="198j$VvEHGS" role="33vP2m">
+                    <node concept="1eOMI4" id="198j$VvEGUp" role="2Oq$k0">
+                      <node concept="10QFUN" id="198j$VvEGUm" role="1eOMHV">
+                        <node concept="37vLTw" id="198j$VvEGUn" role="10QFUP">
+                          <ref role="3cqZAo" node="198j$VvEGU7" resolve="recentFocusedWindow" />
+                        </node>
+                        <node concept="3uibUv" id="198j$VvEGUo" role="10QFUM">
+                          <ref role="3uigEE" to="jkny:~IdeFrame" resolve="IdeFrame" />
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="liA8E" id="198j$VvEHGT" role="2OqNvi">
+                      <ref role="37wK5l" to="jkny:~IdeFrame.getProject()" resolve="getProject" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3clFbF" id="198j$VvF42z" role="3cqZAp">
+                <node concept="37vLTI" id="198j$VvF47f" role="3clFbG">
+                  <node concept="2YIFZM" id="198j$VvF5NM" role="37vLTx">
+                    <ref role="37wK5l" to="alof:~ProjectHelper.fromIdeaProject(com.intellij.openapi.project.Project)" resolve="fromIdeaProject" />
+                    <ref role="1Pybhc" to="alof:~ProjectHelper" resolve="ProjectHelper" />
+                    <node concept="37vLTw" id="198j$VvF5NN" role="37wK5m">
+                      <ref role="3cqZAo" node="198j$VvEGUi" resolve="recentFocusedProject" />
+                    </node>
+                  </node>
+                  <node concept="37vLTw" id="198j$VvF42y" role="37vLTJ">
+                    <ref role="3cqZAo" node="198j$VvF2I5" resolve="project" />
+                  </node>
+                </node>
+              </node>
+              <node concept="3clFbJ" id="198j$VvFmKX" role="3cqZAp">
+                <node concept="3clFbS" id="198j$VvFmKZ" role="3clFbx">
+                  <node concept="3cpWs6" id="198j$VvFmQp" role="3cqZAp" />
+                </node>
+                <node concept="2OqwBi" id="198j$VvFm6x" role="3clFbw">
+                  <node concept="37vLTw" id="198j$VvFlOL" role="2Oq$k0">
+                    <ref role="3cqZAo" node="198j$VvF2I5" resolve="project" />
+                  </node>
+                  <node concept="liA8E" id="198j$VvFmng" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~Project.isDisposed()" resolve="isDisposed" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbC" id="198j$VvF3m4" role="3clFbw">
+          <node concept="10Nm6u" id="198j$VvF3uC" role="3uHU7w" />
+          <node concept="37vLTw" id="198j$VvF3kZ" role="3uHU7B">
+            <ref role="3cqZAo" node="198j$VvF2I5" resolve="project" />
+          </node>
+        </node>
+      </node>
       <node concept="3clFbH" id="45IuY9n8tBm" role="3cqZAp" />
       <node concept="3clFbJ" id="ah8HpWhKTt" role="3cqZAp">
         <node concept="2YIFZM" id="45IuY9n8e$$" role="3clFbw">
           <ref role="37wK5l" to="bdtf:45IuY9n8bn5" resolve="isSomethingDeprecated" />
           <ref role="1Pybhc" to="bdtf:7LZ1KAVSSeM" resolve="DeprecationFacade" />
           <node concept="37vLTw" id="45IuY9n8tE8" role="37wK5m">
-            <ref role="3cqZAo" node="45IuY9n8txc" resolve="project" />
+            <ref role="3cqZAo" node="198j$VvF2I5" resolve="project" />
           </node>
           <node concept="37vLTw" id="45IuY9n8sOw" role="37wK5m">
             <ref role="3cqZAo" node="7LZ1KAVTPJg" resolve="date" />

--- a/code/languages/org.mpsqa.deprecated/tests/test.org.mpsqa.deprecated/models/test.org.mpsqa.deprecated._010_deprecation_tests@tests.mps
+++ b/code/languages/org.mpsqa.deprecated/tests/test.org.mpsqa.deprecated/models/test.org.mpsqa.deprecated._010_deprecation_tests@tests.mps
@@ -2,7 +2,7 @@
 <model ref="r:51c68bd7-406b-4931-a4be-33c3d3009e13(test.org.mpsqa.deprecated._010_deprecation_tests@tests)">
   <persistence version="9" />
   <languages>
-    <use id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test" version="5" />
+    <use id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test" version="6" />
     <use id="f61473f9-130f-42f6-b98d-6c438812c2f6" name="jetbrains.mps.baseLanguage.unitTest" version="1" />
     <use id="b73ca93f-6762-4398-b251-df0d708b305b" name="org.mpsqa.deprecated" version="0" />
     <use id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel" version="19" />
@@ -35,6 +35,7 @@
       </concept>
       <concept id="1225467090849" name="jetbrains.mps.lang.test.structure.ProjectExpression" flags="nn" index="1jxXqW" />
       <concept id="1216913645126" name="jetbrains.mps.lang.test.structure.NodesTestCase" flags="lg" index="1lH9Xt">
+        <property id="2616911529524314943" name="accessMode" index="3DII0k" />
         <child id="1217501822150" name="nodesToCheck" index="1SKRRt" />
         <child id="1217501895093" name="testMethods" index="1SL9yI" />
       </concept>
@@ -182,6 +183,7 @@
   </node>
   <node concept="1lH9Xt" id="3dqUbgQn16k">
     <property role="TrG5h" value="_010_deprecated_concepts" />
+    <property role="3DII0k" value="2hh8MJdVwqX/command" />
     <node concept="1LZb2c" id="3dqUbgQn16r" role="1SL9yI">
       <property role="TrG5h" value="testDeprecatedConcepts" />
       <node concept="3cqZAl" id="3dqUbgQn16s" role="3clF45" />
@@ -336,9 +338,9 @@
         <node concept="3xLA65" id="3dqUbgQnekA" role="lGtFl">
           <property role="TrG5h" value="deprecated_config" />
         </node>
-        <node concept="7CXmI" id="dIZf5trguK" role="lGtFl">
-          <node concept="1TM$A" id="dIZf5trguL" role="7EUXB">
-            <node concept="2PYRI3" id="dIZf5truhF" role="3lydEf">
+        <node concept="7CXmI" id="198j$VvD1Is" role="lGtFl">
+          <node concept="1TM$A" id="198j$VvD1It" role="7EUXB">
+            <node concept="2PYRI3" id="198j$VvD1Nv" role="3lydEf">
               <ref role="39XzEq" to="vfwe:ah8HpWhOs_" />
             </node>
           </node>

--- a/code/languages/org.mpsqa.deprecated/tests/test.org.mpsqa.deprecated/test.org.mpsqa.deprecated.msd
+++ b/code/languages/org.mpsqa.deprecated/tests/test.org.mpsqa.deprecated/test.org.mpsqa.deprecated.msd
@@ -26,7 +26,7 @@
     <language slang="l:ceab5195-25ea-4f22-9b92-103b95ca8c0c:jetbrains.mps.lang.core" version="2" />
     <language slang="l:446c26eb-2b7b-4bf0-9b35-f83fa582753e:jetbrains.mps.lang.modelapi" version="0" />
     <language slang="l:7866978e-a0f0-4cc7-81bc-4d213d9375e1:jetbrains.mps.lang.smodel" version="19" />
-    <language slang="l:8585453e-6bfb-4d80-98de-b16074f1d86c:jetbrains.mps.lang.test" version="5" />
+    <language slang="l:8585453e-6bfb-4d80-98de-b16074f1d86c:jetbrains.mps.lang.test" version="6" />
     <language slang="l:9ded098b-ad6a-4657-bfd9-48636cfe8bc3:jetbrains.mps.lang.traceable" version="0" />
     <language slang="l:b73ca93f-6762-4398-b251-df0d708b305b:org.mpsqa.deprecated" version="0" />
     <language slang="l:4964867e-90b8-4a58-b13e-6cd7893d620f:org.mpsqa.deprecated.example_lan" version="0" />

--- a/code/languages/org.mpsqa.mutant/.mps/migration.xml
+++ b/code/languages/org.mpsqa.mutant/.mps/migration.xml
@@ -7,6 +7,6 @@
     <entry key="jetbrains.mps.ide.mpsmigration.v_2019_3.DefaultFacetExplicitPersistence" value="executed" />
     <entry key="jetbrains.mps.ide.mpsmigration.v_2021_2.SplitMPSCoreStub" value="executed" />
     <entry key="jetbrains.mps.ide.mpsmigration.v_2021_3.ExtractMPSBootStubs" value="executed" />
-    <entry key="project.migrated.version" value="213" />
+    <entry key="project.migrated.version" value="222" />
   </component>
 </project>

--- a/code/languages/org.mpsqa.mutant/tests/test.org.mpsqa.mutant.demolang/models/test.org.mpsqa.mutant.demolang._010_smoke_tests@tests.mps
+++ b/code/languages/org.mpsqa.mutant/tests/test.org.mpsqa.mutant.demolang/models/test.org.mpsqa.mutant.demolang._010_smoke_tests@tests.mps
@@ -2,7 +2,7 @@
 <model ref="r:f4782510-f1bf-4c18-ac6e-0285cc0907c7(test.org.mpsqa.mutant.demolang._010_smoke_tests@tests)">
   <persistence version="9" />
   <languages>
-    <use id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test" version="5" />
+    <use id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test" version="6" />
     <use id="f61473f9-130f-42f6-b98d-6c438812c2f6" name="jetbrains.mps.baseLanguage.unitTest" version="1" />
     <use id="3313ed27-e24e-4f1d-81b0-b1b57775ffac" name="org.mpsqa.mutant.demolang" version="0" />
     <use id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel" version="19" />
@@ -23,6 +23,7 @@
       </concept>
       <concept id="1225467090849" name="jetbrains.mps.lang.test.structure.ProjectExpression" flags="nn" index="1jxXqW" />
       <concept id="1216913645126" name="jetbrains.mps.lang.test.structure.NodesTestCase" flags="lg" index="1lH9Xt">
+        <property id="2616911529524314943" name="accessMode" index="3DII0k" />
         <child id="1217501895093" name="testMethods" index="1SL9yI" />
       </concept>
       <concept id="1225978065297" name="jetbrains.mps.lang.test.structure.SimpleNodeTest" flags="ng" index="1LZb2c" />
@@ -140,6 +141,7 @@
   </node>
   <node concept="1lH9Xt" id="4eFGY40na3J">
     <property role="TrG5h" value="_010_test_generate_terminals_depth_1" />
+    <property role="3DII0k" value="2hh8MJdVwqX/command" />
     <node concept="1LZb2c" id="4eFGY40na3Q" role="1SL9yI">
       <property role="TrG5h" value="test_generate_terminals" />
       <node concept="3cqZAl" id="4eFGY40na3R" role="3clF45" />
@@ -288,6 +290,7 @@
   </node>
   <node concept="1lH9Xt" id="4eFGY40qr5t">
     <property role="TrG5h" value="_020_test_generate_depth_2" />
+    <property role="3DII0k" value="2hh8MJdVwqX/command" />
     <node concept="1LZb2c" id="4eFGY40qr5u" role="1SL9yI">
       <property role="TrG5h" value="test_generate_depth_2" />
       <node concept="3cqZAl" id="4eFGY40qr5v" role="3clF45" />
@@ -436,6 +439,7 @@
   </node>
   <node concept="1lH9Xt" id="4eFGY40rc3$">
     <property role="TrG5h" value="_030_test_generate_depth_3" />
+    <property role="3DII0k" value="2hh8MJdVwqX/command" />
     <node concept="1LZb2c" id="4eFGY40rc3_" role="1SL9yI">
       <property role="TrG5h" value="test_generate_depth_3" />
       <node concept="3cqZAl" id="4eFGY40rc3A" role="3clF45" />
@@ -623,6 +627,7 @@
   </node>
   <node concept="1lH9Xt" id="5jW7oooqZBN">
     <property role="TrG5h" value="_040_test_generate_concept_with_two_children_depth_2" />
+    <property role="3DII0k" value="2hh8MJdVwqX/command" />
     <node concept="1LZb2c" id="5jW7oooqZBO" role="1SL9yI">
       <property role="TrG5h" value="test_generate_concept_with_two_children_depth_2" />
       <node concept="3cqZAl" id="5jW7oooqZBP" role="3clF45" />

--- a/code/languages/org.mpsqa.mutant/tests/test.org.mpsqa.mutant.demolang/models/test.org.mpsqa.mutant.demolang._020_smoke_constraints_tests@tests.mps
+++ b/code/languages/org.mpsqa.mutant/tests/test.org.mpsqa.mutant.demolang/models/test.org.mpsqa.mutant.demolang._020_smoke_constraints_tests@tests.mps
@@ -2,7 +2,7 @@
 <model ref="r:2138a32e-293e-4700-9179-adccaaa9035e(test.org.mpsqa.mutant.demolang._020_smoke_constraints_tests@tests)">
   <persistence version="9" />
   <languages>
-    <use id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test" version="5" />
+    <use id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test" version="6" />
     <use id="f61473f9-130f-42f6-b98d-6c438812c2f6" name="jetbrains.mps.baseLanguage.unitTest" version="1" />
     <use id="3313ed27-e24e-4f1d-81b0-b1b57775ffac" name="org.mpsqa.mutant.demolang" version="0" />
     <use id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel" version="19" />
@@ -24,6 +24,7 @@
       </concept>
       <concept id="1225467090849" name="jetbrains.mps.lang.test.structure.ProjectExpression" flags="nn" index="1jxXqW" />
       <concept id="1216913645126" name="jetbrains.mps.lang.test.structure.NodesTestCase" flags="lg" index="1lH9Xt">
+        <property id="2616911529524314943" name="accessMode" index="3DII0k" />
         <child id="1217501895093" name="testMethods" index="1SL9yI" />
       </concept>
       <concept id="1225978065297" name="jetbrains.mps.lang.test.structure.SimpleNodeTest" flags="ng" index="1LZb2c" />
@@ -135,6 +136,7 @@
   </node>
   <node concept="1lH9Xt" id="4DkAay89Ubv">
     <property role="TrG5h" value="_010_test_children_with_constraints" />
+    <property role="3DII0k" value="2hh8MJdVwqX/command" />
     <node concept="1LZb2c" id="4DkAay89Ubw" role="1SL9yI">
       <property role="TrG5h" value="test_filter_out_mutants_due_to_constraints" />
       <node concept="3cqZAl" id="4DkAay89Ubx" role="3clF45" />

--- a/code/languages/org.mpsqa.mutant/tests/test.org.mpsqa.mutant.demolang/test.org.mpsqa.mutant.demolang.msd
+++ b/code/languages/org.mpsqa.mutant/tests/test.org.mpsqa.mutant.demolang/test.org.mpsqa.mutant.demolang.msd
@@ -26,7 +26,7 @@
     <language slang="l:ceab5195-25ea-4f22-9b92-103b95ca8c0c:jetbrains.mps.lang.core" version="2" />
     <language slang="l:446c26eb-2b7b-4bf0-9b35-f83fa582753e:jetbrains.mps.lang.modelapi" version="0" />
     <language slang="l:7866978e-a0f0-4cc7-81bc-4d213d9375e1:jetbrains.mps.lang.smodel" version="19" />
-    <language slang="l:8585453e-6bfb-4d80-98de-b16074f1d86c:jetbrains.mps.lang.test" version="5" />
+    <language slang="l:8585453e-6bfb-4d80-98de-b16074f1d86c:jetbrains.mps.lang.test" version="6" />
     <language slang="l:9ded098b-ad6a-4657-bfd9-48636cfe8bc3:jetbrains.mps.lang.traceable" version="0" />
     <language slang="l:1aa30e2f-c768-4ae5-9ea2-0d88d0d6d7bf:org.mpsqa.mutant" version="0" />
     <language slang="l:3313ed27-e24e-4f1d-81b0-b1b57775ffac:org.mpsqa.mutant.demolang" version="0" />

--- a/code/languages/org.mpsqa.testing/solutions/org.mpsqa.gentest.baseline/models/org.mpsqa.gentest.baseline.mps
+++ b/code/languages/org.mpsqa.testing/solutions/org.mpsqa.gentest.baseline/models/org.mpsqa.gentest.baseline.mps
@@ -482,7 +482,7 @@
             <node concept="2OqwBi" id="7cLvrVTV6ry" role="33vP2m">
               <node concept="2OqwBi" id="7cLvrVTV5P2" role="2Oq$k0">
                 <node concept="37vLTw" id="7cLvrVTV7GN" role="2Oq$k0">
-                  <ref role="3cqZAo" node="7cLvrVTV7GC" resolve="facet" />
+                  <ref role="3cqZAo" node="7cLvrVTV7GC" resolve="generationTargetFacet" />
                 </node>
                 <node concept="liA8E" id="7cLvrVTV5Pd" role="2OqNvi">
                   <ref role="37wK5l" to="b0pz:~GenerationTargetFacet.getOutputLocation(org.jetbrains.mps.openapi.model.SModel)" resolve="getOutputLocation" />

--- a/code/languages/org.mpsqa.unused/.mps/migration.xml
+++ b/code/languages/org.mpsqa.unused/.mps/migration.xml
@@ -7,6 +7,6 @@
     <entry key="jetbrains.mps.ide.mpsmigration.v_2019_3.DefaultFacetExplicitPersistence" value="executed" />
     <entry key="jetbrains.mps.ide.mpsmigration.v_2021_2.SplitMPSCoreStub" value="executed" />
     <entry key="jetbrains.mps.ide.mpsmigration.v_2021_3.ExtractMPSBootStubs" value="executed" />
-    <entry key="project.migrated.version" value="213" />
+    <entry key="project.migrated.version" value="222" />
   </component>
 </project>

--- a/code/languages/org.mpsqa.unused/languages/org.mpsqa.invisible_models.test_lang/models/org.mpsqa.invisible_models.test_lang.behavior.mps
+++ b/code/languages/org.mpsqa.unused/languages/org.mpsqa.invisible_models.test_lang/models/org.mpsqa.invisible_models.test_lang.behavior.mps
@@ -2,7 +2,7 @@
 <model ref="r:2aa54a84-e8e4-4123-8746-6a361d78e93c(org.mpsqa.invisible_models.test_lang.behavior)">
   <persistence version="9" />
   <languages>
-    <use id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel" version="18" />
+    <use id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel" version="19" />
     <use id="af65afd8-f0dd-4942-87d9-63a55f2a9db1" name="jetbrains.mps.lang.behavior" version="2" />
     <devkit ref="fbc25dd2-5da4-483a-8b19-70928e1b62d7(jetbrains.mps.devkit.general-purpose)" />
   </languages>

--- a/code/languages/org.mpsqa.unused/languages/org.mpsqa.invisible_models.test_lang/org.mpsqa.invisible_models.test_lang.mpl
+++ b/code/languages/org.mpsqa.unused/languages/org.mpsqa.invisible_models.test_lang/org.mpsqa.invisible_models.test_lang.mpl
@@ -13,7 +13,7 @@
   <accessoryModels />
   <sourcePath />
   <languageVersions>
-    <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="11" />
+    <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="12" />
     <language slang="l:443f4c36-fcf5-4eb6-9500-8d06ed259e3e:jetbrains.mps.baseLanguage.classifiers" version="0" />
     <language slang="l:fd392034-7849-419d-9071-12563d152375:jetbrains.mps.baseLanguage.closures" version="0" />
     <language slang="l:83888646-71ce-4f1c-9c53-c54016f6ad4f:jetbrains.mps.baseLanguage.collections" version="1" />
@@ -40,7 +40,7 @@
     <language slang="l:b3551702-269c-4f05-ba61-58060cef4292:jetbrains.mps.lang.rulesAndMessages" version="0" />
     <language slang="l:d8f591ec-4d86-4af2-9f92-a9e93c803ffa:jetbrains.mps.lang.scopes" version="0" />
     <language slang="l:13744753-c81f-424a-9c1b-cf8943bf4e86:jetbrains.mps.lang.sharedConcepts" version="0" />
-    <language slang="l:7866978e-a0f0-4cc7-81bc-4d213d9375e1:jetbrains.mps.lang.smodel" version="18" />
+    <language slang="l:7866978e-a0f0-4cc7-81bc-4d213d9375e1:jetbrains.mps.lang.smodel" version="19" />
     <language slang="l:c72da2b9-7cce-4447-8389-f407dc1158b7:jetbrains.mps.lang.structure" version="9" />
     <language slang="l:c7fb639f-be78-4307-89b0-b5959c3fa8c8:jetbrains.mps.lang.text" version="0" />
     <language slang="l:9ded098b-ad6a-4657-bfd9-48636cfe8bc3:jetbrains.mps.lang.traceable" version="0" />

--- a/code/languages/org.mpsqa.unused/languages/org.mpsqa.invisible_models/models/org.mpsqa.invisible_models.behavior.mps
+++ b/code/languages/org.mpsqa.unused/languages/org.mpsqa.invisible_models/models/org.mpsqa.invisible_models.behavior.mps
@@ -2,7 +2,7 @@
 <model ref="r:65c43366-7acf-44a7-a5ff-239caeb5a64c(org.mpsqa.invisible_models.behavior)">
   <persistence version="9" />
   <languages>
-    <use id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel" version="18" />
+    <use id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel" version="19" />
     <use id="af65afd8-f0dd-4942-87d9-63a55f2a9db1" name="jetbrains.mps.lang.behavior" version="2" />
     <devkit ref="fbc25dd2-5da4-483a-8b19-70928e1b62d7(jetbrains.mps.devkit.general-purpose)" />
   </languages>

--- a/code/languages/org.mpsqa.unused/languages/org.mpsqa.invisible_models/org.mpsqa.invisible_models.mpl
+++ b/code/languages/org.mpsqa.unused/languages/org.mpsqa.invisible_models/org.mpsqa.invisible_models.mpl
@@ -19,7 +19,7 @@
     <dependency reexport="false">6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)</dependency>
   </dependencies>
   <languageVersions>
-    <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="11" />
+    <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="12" />
     <language slang="l:443f4c36-fcf5-4eb6-9500-8d06ed259e3e:jetbrains.mps.baseLanguage.classifiers" version="0" />
     <language slang="l:fd392034-7849-419d-9071-12563d152375:jetbrains.mps.baseLanguage.closures" version="0" />
     <language slang="l:83888646-71ce-4f1c-9c53-c54016f6ad4f:jetbrains.mps.baseLanguage.collections" version="1" />
@@ -29,7 +29,6 @@
     <language slang="l:a247e09e-2435-45ba-b8d2-07e93feba96a:jetbrains.mps.baseLanguage.tuples" version="0" />
     <language slang="l:aee9cad2-acd4-4608-aef2-0004f6a1cdbd:jetbrains.mps.lang.actions" version="4" />
     <language slang="l:af65afd8-f0dd-4942-87d9-63a55f2a9db1:jetbrains.mps.lang.behavior" version="2" />
-    <language slang="l:fe9d76d7-5809-45c9-ae28-a40915b4d6ff:jetbrains.mps.lang.checkedName" version="1" />
     <language slang="l:3f4bc5f5-c6c1-4a28-8b10-c83066ffa4a1:jetbrains.mps.lang.constraints" version="6" />
     <language slang="l:e51810c5-7308-4642-bcb6-469e61b5dd18:jetbrains.mps.lang.constraints.msg.specification" version="0" />
     <language slang="l:47257bf3-78d3-470b-89d9-8c3261a61d15:jetbrains.mps.lang.constraints.rules" version="0" />
@@ -49,7 +48,7 @@
     <language slang="l:b3551702-269c-4f05-ba61-58060cef4292:jetbrains.mps.lang.rulesAndMessages" version="0" />
     <language slang="l:d8f591ec-4d86-4af2-9f92-a9e93c803ffa:jetbrains.mps.lang.scopes" version="0" />
     <language slang="l:13744753-c81f-424a-9c1b-cf8943bf4e86:jetbrains.mps.lang.sharedConcepts" version="0" />
-    <language slang="l:7866978e-a0f0-4cc7-81bc-4d213d9375e1:jetbrains.mps.lang.smodel" version="18" />
+    <language slang="l:7866978e-a0f0-4cc7-81bc-4d213d9375e1:jetbrains.mps.lang.smodel" version="19" />
     <language slang="l:c72da2b9-7cce-4447-8389-f407dc1158b7:jetbrains.mps.lang.structure" version="9" />
     <language slang="l:c7fb639f-be78-4307-89b0-b5959c3fa8c8:jetbrains.mps.lang.text" version="0" />
     <language slang="l:9ded098b-ad6a-4657-bfd9-48636cfe8bc3:jetbrains.mps.lang.traceable" version="0" />

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.5-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.1-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
I'd like to use the linters in MPS-Extensions, that's why I need the migration to 2022.2. For MPS 2022.2 you require JBR 17. The newer versions of the MPS Gradle plugin contain a fix for this JBR version, that's why I have upgraded it.