### PR TITLE
Allow casts to node<>, integrate tests into the build

### DIFF
--- a/.github/workflows/build_mpsqa.yml
+++ b/.github/workflows/build_mpsqa.yml
@@ -27,7 +27,7 @@ jobs:
     - name: Build MPS-QA and Publish to Github Maven
       uses: gradle/gradle-build-action@v2
       with: 
-        arguments: publish
+        arguments: build publish
         wrapper-cache-enabled: true
         dependencies-cache-enabled: true
         dependencies-cache-key: gradle/dependency-locks/**

--- a/.github/workflows/build_mpsqa.yml
+++ b/.github/workflows/build_mpsqa.yml
@@ -27,7 +27,7 @@ jobs:
     - name: Build MPS-QA and Publish to Github Maven
       uses: gradle/gradle-build-action@v2
       with: 
-        arguments: publish -Pgpr.user=${{github.actor}} -Pgpr.token=${{ secrets.GITHUB_TOKEN }}
+        arguments: publish
         wrapper-cache-enabled: true
         dependencies-cache-enabled: true
         dependencies-cache-key: gradle/dependency-locks/**

--- a/build.gradle
+++ b/build.gradle
@@ -225,12 +225,10 @@ publishing {
 		maven {
 			name = "GitHubPackages"
 			url = uri("https://maven.pkg.github.com/mbeddr/mps-qa")
-			if(project.hasProperty("gpr.token")) {
-				credentials {
-					username = project.findProperty("gpr.user")
-					password = project.findProperty("gpr.token")
-				}
-			}
+            credentials {
+                username = project.findProperty("github_username") ?: System.getenv("GITHUB_ACTOR")
+                password = project.findProperty("github_token") ?: System.getenv("GITHUB_TOKEN")
+            }
 		}
     }
     publications {

--- a/build.gradle
+++ b/build.gradle
@@ -93,7 +93,6 @@ dependencies {
 }
 
 repositories {
-    mavenLocal()
     for (repoUrl in project.dependencyRepositories) {
         maven {
             url repoUrl

--- a/build.gradle
+++ b/build.gradle
@@ -1,26 +1,7 @@
 import de.itemis.mps.gradle.*
 
-//will pull the groovy classes/types from nexus to the classpath
-buildscript {
-    repositories {
-        mavenCentral()
-        def githubRepos = ["https://maven.pkg.github.com/mbeddr/*"]
-        for (def repo in githubRepos) {
-            maven {
-                url = uri(repo)
-                credentials {
-                    username = project.findProperty("github_username") ?: System.getenv("GITHUB_ACTOR")
-                    password = project.findProperty("github_token") ?: System.getenv("GITHUB_TOKEN")
-                }
-            }
-        }
-    }
-    dependencies {
-        classpath 'de.itemis.mps:mps-gradle-plugin:1.16.+'
-    }
-}
-
 plugins {
+    id 'de.itemis.mps.gradle.common' version '1.17.+'
     id 'base'
     id 'maven-publish'
     id 'co.riiid.gradle' version '0.4.2'
@@ -44,7 +25,7 @@ if (System.env.CI != null && System.env.CI.toBoolean()) {
 }
 
 // Detect jdk location, required to start ant with tools.jar on classpath otherwise javac and tests will fail
-def jdk_home
+String jdk_home
 
 if (ext.has('java11_home')) {
     jdk_home = ext.get('java11_home')

--- a/build.gradle
+++ b/build.gradle
@@ -156,11 +156,23 @@ task configureJava {
     }
 }
 
+// All MPS tasks depend on configureJava and resolveMps
+tasks.withType(RunAntScript).configureEach {
+    dependsOn(configureJava, resolveMps)
+}
+
 task build_allScripts(type: BuildLanguages, dependsOn: [resolveMps, configureJava]) {
     script "$buildDir/scripts/build_all_scripts.xml"
 }
 
-task build_base_languages(type: BuildLanguages, dependsOn: [build_allScripts]) {
+// All other MPS tasks depend on build_allScripts
+tasks.withType(RunAntScript).configureEach {
+    if (it != build_allScripts) {
+        it.dependsOn(build_allScripts)
+    }
+}
+
+task build_base_languages(type: BuildLanguages) {
     script "$buildDir/scripts/build-base-languages.xml"
 }
 
@@ -211,14 +223,17 @@ task package_mpsqa(type: Zip, dependsOn: build_allInOne_package) {
 }
 
 task run_clones_headless(type: TestLanguages, dependsOn: build_clones_languages) {
-    description "Will execute all tests from command line"
+    description "Will execute clones tests from command line"
     print "mpsqa.home = " + rootDir;
 	script new File("$buildDir/scripts/build-clones-headless-detector.xml")
 }
 
-check.dependsOn run_clones_headless
+task test_lint(type: TestLanguages, dependsOn: build_lint_analysis_languages) {
+    description "Will execute lint tests from command line"
+    script "$buildDir/scripts/build-lint-tests.xml"
+}
 
-assemble.dependsOn run_clones_headless
+check.dependsOn run_clones_headless, test_lint
 
 publishing {
     repositories {

--- a/build/scripts/build_all_scripts.xml
+++ b/build/scripts/build_all_scripts.xml
@@ -120,7 +120,7 @@
     <delete dir="${build.layout}" />
   </target>
   
-  <target name="compileJava" depends="java.compile.org.mpsqa.build" />
+  <target name="compileJava" depends="java.compile.org.mpsqa.build, java.compile.org.mpsqa.lint.build, java.compile.org.mpsqa.clones.build" />
   
   <target name="processResources" />
   
@@ -223,6 +223,8 @@
       <library file="${artifacts.mps}/languages/xml/jetbrains.mps.core.xml.jar" />
       <chunk>
         <module file="${mpsqa.build.home}/solutions/org.mpsqa.build/org.mpsqa.build.msd" />
+        <module file="${mpsqa.home}/code/languages/org.mpsqa.clones/solutions/org.mpsqa.clones.build/org.mpsqa.clones.build.msd" />
+        <module file="${mpsqa.home}/code/languages/org.mpsqa.lint/solutions/org.mpsqa.lint.build/org.mpsqa.lint.build.msd" />
       </chunk>
       <jvmargs>
         <arg value="-ea" />
@@ -250,7 +252,33 @@
     </javac>
   </target>
   
+  <target name="java.compile.org.mpsqa.lint.build" depends="java.compile.org.mpsqa.build">
+    <mkdir dir="${mpsqa.home}/code/languages/org.mpsqa.lint/solutions/org.mpsqa.lint.build/source_gen" />
+    <mkdir dir="${build.tmp}/java/out/org.mpsqa.lint.build" />
+    <javac destdir="${build.tmp}/java/out/org.mpsqa.lint.build" fork="true" encoding="utf8" includeantruntime="false" debug="true">
+      <compilerarg value="-Xlint:none" />
+      <src>
+        <path location="${mpsqa.home}/code/languages/org.mpsqa.lint/solutions/org.mpsqa.lint.build/source_gen" />
+      </src>
+      <classpath path="${build.tmp}/java/out/org.mpsqa.build" />
+    </javac>
+  </target>
+  
+  <target name="java.compile.org.mpsqa.clones.build" depends="java.compile.org.mpsqa.build">
+    <mkdir dir="${mpsqa.home}/code/languages/org.mpsqa.clones/solutions/org.mpsqa.clones.build/source_gen" />
+    <mkdir dir="${build.tmp}/java/out/org.mpsqa.clones.build" />
+    <javac destdir="${build.tmp}/java/out/org.mpsqa.clones.build" fork="true" encoding="utf8" includeantruntime="false" debug="true">
+      <compilerarg value="-Xlint:none" />
+      <src>
+        <path location="${mpsqa.home}/code/languages/org.mpsqa.clones/solutions/org.mpsqa.clones.build/source_gen" />
+      </src>
+      <classpath path="${build.tmp}/java/out/org.mpsqa.build" />
+    </javac>
+  </target>
+  
   <target name="cleanSources">
     <delete dir="${mpsqa.build.home}/solutions/org.mpsqa.build/source_gen" />
+    <delete dir="${mpsqa.home}/code/languages/org.mpsqa.clones/solutions/org.mpsqa.clones.build/source_gen" />
+    <delete dir="${mpsqa.home}/code/languages/org.mpsqa.lint/solutions/org.mpsqa.lint.build/source_gen" />
   </target>
 </project>

--- a/code/languages/org.mpsqa.build/solutions/org.mpsqa.build/models/org.mpsqa.build._000_all_scripts.mps
+++ b/code/languages/org.mpsqa.build/solutions/org.mpsqa.build/models/org.mpsqa.build._000_all_scripts.mps
@@ -242,6 +242,140 @@
         </node>
       </node>
     </node>
+    <node concept="1E1JtA" id="4jd8IzHAZiK" role="3989C9">
+      <property role="BnDLt" value="true" />
+      <property role="TrG5h" value="org.mpsqa.lint.build" />
+      <property role="3LESm3" value="a89565e6-84af-4e8f-ad86-d4a45e3387fe" />
+      <node concept="398BVA" id="4jd8IzHAZjc" role="3LF7KH">
+        <ref role="398BVh" node="7C9PHv6FBIJ" resolve="mpsqa.home" />
+        <node concept="2Ry0Ak" id="4jd8IzHAZji" role="iGT6I">
+          <property role="2Ry0Am" value="code" />
+          <node concept="2Ry0Ak" id="4jd8IzHAZjn" role="2Ry0An">
+            <property role="2Ry0Am" value="languages" />
+            <node concept="2Ry0Ak" id="4jd8IzHAZjs" role="2Ry0An">
+              <property role="2Ry0Am" value="org.mpsqa.lint" />
+              <node concept="2Ry0Ak" id="4jd8IzHAZjx" role="2Ry0An">
+                <property role="2Ry0Am" value="solutions" />
+                <node concept="2Ry0Ak" id="4jd8IzHAZjA" role="2Ry0An">
+                  <property role="2Ry0Am" value="org.mpsqa.lint.build" />
+                  <node concept="2Ry0Ak" id="4jd8IzHAZjF" role="2Ry0An">
+                    <property role="2Ry0Am" value="org.mpsqa.lint.build.msd" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="1SiIV0" id="4jd8IzHAZjS" role="3bR37C">
+        <node concept="3bR9La" id="4jd8IzHAZjT" role="1SiIV1">
+          <ref role="3bR37D" node="5Xjjs0Nf2r4" resolve="org.mpsqa.build" />
+        </node>
+      </node>
+      <node concept="1SiIV0" id="4jd8IzHAZjU" role="3bR37C">
+        <node concept="3bR9La" id="4jd8IzHAZjV" role="1SiIV1">
+          <ref role="3bR37D" to="ffeo:78GwwOvB3tw" resolve="jetbrains.mps.ide.build" />
+        </node>
+      </node>
+      <node concept="1BupzO" id="4jd8IzHAZk3" role="3bR31x">
+        <property role="3ZfqAx" value="models" />
+        <property role="1Hdu6h" value="true" />
+        <property role="1HemKv" value="true" />
+        <node concept="3LXTmp" id="4jd8IzHAZk4" role="1HemKq">
+          <node concept="398BVA" id="4jd8IzHAZjW" role="3LXTmr">
+            <ref role="398BVh" node="7C9PHv6FBIJ" resolve="mpsqa.home" />
+            <node concept="2Ry0Ak" id="4jd8IzHAZjX" role="iGT6I">
+              <property role="2Ry0Am" value="code" />
+              <node concept="2Ry0Ak" id="4jd8IzHAZjY" role="2Ry0An">
+                <property role="2Ry0Am" value="languages" />
+                <node concept="2Ry0Ak" id="4jd8IzHAZjZ" role="2Ry0An">
+                  <property role="2Ry0Am" value="org.mpsqa.lint" />
+                  <node concept="2Ry0Ak" id="4jd8IzHAZk0" role="2Ry0An">
+                    <property role="2Ry0Am" value="solutions" />
+                    <node concept="2Ry0Ak" id="4jd8IzHAZk1" role="2Ry0An">
+                      <property role="2Ry0Am" value="org.mpsqa.lint.build" />
+                      <node concept="2Ry0Ak" id="4jd8IzHAZk2" role="2Ry0An">
+                        <property role="2Ry0Am" value="models" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3qWCbU" id="4jd8IzHAZk5" role="3LXTna">
+            <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1E1JtA" id="4jd8IzHAZnq" role="3989C9">
+      <property role="BnDLt" value="true" />
+      <property role="TrG5h" value="org.mpsqa.clones.build" />
+      <property role="3LESm3" value="cf9e90bb-6263-4505-b1d0-f6a2339ece89" />
+      <node concept="398BVA" id="4jd8IzHAZoc" role="3LF7KH">
+        <ref role="398BVh" node="7C9PHv6FBIJ" resolve="mpsqa.home" />
+        <node concept="2Ry0Ak" id="4jd8IzHAZog" role="iGT6I">
+          <property role="2Ry0Am" value="code" />
+          <node concept="2Ry0Ak" id="4jd8IzHAZol" role="2Ry0An">
+            <property role="2Ry0Am" value="languages" />
+            <node concept="2Ry0Ak" id="4jd8IzHAZoq" role="2Ry0An">
+              <property role="2Ry0Am" value="org.mpsqa.clones" />
+              <node concept="2Ry0Ak" id="4jd8IzHAZov" role="2Ry0An">
+                <property role="2Ry0Am" value="solutions" />
+                <node concept="2Ry0Ak" id="4jd8IzHAZoB" role="2Ry0An">
+                  <property role="2Ry0Am" value="org.mpsqa.clones.build" />
+                  <node concept="2Ry0Ak" id="4jd8IzHAZoG" role="2Ry0An">
+                    <property role="2Ry0Am" value="org.mpsqa.clones.build.msd" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="1SiIV0" id="4jd8IzHAZp0" role="3bR37C">
+        <node concept="3bR9La" id="4jd8IzHAZp1" role="1SiIV1">
+          <ref role="3bR37D" node="5Xjjs0Nf2r4" resolve="org.mpsqa.build" />
+        </node>
+      </node>
+      <node concept="1SiIV0" id="4jd8IzHAZp2" role="3bR37C">
+        <node concept="3bR9La" id="4jd8IzHAZp3" role="1SiIV1">
+          <ref role="3bR37D" to="ffeo:78GwwOvB3tw" resolve="jetbrains.mps.ide.build" />
+        </node>
+      </node>
+      <node concept="1BupzO" id="4jd8IzHAZpb" role="3bR31x">
+        <property role="3ZfqAx" value="models" />
+        <property role="1Hdu6h" value="true" />
+        <property role="1HemKv" value="true" />
+        <node concept="3LXTmp" id="4jd8IzHAZpc" role="1HemKq">
+          <node concept="398BVA" id="4jd8IzHAZp4" role="3LXTmr">
+            <ref role="398BVh" node="7C9PHv6FBIJ" resolve="mpsqa.home" />
+            <node concept="2Ry0Ak" id="4jd8IzHAZp5" role="iGT6I">
+              <property role="2Ry0Am" value="code" />
+              <node concept="2Ry0Ak" id="4jd8IzHAZp6" role="2Ry0An">
+                <property role="2Ry0Am" value="languages" />
+                <node concept="2Ry0Ak" id="4jd8IzHAZp7" role="2Ry0An">
+                  <property role="2Ry0Am" value="org.mpsqa.clones" />
+                  <node concept="2Ry0Ak" id="4jd8IzHAZp8" role="2Ry0An">
+                    <property role="2Ry0Am" value="solutions" />
+                    <node concept="2Ry0Ak" id="4jd8IzHAZp9" role="2Ry0An">
+                      <property role="2Ry0Am" value="org.mpsqa.clones.build" />
+                      <node concept="2Ry0Ak" id="4jd8IzHAZpa" role="2Ry0An">
+                        <property role="2Ry0Am" value="models" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3qWCbU" id="4jd8IzHAZpd" role="3LXTna">
+            <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
+          </node>
+        </node>
+      </node>
+    </node>
     <node concept="2igEWh" id="3GDqItDloKJ" role="1hWBAP">
       <property role="3UIfUI" value="1024" />
     </node>

--- a/code/languages/org.mpsqa.clones/languages/org.mpsqa.clones.config/models/org.mpsqa.clones.config.structure.mps
+++ b/code/languages/org.mpsqa.clones/languages/org.mpsqa.clones.config/models/org.mpsqa.clones.config.structure.mps
@@ -72,35 +72,35 @@
       <property role="IQ2ns" value="3373285491508535697" />
       <property role="20lmBu" value="aggregation" />
       <property role="20kJfa" value="scope" />
-      <property role="20lbJX" value="1" />
+      <property role="20lbJX" value="fLJekj4/_1" />
       <ref role="20lvS9" node="2VgkkwRm66t" resolve="CloneDetectionScopeBase" />
     </node>
     <node concept="1TJgyj" id="1GhTetdWNt7" role="1TKVEi">
       <property role="IQ2ns" value="1950591795724498759" />
       <property role="20lmBu" value="aggregation" />
       <property role="20kJfa" value="consideredModules" />
-      <property role="20lbJX" value="0..n" />
+      <property role="20lbJX" value="fLJekj5/_0__n" />
       <ref role="20lvS9" node="2VgkkwRqN5V" resolve="IIgnoreElement" />
     </node>
     <node concept="1TJgyj" id="7vLq_hstMma" role="1TKVEi">
       <property role="IQ2ns" value="8642806070461801866" />
       <property role="20lmBu" value="aggregation" />
       <property role="20kJfa" value="ignoredModules" />
-      <property role="20lbJX" value="0..n" />
+      <property role="20lbJX" value="fLJekj5/_0__n" />
       <ref role="20lvS9" node="2VgkkwRqN5V" resolve="IIgnoreElement" />
     </node>
     <node concept="1TJgyj" id="7vLq_hstMmd" role="1TKVEi">
       <property role="IQ2ns" value="8642806070461801869" />
       <property role="20lmBu" value="aggregation" />
       <property role="20kJfa" value="ignoredModels" />
-      <property role="20lbJX" value="0..n" />
+      <property role="20lbJX" value="fLJekj5/_0__n" />
       <ref role="20lvS9" node="2VgkkwRqN5V" resolve="IIgnoreElement" />
     </node>
     <node concept="1TJgyj" id="GBiWXwJuSz" role="1TKVEi">
       <property role="IQ2ns" value="803694412562296355" />
       <property role="20lmBu" value="aggregation" />
       <property role="20kJfa" value="ignoredConcepts" />
-      <property role="20lbJX" value="0..n" />
+      <property role="20lbJX" value="fLJekj5/_0__n" />
       <ref role="20lvS9" node="2VgkkwRqN5V" resolve="IIgnoreElement" />
     </node>
     <node concept="PrWs8" id="7vLq_hstL0g" role="PzmwI">
@@ -113,7 +113,6 @@
       <property role="IQ2ns" value="7342432778946760608" />
       <property role="20lmBu" value="aggregation" />
       <property role="20kJfa" value="postprocessor" />
-      <property role="20lbJX" value="0..1" />
       <ref role="20lvS9" node="6n_zVnCdQPg" resolve="IClonesPostprocessor" />
     </node>
     <node concept="1TJgyi" id="6dJ4vxiQa_1" role="1TKVEl">

--- a/code/languages/org.mpsqa.clones/solutions/org.mpsqa.clones.build/models/org.mpsqa.clones.build.mps
+++ b/code/languages/org.mpsqa.clones/solutions/org.mpsqa.clones.build/models/org.mpsqa.clones.build.mps
@@ -20,7 +20,9 @@
       <concept id="4560297596904469362" name="jetbrains.mps.build.mps.tests.structure.BuildMps_TestModule" flags="nn" index="22LTRM">
         <reference id="4560297596904469363" name="module" index="22LTRN" />
       </concept>
-      <concept id="6593674873639474400" name="jetbrains.mps.build.mps.tests.structure.BuildMps_TestModules_Options" flags="ng" index="24cAiW" />
+      <concept id="6593674873639474400" name="jetbrains.mps.build.mps.tests.structure.BuildMps_TestModules_Options" flags="ng" index="24cAiW">
+        <child id="6593674873639478221" name="haltonfailure" index="24c_eh" />
+      </concept>
       <concept id="4005526075820600484" name="jetbrains.mps.build.mps.tests.structure.BuildModuleTestsPlugin" flags="ng" index="1gjT0q" />
     </language>
     <language id="798100da-4f0a-421a-b991-71f8c50ce5d2" name="jetbrains.mps.build">
@@ -336,7 +338,13 @@
       <node concept="22LTRM" id="1GhTetdBYvk" role="22LTRK">
         <ref role="22LTRN" node="2JVMSZMFYb5" resolve="test.org.mpsqa.clones.headless" />
       </node>
-      <node concept="24cAiW" id="1GhTetdClxk" role="24cAkG" />
+      <node concept="24cAiW" id="1GhTetdClxk" role="24cAkG">
+        <node concept="NbPM2" id="4jd8IzHDwG7" role="24c_eh">
+          <node concept="3Mxwew" id="4jd8IzHDwG6" role="3MwsjC">
+            <property role="3MwjfP" value="true" />
+          </node>
+        </node>
+      </node>
     </node>
   </node>
 </model>

--- a/code/languages/org.mpsqa.clones/tests/test.org.mpsqa.clones.headless/models/_010_headless_runner_1@tests.mps
+++ b/code/languages/org.mpsqa.clones/tests/test.org.mpsqa.clones.headless/models/_010_headless_runner_1@tests.mps
@@ -7,6 +7,7 @@
     <use id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel" version="19" />
     <use id="28f9e497-3b42-4291-aeba-0a1039153ab1" name="jetbrains.mps.lang.plugin" version="5" />
     <use id="56cfcf05-92e4-4822-8126-2ea0e0cece6b" name="org.mpsqa.clones.config" version="0" />
+    <use id="c7fb639f-be78-4307-89b0-b5959c3fa8c8" name="jetbrains.mps.lang.text" version="0" />
   </languages>
   <imports>
     <import index="f4mj" ref="r:87c69567-b194-437c-b9e6-0ce2770f06d2(org.mpsqa.clones.config.pluginSolution.utils)" />
@@ -82,12 +83,6 @@
       </concept>
       <concept id="1107535904670" name="jetbrains.mps.baseLanguage.structure.ClassifierType" flags="in" index="3uibUv">
         <reference id="1107535924139" name="classifier" index="3uigEE" />
-      </concept>
-      <concept id="6329021646629104957" name="jetbrains.mps.baseLanguage.structure.TextCommentPart" flags="nn" index="3SKdUq">
-        <property id="6329021646629104958" name="text" index="3SKdUp" />
-      </concept>
-      <concept id="6329021646629104954" name="jetbrains.mps.baseLanguage.structure.SingleLineComment" flags="nn" index="3SKdUt">
-        <child id="6329021646629175155" name="commentPart" index="3SKWNk" />
       </concept>
     </language>
     <language id="446c26eb-2b7b-4bf0-9b35-f83fa582753e" name="jetbrains.mps.lang.modelapi">
@@ -195,19 +190,9 @@
           </node>
         </node>
         <node concept="3clFbH" id="2KLGrfl1HUW" role="3cqZAp" />
-        <node concept="3SKdUt" id="2KLGrfl1HUX" role="3cqZAp">
-          <node concept="3SKdUq" id="2KLGrfl1HUY" role="3SKWNk">
-            <property role="3SKdUp" value="if the clones detection config has as postprocessor the &quot;filtering of new clones w.r.t. baseline&quot;, then our test " />
-          </node>
-        </node>
-        <node concept="3SKdUt" id="2KLGrfl1HUZ" role="3cqZAp">
-          <node concept="3SKdUq" id="2KLGrfl1HV0" role="3SKWNk">
-            <property role="3SKdUp" value="will fail if new clones are detected " />
-          </node>
-        </node>
         <node concept="3vlDli" id="2KLGrfl1HV1" role="3cqZAp">
           <node concept="3cmrfG" id="2KLGrfl1HV2" role="3tpDZB">
-            <property role="3cmrfH" value="0" />
+            <property role="3cmrfH" value="1" />
           </node>
           <node concept="2OqwBi" id="2KLGrfl1HV3" role="3tpDZA">
             <node concept="37vLTw" id="2KLGrfl1HV4" role="2Oq$k0">

--- a/code/languages/org.mpsqa.clones/tests/test.org.mpsqa.clones.headless/models/clone_config_headless_01.mps
+++ b/code/languages/org.mpsqa.clones/tests/test.org.mpsqa.clones.headless/models/clone_config_headless_01.mps
@@ -18,14 +18,10 @@
         <property id="7164965290409240908" name="minimalNumberOfSiblings" index="LHVyO" />
         <property id="7164965290409240897" name="minimalSuffixSize" index="LHVyT" />
         <property id="7164965290409240901" name="maximalSuffixSize" index="LHVyX" />
-        <child id="7342432778946760608" name="postprocessor" index="2dEW0l" />
         <child id="3373285491508535697" name="scope" index="py33p" />
         <child id="8642806070461801866" name="ignoredModules" index="Fx$Zu" />
         <child id="1950591795724498759" name="consideredModules" index="1mSHew" />
         <child id="803694412562296355" name="ignoredConcepts" index="1FAEnG" />
-      </concept>
-      <concept id="1268924532562219296" name="org.mpsqa.clones.config.structure.NewClonesFilter" flags="ng" index="2VIB43">
-        <property id="1268924532562219297" name="path" index="2VIB42" />
       </concept>
     </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
@@ -64,9 +60,6 @@
       <property role="Fx$Zl" value=".*lib" />
     </node>
     <node concept="py32F" id="7YZJmepzrg1" role="py33p" />
-    <node concept="2VIB43" id="wcbKZIZ4mX" role="2dEW0l">
-      <property role="2VIB42" value="d:/clones.xml" />
-    </node>
   </node>
 </model>
 

--- a/code/languages/org.mpsqa.clones/tests/test.org.mpsqa.clones.headless/test.org.mpsqa.clones.headless.msd
+++ b/code/languages/org.mpsqa.clones/tests/test.org.mpsqa.clones.headless/test.org.mpsqa.clones.headless.msd
@@ -31,6 +31,7 @@
     <language slang="l:28f9e497-3b42-4291-aeba-0a1039153ab1:jetbrains.mps.lang.plugin" version="5" />
     <language slang="l:7866978e-a0f0-4cc7-81bc-4d213d9375e1:jetbrains.mps.lang.smodel" version="19" />
     <language slang="l:8585453e-6bfb-4d80-98de-b16074f1d86c:jetbrains.mps.lang.test" version="6" />
+    <language slang="l:c7fb639f-be78-4307-89b0-b5959c3fa8c8:jetbrains.mps.lang.text" version="0" />
     <language slang="l:9ded098b-ad6a-4657-bfd9-48636cfe8bc3:jetbrains.mps.lang.traceable" version="0" />
     <language slang="l:56cfcf05-92e4-4822-8126-2ea0e0cece6b:org.mpsqa.clones.config" version="0" />
   </languageVersions>

--- a/code/languages/org.mpsqa.lint/.mps/modules.xml
+++ b/code/languages/org.mpsqa.lint/.mps/modules.xml
@@ -6,6 +6,7 @@
       <modulePath path="$PROJECT_DIR$/solutions/org.mpsqa.lint.generic.linters_library/org.mpsqa.lint.generic.linters_library.msd" folder="" />
       <modulePath path="$PROJECT_DIR$/solutions/org.mpsqa.lint.generic.sandbox/org.mpsqa.lint.generic.sandbox.msd" folder="" />
       <modulePath path="$PROJECT_DIR$/solutions/org.mpsqa.lint.mps_lang.linters_library/org.mpsqa.lint.mps_lang.linters_library.msd" folder="" />
+      <modulePath path="$PROJECT_DIR$/solutions/org.mpsqa.lint.test/org.mpsqa.lint.test.msd" folder="" />
     </projectModules>
   </component>
 </project>

--- a/code/languages/org.mpsqa.lint/.mps/modules.xml
+++ b/code/languages/org.mpsqa.lint/.mps/modules.xml
@@ -3,6 +3,7 @@
   <component name="MPSProject">
     <projectModules>
       <modulePath path="$PROJECT_DIR$/languages/org.mpsqa.lint.generic/org.mpsqa.lint.generic.mpl" folder="" />
+      <modulePath path="$PROJECT_DIR$/solutions/org.mpsqa.lint.build/org.mpsqa.lint.build.msd" folder="build" />
       <modulePath path="$PROJECT_DIR$/solutions/org.mpsqa.lint.generic.linters_library/org.mpsqa.lint.generic.linters_library.msd" folder="" />
       <modulePath path="$PROJECT_DIR$/solutions/org.mpsqa.lint.generic.sandbox/org.mpsqa.lint.generic.sandbox.msd" folder="" />
       <modulePath path="$PROJECT_DIR$/solutions/org.mpsqa.lint.mps_lang.linters_library/org.mpsqa.lint.mps_lang.linters_library.msd" folder="" />

--- a/code/languages/org.mpsqa.lint/languages/org.mpsqa.lint.generic/org.mpsqa.lint.generic.mpl
+++ b/code/languages/org.mpsqa.lint/languages/org.mpsqa.lint.generic/org.mpsqa.lint.generic.mpl
@@ -51,8 +51,6 @@
         <module reference="6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)" version="0" />
         <module reference="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)" version="0" />
         <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
-        <module reference="4c6a28d1-2c60-478d-b36e-db9b3cbb21fb(closures.runtime)" version="0" />
-        <module reference="9b80526e-f0bf-4992-bdf5-cee39c1833f3(collections.runtime)" version="0" />
         <module reference="f3061a53-9226-4cc5-a443-f952ceaf5816(jetbrains.mps.baseLanguage)" version="0" />
         <module reference="52b81ac7-93fd-4e9e-b972-4995882da6d4(jetbrains.mps.baseLanguage.references.runtime)" version="0" />
         <module reference="e39e4a59-8cb6-498e-860e-8fa8361c0d90(jetbrains.mps.baseLanguage.scopes)" version="0" />
@@ -69,7 +67,6 @@
   <dependencies>
     <dependency reexport="false">f3061a53-9226-4cc5-a443-f952ceaf5816(jetbrains.mps.baseLanguage)</dependency>
     <dependency reexport="false">c7fb639f-be78-4307-89b0-b5959c3fa8c8(jetbrains.mps.lang.text)</dependency>
-    <dependency reexport="false" scope="generate-into">83888646-71ce-4f1c-9c53-c54016f6ad4f(jetbrains.mps.baseLanguage.collections)</dependency>
     <dependency reexport="false">6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)</dependency>
     <dependency reexport="false">8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)</dependency>
     <dependency reexport="false">6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)</dependency>

--- a/code/languages/org.mpsqa.lint/solutions/org.mpsqa.lint.build/models/org.mpsqa.lint.build.mps
+++ b/code/languages/org.mpsqa.lint/solutions/org.mpsqa.lint.build/models/org.mpsqa.lint.build.mps
@@ -1,0 +1,243 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:f44fe2b3-781b-4c2a-8a73-8a395c3251d8(org.mpsqa.lint.build)">
+  <persistence version="9" />
+  <languages>
+    <use id="0cf935df-4699-4e9c-a132-fa109541cba3" name="jetbrains.mps.build.mps" version="7" />
+    <use id="798100da-4f0a-421a-b991-71f8c50ce5d2" name="jetbrains.mps.build" version="0" />
+    <use id="3600cb0a-44dd-4a5b-9968-22924406419e" name="jetbrains.mps.build.mps.tests" version="1" />
+  </languages>
+  <imports>
+    <import index="ffeo" ref="r:874d959d-e3b4-4d04-b931-ca849af130dd(jetbrains.mps.ide.build)" />
+    <import index="390y" ref="r:7cf4c5c6-be6b-461a-9752-5a87d0b55129(org.mpsqa.build._080_lint_build)" />
+  </imports>
+  <registry>
+    <language id="3600cb0a-44dd-4a5b-9968-22924406419e" name="jetbrains.mps.build.mps.tests">
+      <concept id="4560297596904469355" name="jetbrains.mps.build.mps.tests.structure.BuildMps_TestModuleGroup" flags="ng" index="22LTRF">
+        <reference id="4560297596904469356" name="group" index="22LTRG" />
+      </concept>
+      <concept id="4560297596904469357" name="jetbrains.mps.build.mps.tests.structure.BuildAspect_MpsTestModules" flags="nn" index="22LTRH">
+        <child id="4560297596904469360" name="modules" index="22LTRK" />
+        <child id="6593674873639474544" name="options" index="24cAkG" />
+      </concept>
+      <concept id="6593674873639474400" name="jetbrains.mps.build.mps.tests.structure.BuildMps_TestModules_Options" flags="ng" index="24cAiW">
+        <child id="6593674873639478221" name="haltonfailure" index="24c_eh" />
+      </concept>
+      <concept id="4005526075820600484" name="jetbrains.mps.build.mps.tests.structure.BuildModuleTestsPlugin" flags="ng" index="1gjT0q" />
+    </language>
+    <language id="798100da-4f0a-421a-b991-71f8c50ce5d2" name="jetbrains.mps.build">
+      <concept id="5481553824944787378" name="jetbrains.mps.build.structure.BuildSourceProjectRelativePath" flags="ng" index="55IIr" />
+      <concept id="7321017245476976379" name="jetbrains.mps.build.structure.BuildRelativePath" flags="ng" index="iG8Mu">
+        <child id="7321017245477039051" name="compositePart" index="iGT6I" />
+      </concept>
+      <concept id="4993211115183325728" name="jetbrains.mps.build.structure.BuildProjectDependency" flags="ng" index="2sgV4H">
+        <reference id="5617550519002745380" name="script" index="1l3spb" />
+        <child id="4129895186893471026" name="artifacts" index="2JcizS" />
+      </concept>
+      <concept id="4380385936562003279" name="jetbrains.mps.build.structure.BuildString" flags="ng" index="NbPM2">
+        <child id="4903714810883783243" name="parts" index="3MwsjC" />
+      </concept>
+      <concept id="8618885170173601777" name="jetbrains.mps.build.structure.BuildCompositePath" flags="nn" index="2Ry0Ak">
+        <property id="8618885170173601779" name="head" index="2Ry0Am" />
+        <child id="8618885170173601778" name="tail" index="2Ry0An" />
+      </concept>
+      <concept id="6647099934206700647" name="jetbrains.mps.build.structure.BuildJavaPlugin" flags="ng" index="10PD9b" />
+      <concept id="7389400916848136194" name="jetbrains.mps.build.structure.BuildFolderMacro" flags="ng" index="398rNT">
+        <child id="7389400916848144618" name="defaultPath" index="398pKh" />
+      </concept>
+      <concept id="7389400916848153117" name="jetbrains.mps.build.structure.BuildSourceMacroRelativePath" flags="ng" index="398BVA">
+        <reference id="7389400916848153130" name="macro" index="398BVh" />
+      </concept>
+      <concept id="5617550519002745364" name="jetbrains.mps.build.structure.BuildLayout" flags="ng" index="1l3spV" />
+      <concept id="5617550519002745363" name="jetbrains.mps.build.structure.BuildProject" flags="ng" index="1l3spW">
+        <property id="4915877860348071612" name="fileName" index="turDy" />
+        <property id="5204048710541015587" name="internalBaseDirectory" index="2DA0ip" />
+        <child id="6647099934206700656" name="plugins" index="10PD9s" />
+        <child id="7389400916848080626" name="parts" index="3989C9" />
+        <child id="3542413272732620719" name="aspects" index="1hWBAP" />
+        <child id="5617550519002745381" name="dependencies" index="1l3spa" />
+        <child id="5617550519002745378" name="macros" index="1l3spd" />
+        <child id="5617550519002745372" name="layout" index="1l3spN" />
+      </concept>
+      <concept id="8654221991637384182" name="jetbrains.mps.build.structure.BuildFileIncludesSelector" flags="ng" index="3qWCbU">
+        <property id="8654221991637384184" name="pattern" index="3qWCbO" />
+      </concept>
+      <concept id="4701820937132344003" name="jetbrains.mps.build.structure.BuildLayout_Container" flags="ng" index="1y1bJS">
+        <child id="7389400916848037006" name="children" index="39821P" />
+      </concept>
+      <concept id="5248329904287794596" name="jetbrains.mps.build.structure.BuildInputFiles" flags="ng" index="3LXTmp">
+        <child id="5248329904287794598" name="dir" index="3LXTmr" />
+        <child id="5248329904287794679" name="selectors" index="3LXTna" />
+      </concept>
+      <concept id="4903714810883702019" name="jetbrains.mps.build.structure.BuildTextStringPart" flags="ng" index="3Mxwew">
+        <property id="4903714810883755350" name="text" index="3MwjfP" />
+      </concept>
+    </language>
+    <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
+        <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+    </language>
+    <language id="0cf935df-4699-4e9c-a132-fa109541cba3" name="jetbrains.mps.build.mps">
+      <concept id="1500819558095907805" name="jetbrains.mps.build.mps.structure.BuildMps_Group" flags="ng" index="2G$12M">
+        <child id="1500819558095907806" name="modules" index="2G$12L" />
+      </concept>
+      <concept id="1265949165890536423" name="jetbrains.mps.build.mps.structure.BuildMpsLayout_ModuleJars" flags="ng" index="L2wRC">
+        <reference id="1265949165890536425" name="module" index="L2wRA" />
+      </concept>
+      <concept id="868032131020265945" name="jetbrains.mps.build.mps.structure.BuildMPSPlugin" flags="ng" index="3b7kt6" />
+      <concept id="5253498789149381388" name="jetbrains.mps.build.mps.structure.BuildMps_Module" flags="ng" index="3bQrTs">
+        <child id="5253498789149547825" name="sources" index="3bR31x" />
+        <child id="5253498789149547704" name="dependencies" index="3bR37C" />
+      </concept>
+      <concept id="5253498789149585690" name="jetbrains.mps.build.mps.structure.BuildMps_ModuleDependencyOnModule" flags="ng" index="3bR9La">
+        <reference id="5253498789149547705" name="module" index="3bR37D" />
+      </concept>
+      <concept id="4278635856200817744" name="jetbrains.mps.build.mps.structure.BuildMps_ModuleModelRoot" flags="ng" index="1BupzO">
+        <property id="8137134783396907368" name="convert2binary" index="1Hdu6h" />
+        <property id="8137134783396676838" name="extracted" index="1HemKv" />
+        <property id="2889113830911481881" name="deployFolderName" index="3ZfqAx" />
+        <child id="8137134783396676835" name="location" index="1HemKq" />
+      </concept>
+      <concept id="3189788309731840247" name="jetbrains.mps.build.mps.structure.BuildMps_Solution" flags="ng" index="1E1JtA">
+        <property id="269707337715731330" name="sourcesKind" index="aoJFB" />
+      </concept>
+      <concept id="322010710375871467" name="jetbrains.mps.build.mps.structure.BuildMps_AbstractModule" flags="ng" index="3LEN3z">
+        <property id="8369506495128725901" name="compact" index="BnDLt" />
+        <property id="322010710375892619" name="uuid" index="3LESm3" />
+        <child id="322010710375956261" name="path" index="3LF7KH" />
+      </concept>
+      <concept id="7259033139236285166" name="jetbrains.mps.build.mps.structure.BuildMps_ExtractedModuleDependency" flags="nn" index="1SiIV0">
+        <child id="7259033139236285167" name="dependency" index="1SiIV1" />
+      </concept>
+    </language>
+  </registry>
+  <node concept="1l3spW" id="2JVMSZMFXJP">
+    <property role="2DA0ip" value="../../../../../build/scripts" />
+    <property role="TrG5h" value="org.mpsqa.lint.tests" />
+    <property role="turDy" value="build-lint-tests.xml" />
+    <node concept="2sgV4H" id="2JVMSZMFY8e" role="1l3spa">
+      <ref role="1l3spb" to="ffeo:3IKDaVZmzS6" resolve="mps" />
+      <node concept="398BVA" id="2JVMSZMFY8f" role="2JcizS">
+        <ref role="398BVh" node="1GhTetdB0o4" resolve="mps.home" />
+      </node>
+    </node>
+    <node concept="2sgV4H" id="3C011mxaO2f" role="1l3spa">
+      <ref role="1l3spb" to="390y:3dqUbgQmcyp" resolve="org.mpsqa.lint" />
+    </node>
+    <node concept="398rNT" id="1GhTetdB0nZ" role="1l3spd">
+      <property role="TrG5h" value="mpsqa.home" />
+      <node concept="55IIr" id="1GhTetdB0o0" role="398pKh">
+        <node concept="2Ry0Ak" id="1GhTetdB0o1" role="iGT6I">
+          <property role="2Ry0Am" value=".." />
+          <node concept="2Ry0Ak" id="1GhTetdB0o2" role="2Ry0An">
+            <property role="2Ry0Am" value=".." />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="398rNT" id="1GhTetdB0o4" role="1l3spd">
+      <property role="TrG5h" value="mps.home" />
+    </node>
+    <node concept="398rNT" id="1GhTetdB0oc" role="1l3spd">
+      <property role="TrG5h" value="mpsqa.lint.home" />
+      <node concept="398BVA" id="1GhTetdB0od" role="398pKh">
+        <ref role="398BVh" node="1GhTetdB0nZ" resolve="mpsqa.home" />
+        <node concept="2Ry0Ak" id="1GhTetdB0oe" role="iGT6I">
+          <property role="2Ry0Am" value="code" />
+          <node concept="2Ry0Ak" id="1GhTetdB0of" role="2Ry0An">
+            <property role="2Ry0Am" value="languages" />
+            <node concept="2Ry0Ak" id="4jd8IzHAZg8" role="2Ry0An">
+              <property role="2Ry0Am" value="org.mpsqa.lint" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="398rNT" id="6dJ4vxiMMPU" role="1l3spd">
+      <property role="TrG5h" value="mps.macro.mpsqa.home" />
+      <node concept="398BVA" id="6dJ4vxiMMQJ" role="398pKh">
+        <ref role="398BVh" node="1GhTetdB0nZ" resolve="mpsqa.home" />
+      </node>
+    </node>
+    <node concept="10PD9b" id="2JVMSZMFXJS" role="10PD9s" />
+    <node concept="3b7kt6" id="2JVMSZMFXJT" role="10PD9s" />
+    <node concept="1gjT0q" id="2JVMSZMFXK5" role="10PD9s" />
+    <node concept="1l3spV" id="2JVMSZMFXJR" role="1l3spN">
+      <node concept="L2wRC" id="1GhTetdC1GF" role="39821P">
+        <ref role="L2wRA" node="4jd8IzHAZgn" resolve="org.mpsqa.lint.test" />
+      </node>
+    </node>
+    <node concept="2G$12M" id="2JVMSZMFYb4" role="3989C9">
+      <property role="TrG5h" value="org.mpsqa.lint.tests" />
+      <node concept="1E1JtA" id="4jd8IzHAZgn" role="2G$12L">
+        <property role="BnDLt" value="true" />
+        <property role="TrG5h" value="org.mpsqa.lint.test" />
+        <property role="3LESm3" value="8dea0738-32a6-4d3d-bd7c-7b5fd43da198" />
+        <property role="aoJFB" value="eYcmk9QOlj/sources_and_tests" />
+        <node concept="398BVA" id="4jd8IzHAZgz" role="3LF7KH">
+          <ref role="398BVh" node="1GhTetdB0oc" resolve="mpsqa.lint.home" />
+          <node concept="2Ry0Ak" id="4jd8IzHAZgD" role="iGT6I">
+            <property role="2Ry0Am" value="solutions" />
+            <node concept="2Ry0Ak" id="4jd8IzHAZgI" role="2Ry0An">
+              <property role="2Ry0Am" value="org.mpsqa.lint.test" />
+              <node concept="2Ry0Ak" id="4jd8IzHAZgN" role="2Ry0An">
+                <property role="2Ry0Am" value="org.mpsqa.lint.test.msd" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="4jd8IzHAZgP" role="3bR37C">
+          <node concept="3bR9La" id="4jd8IzHAZgQ" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:1H905DlDUSw" resolve="MPS.OpenAPI" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="4jd8IzHAZgR" role="3bR37C">
+          <node concept="3bR9La" id="4jd8IzHAZgS" role="1SiIV1">
+            <ref role="3bR37D" to="390y:51obkXDz7OB" resolve="org.mpsqa.lint.mps_lang.linters_library" />
+          </node>
+        </node>
+        <node concept="1SiIV0" id="4jd8IzHAZgT" role="3bR37C">
+          <node concept="3bR9La" id="4jd8IzHAZgU" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:7Kfy9QB6KXW" resolve="jetbrains.mps.lang.core" />
+          </node>
+        </node>
+        <node concept="1BupzO" id="4jd8IzHAZhd" role="3bR31x">
+          <property role="3ZfqAx" value="models" />
+          <property role="1Hdu6h" value="true" />
+          <property role="1HemKv" value="true" />
+          <node concept="3LXTmp" id="4jd8IzHAZhe" role="1HemKq">
+            <node concept="398BVA" id="4jd8IzHAZgV" role="3LXTmr">
+              <ref role="398BVh" node="1GhTetdB0oc" resolve="mpsqa.lint.home" />
+              <node concept="2Ry0Ak" id="4jd8IzHAZgW" role="iGT6I">
+                <property role="2Ry0Am" value="solutions" />
+                <node concept="2Ry0Ak" id="4jd8IzHAZgX" role="2Ry0An">
+                  <property role="2Ry0Am" value="org.mpsqa.lint.test" />
+                  <node concept="2Ry0Ak" id="4jd8IzHAZgY" role="2Ry0An">
+                    <property role="2Ry0Am" value="models" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3qWCbU" id="4jd8IzHAZhf" role="3LXTna">
+              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="22LTRH" id="2JVMSZMFYqK" role="1hWBAP">
+      <property role="TrG5h" value="lint tests" />
+      <node concept="22LTRF" id="4jd8IzHAZhU" role="22LTRK">
+        <ref role="22LTRG" node="2JVMSZMFYb4" resolve="org.mpsqa.lint.tests" />
+      </node>
+      <node concept="24cAiW" id="1GhTetdClxk" role="24cAkG">
+        <node concept="NbPM2" id="4jd8IzHDwG3" role="24c_eh">
+          <node concept="3Mxwew" id="4jd8IzHDwG2" role="3MwsjC">
+            <property role="3MwjfP" value="true" />
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+</model>
+

--- a/code/languages/org.mpsqa.lint/solutions/org.mpsqa.lint.build/org.mpsqa.lint.build.msd
+++ b/code/languages/org.mpsqa.lint/solutions/org.mpsqa.lint.build/org.mpsqa.lint.build.msd
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<solution name="org.mpsqa.lint.build" uuid="a89565e6-84af-4e8f-ad86-d4a45e3387fe" moduleVersion="0" compileInMPS="true">
+  <models>
+    <modelRoot contentPath="${module}" type="default">
+      <sourceRoot location="models" />
+    </modelRoot>
+  </models>
+  <facets>
+    <facet type="java">
+      <classes generated="true" path="${module}/classes_gen" />
+    </facet>
+  </facets>
+  <sourcePath />
+  <dependencies>
+    <dependency reexport="false">11d4368a-a7e8-4dd9-bfc6-c2de268d1994(org.mpsqa.build)</dependency>
+    <dependency reexport="false">422c2909-59d6-41a9-b318-40e6256b250f(jetbrains.mps.ide.build)</dependency>
+  </dependencies>
+  <languageVersions>
+    <language slang="l:798100da-4f0a-421a-b991-71f8c50ce5d2:jetbrains.mps.build" version="0" />
+    <language slang="l:0cf935df-4699-4e9c-a132-fa109541cba3:jetbrains.mps.build.mps" version="7" />
+    <language slang="l:3600cb0a-44dd-4a5b-9968-22924406419e:jetbrains.mps.build.mps.tests" version="1" />
+    <language slang="l:ceab5195-25ea-4f22-9b92-103b95ca8c0c:jetbrains.mps.lang.core" version="2" />
+  </languageVersions>
+  <dependencyVersions>
+    <module reference="422c2909-59d6-41a9-b318-40e6256b250f(jetbrains.mps.ide.build)" version="0" />
+    <module reference="11d4368a-a7e8-4dd9-bfc6-c2de268d1994(org.mpsqa.build)" version="0" />
+    <module reference="a89565e6-84af-4e8f-ad86-d4a45e3387fe(org.mpsqa.lint.build)" version="0" />
+  </dependencyVersions>
+</solution>
+

--- a/code/languages/org.mpsqa.lint/solutions/org.mpsqa.lint.mps_lang.linters_library/models/org.mpsqa.lint.mps_lang.linters_library.expressions.mps
+++ b/code/languages/org.mpsqa.lint/solutions/org.mpsqa.lint.mps_lang.linters_library/models/org.mpsqa.lint.mps_lang.linters_library.expressions.mps
@@ -7,6 +7,7 @@
     <use id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel" version="19" />
     <use id="83888646-71ce-4f1c-9c53-c54016f6ad4f" name="jetbrains.mps.baseLanguage.collections" version="1" />
     <use id="1a8554c4-eb84-43ba-8c34-6f0d90c6e75a" name="jetbrains.mps.lang.smodel.query" version="3" />
+    <use id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage" version="12" />
   </languages>
   <imports>
     <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" />
@@ -15,14 +16,13 @@
     <import index="zn9m" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.openapi.util(MPS.IDEA/)" />
     <import index="tpcu" ref="r:00000000-0000-4000-0000-011c89590282(jetbrains.mps.lang.core.behavior)" />
     <import index="tpee" ref="r:00000000-0000-4000-0000-011c895902ca(jetbrains.mps.baseLanguage.structure)" implicit="true" />
+    <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" implicit="true" />
   </imports>
   <registry>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
       <concept id="4836112446988635817" name="jetbrains.mps.baseLanguage.structure.UndefinedType" flags="in" index="2jxLKc" />
       <concept id="1202948039474" name="jetbrains.mps.baseLanguage.structure.InstanceMethodCallOperation" flags="nn" index="liA8E" />
-      <concept id="1154032098014" name="jetbrains.mps.baseLanguage.structure.AbstractLoopStatement" flags="nn" index="2LF5Ji">
-        <child id="1154032183016" name="body" index="2LFqv$" />
-      </concept>
+      <concept id="1465982738277781862" name="jetbrains.mps.baseLanguage.structure.PlaceholderMember" flags="nn" index="2tJIrI" />
       <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
         <child id="1197027771414" name="operand" index="2Oq$k0" />
         <child id="1197027833540" name="operation" index="2OqNvi" />
@@ -36,23 +36,45 @@
       <concept id="1070475926800" name="jetbrains.mps.baseLanguage.structure.StringLiteral" flags="nn" index="Xl_RD">
         <property id="1070475926801" name="value" index="Xl_RC" />
       </concept>
+      <concept id="1081236700938" name="jetbrains.mps.baseLanguage.structure.StaticMethodDeclaration" flags="ig" index="2YIFZL" />
+      <concept id="1081236700937" name="jetbrains.mps.baseLanguage.structure.StaticMethodCall" flags="nn" index="2YIFZM">
+        <reference id="1144433194310" name="classConcept" index="1Pybhc" />
+      </concept>
+      <concept id="1070534058343" name="jetbrains.mps.baseLanguage.structure.NullLiteral" flags="nn" index="10Nm6u" />
+      <concept id="1070534644030" name="jetbrains.mps.baseLanguage.structure.BooleanType" flags="in" index="10P_77" />
+      <concept id="1068390468198" name="jetbrains.mps.baseLanguage.structure.ClassConcept" flags="ig" index="312cEu" />
       <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
         <child id="1068431790190" name="initializer" index="33vP2m" />
+      </concept>
+      <concept id="1513279640923991009" name="jetbrains.mps.baseLanguage.structure.IGenericClassCreator" flags="ng" index="366HgL">
+        <property id="1513279640906337053" name="inferTypeParams" index="373rjd" />
       </concept>
       <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
         <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
       </concept>
+      <concept id="1068498886292" name="jetbrains.mps.baseLanguage.structure.ParameterDeclaration" flags="ir" index="37vLTG" />
       <concept id="1225271177708" name="jetbrains.mps.baseLanguage.structure.StringType" flags="in" index="17QB3L" />
       <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
         <child id="5680397130376446158" name="type" index="1tU5fm" />
       </concept>
+      <concept id="1068580123132" name="jetbrains.mps.baseLanguage.structure.BaseMethodDeclaration" flags="ng" index="3clF44">
+        <child id="1068580123133" name="returnType" index="3clF45" />
+        <child id="1068580123134" name="parameter" index="3clF46" />
+        <child id="1068580123135" name="body" index="3clF47" />
+      </concept>
+      <concept id="1068580123152" name="jetbrains.mps.baseLanguage.structure.EqualsExpression" flags="nn" index="3clFbC" />
       <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
         <child id="1068580123156" name="expression" index="3clFbG" />
+      </concept>
+      <concept id="1068580123157" name="jetbrains.mps.baseLanguage.structure.Statement" flags="nn" index="3clFbH" />
+      <concept id="1068580123159" name="jetbrains.mps.baseLanguage.structure.IfStatement" flags="nn" index="3clFbJ">
+        <child id="1068580123160" name="condition" index="3clFbw" />
+        <child id="1068580123161" name="ifTrue" index="3clFbx" />
       </concept>
       <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
         <child id="1068581517665" name="statement" index="3cqZAp" />
       </concept>
-      <concept id="1068581242875" name="jetbrains.mps.baseLanguage.structure.PlusExpression" flags="nn" index="3cpWs3" />
+      <concept id="1068580123137" name="jetbrains.mps.baseLanguage.structure.BooleanConstant" flags="nn" index="3clFbT" />
       <concept id="1068581242878" name="jetbrains.mps.baseLanguage.structure.ReturnStatement" flags="nn" index="3cpWs6">
         <child id="1068581517676" name="expression" index="3cqZAk" />
       </concept>
@@ -64,7 +86,12 @@
         <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
         <child id="1068499141038" name="actualArgument" index="37wK5m" />
       </concept>
-      <concept id="1212685548494" name="jetbrains.mps.baseLanguage.structure.ClassCreator" flags="nn" index="1pGfFk" />
+      <concept id="1212685548494" name="jetbrains.mps.baseLanguage.structure.ClassCreator" flags="nn" index="1pGfFk">
+        <child id="1212687122400" name="typeParameter" index="1pMfVU" />
+      </concept>
+      <concept id="1107461130800" name="jetbrains.mps.baseLanguage.structure.Classifier" flags="ng" index="3pOWGL">
+        <child id="5375687026011219971" name="member" index="jymVt" unordered="true" />
+      </concept>
       <concept id="1107535904670" name="jetbrains.mps.baseLanguage.structure.ClassifierType" flags="in" index="3uibUv">
         <reference id="1107535924139" name="classifier" index="3uigEE" />
         <child id="1109201940907" name="parameter" index="11_B2D" />
@@ -73,6 +100,17 @@
         <child id="1081773367579" name="rightExpression" index="3uHU7w" />
         <child id="1081773367580" name="leftExpression" index="3uHU7B" />
       </concept>
+      <concept id="1073239437375" name="jetbrains.mps.baseLanguage.structure.NotEqualsExpression" flags="nn" index="3y3z36" />
+      <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ng" index="1B3ioH">
+        <child id="1178549979242" name="visibility" index="1B3o_S" />
+      </concept>
+      <concept id="5497648299878491908" name="jetbrains.mps.baseLanguage.structure.BaseVariableReference" flags="nn" index="1M0zk4">
+        <reference id="5497648299878491909" name="baseVariableDeclaration" index="1M0zk5" />
+      </concept>
+      <concept id="6329021646629104954" name="jetbrains.mps.baseLanguage.structure.SingleLineComment" flags="nn" index="3SKdUt">
+        <child id="8356039341262087992" name="line" index="1aUNEU" />
+      </concept>
+      <concept id="1146644602865" name="jetbrains.mps.baseLanguage.structure.PublicVisibility" flags="nn" index="3Tm1VV" />
     </language>
     <language id="40ab19e9-751a-4433-b645-0e65160e58a0" name="org.mpsqa.lint.generic">
       <concept id="2555875871752198907" name="org.mpsqa.lint.generic.structure.ConceptFunctionParameter_MPSProject" flags="ng" index="1MG55F" />
@@ -82,6 +120,12 @@
       </concept>
       <concept id="2555875871751904530" name="org.mpsqa.lint.generic.structure.CheckingFunction" flags="ig" index="1MIXq2" />
     </language>
+    <language id="fd392034-7849-419d-9071-12563d152375" name="jetbrains.mps.baseLanguage.closures">
+      <concept id="1199569711397" name="jetbrains.mps.baseLanguage.closures.structure.ClosureLiteral" flags="nn" index="1bVj0M">
+        <child id="1199569906740" name="parameter" index="1bW2Oz" />
+        <child id="1199569916463" name="body" index="1bW5cS" />
+      </concept>
+    </language>
     <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
       <concept id="1177026924588" name="jetbrains.mps.lang.smodel.structure.RefConcept_Reference" flags="nn" index="chp4Y">
         <reference id="1177026940964" name="conceptDeclaration" index="cht4Q" />
@@ -90,9 +134,6 @@
         <child id="1144104376918" name="parameter" index="1xVPHs" />
       </concept>
       <concept id="1179409122411" name="jetbrains.mps.lang.smodel.structure.Node_ConceptMethodCall" flags="nn" index="2qgKlT" />
-      <concept id="4693937538533521280" name="jetbrains.mps.lang.smodel.structure.OfConceptOperation" flags="ng" index="v3k3i">
-        <child id="4693937538533538124" name="requestedConcept" index="v3oSu" />
-      </concept>
       <concept id="1143234257716" name="jetbrains.mps.lang.smodel.structure.Node_GetModelOperation" flags="nn" index="I4A8Y" />
       <concept id="1883223317721008708" name="jetbrains.mps.lang.smodel.structure.IfInstanceOfStatement" flags="nn" index="Jncv_">
         <reference id="1883223317721008712" name="nodeConcept" index="JncvD" />
@@ -101,15 +142,21 @@
         <child id="1883223317721008710" name="nodeExpression" index="JncvB" />
       </concept>
       <concept id="1883223317721008713" name="jetbrains.mps.lang.smodel.structure.IfInstanceOfVariable" flags="ng" index="JncvC" />
+      <concept id="1883223317721107059" name="jetbrains.mps.lang.smodel.structure.IfInstanceOfVarReference" flags="nn" index="Jnkvi" />
       <concept id="1145404486709" name="jetbrains.mps.lang.smodel.structure.SemanticDowncastExpression" flags="nn" index="2JrnkZ">
         <child id="1145404616321" name="leftExpression" index="2JrQYb" />
       </concept>
       <concept id="1171310072040" name="jetbrains.mps.lang.smodel.structure.Node_GetContainingRootOperation" flags="nn" index="2Rxl7S" />
       <concept id="1171407110247" name="jetbrains.mps.lang.smodel.structure.Node_GetAncestorOperation" flags="nn" index="2Xjw5R" />
+      <concept id="1139621453865" name="jetbrains.mps.lang.smodel.structure.Node_IsInstanceOfOperation" flags="nn" index="1mIQ4w">
+        <child id="1177027386292" name="conceptArgument" index="cj9EA" />
+      </concept>
       <concept id="1144101972840" name="jetbrains.mps.lang.smodel.structure.OperationParm_Concept" flags="ng" index="1xMEDy">
         <child id="1207343664468" name="conceptArgument" index="ri$Ld" />
       </concept>
-      <concept id="1138055754698" name="jetbrains.mps.lang.smodel.structure.SNodeType" flags="in" index="3Tqbb2" />
+      <concept id="1138055754698" name="jetbrains.mps.lang.smodel.structure.SNodeType" flags="in" index="3Tqbb2">
+        <reference id="1138405853777" name="concept" index="ehGHo" />
+      </concept>
       <concept id="1138056022639" name="jetbrains.mps.lang.smodel.structure.SPropertyAccess" flags="nn" index="3TrcHB">
         <reference id="1138056395725" name="property" index="3TsBF5" />
       </concept>
@@ -134,32 +181,32 @@
       </concept>
     </language>
     <language id="1a8554c4-eb84-43ba-8c34-6f0d90c6e75a" name="jetbrains.mps.lang.smodel.query">
-      <concept id="2822369470875160718" name="jetbrains.mps.lang.smodel.query.structure.NodesExpression" flags="ng" index="2Jgcaq" />
+      <concept id="7738379549910147341" name="jetbrains.mps.lang.smodel.query.structure.InstancesExpression" flags="ng" index="qVDSY">
+        <child id="7738379549910147342" name="conceptArg" index="qVDSX" />
+      </concept>
       <concept id="4234138103881610891" name="jetbrains.mps.lang.smodel.query.structure.WithStatement" flags="ng" index="L3pyB">
         <child id="4234138103881610935" name="scope" index="L3pyr" />
         <child id="4234138103881610892" name="stmts" index="L3pyw" />
       </concept>
     </language>
     <language id="83888646-71ce-4f1c-9c53-c54016f6ad4f" name="jetbrains.mps.baseLanguage.collections">
+      <concept id="1204796164442" name="jetbrains.mps.baseLanguage.collections.structure.InternalSequenceOperation" flags="nn" index="23sCx2">
+        <child id="1204796294226" name="closure" index="23t8la" />
+      </concept>
       <concept id="540871147943773365" name="jetbrains.mps.baseLanguage.collections.structure.SingleArgumentSequenceOperation" flags="nn" index="25WWJ4">
         <child id="540871147943773366" name="argument" index="25WWJ7" />
       </concept>
       <concept id="1151688443754" name="jetbrains.mps.baseLanguage.collections.structure.ListType" flags="in" index="_YKpA">
         <child id="1151688676805" name="elementType" index="_ZDj9" />
       </concept>
-      <concept id="1153943597977" name="jetbrains.mps.baseLanguage.collections.structure.ForEachStatement" flags="nn" index="2Gpval">
-        <child id="1153944400369" name="variable" index="2Gsz3X" />
-        <child id="1153944424730" name="inputSequence" index="2GsD0m" />
-      </concept>
-      <concept id="1153944193378" name="jetbrains.mps.baseLanguage.collections.structure.ForEachVariable" flags="nr" index="2GrKxI" />
-      <concept id="1153944233411" name="jetbrains.mps.baseLanguage.collections.structure.ForEachVariableReference" flags="nn" index="2GrUjf">
-        <reference id="1153944258490" name="variable" index="2Gs0qQ" />
-      </concept>
       <concept id="1237721394592" name="jetbrains.mps.baseLanguage.collections.structure.AbstractContainerCreator" flags="nn" index="HWqM0">
         <child id="1237721435807" name="elementType" index="HW$YZ" />
       </concept>
+      <concept id="1203518072036" name="jetbrains.mps.baseLanguage.collections.structure.SmartClosureParameterDeclaration" flags="ig" index="Rh6nW" />
       <concept id="1160600644654" name="jetbrains.mps.baseLanguage.collections.structure.ListCreatorWithInit" flags="nn" index="Tc6Ow" />
-      <concept id="1160612413312" name="jetbrains.mps.baseLanguage.collections.structure.AddElementOperation" flags="nn" index="TSZUe" />
+      <concept id="1160666733551" name="jetbrains.mps.baseLanguage.collections.structure.AddAllElementsOperation" flags="nn" index="X8dFx" />
+      <concept id="1202120902084" name="jetbrains.mps.baseLanguage.collections.structure.WhereOperation" flags="nn" index="3zZkjj" />
+      <concept id="1202128969694" name="jetbrains.mps.baseLanguage.collections.structure.SelectOperation" flags="nn" index="3$u5V9" />
     </language>
   </registry>
   <node concept="1MIHA_" id="3pz5R1DPwMT">
@@ -184,6 +231,21 @@
         <node concept="3oM_SD" id="3pz5R1DPFXL" role="1PaTwD">
           <property role="3oM_SC" value="SNodeType" />
         </node>
+        <node concept="3oM_SD" id="4jd8IzHxs0D" role="1PaTwD">
+          <property role="3oM_SC" value="with" />
+        </node>
+        <node concept="3oM_SD" id="4jd8IzHxs0T" role="1PaTwD">
+          <property role="3oM_SC" value="a" />
+        </node>
+        <node concept="3oM_SD" id="4jd8IzHxs1a" role="1PaTwD">
+          <property role="3oM_SC" value="concept" />
+        </node>
+        <node concept="3oM_SD" id="4jd8IzHxs1s" role="1PaTwD">
+          <property role="3oM_SC" value="(e.g." />
+        </node>
+        <node concept="3oM_SD" id="4jd8IzHxs1J" role="1PaTwD">
+          <property role="3oM_SC" value="node&lt;PlusExpression&gt;)" />
+        </node>
         <node concept="3oM_SD" id="3pz5R1DPwNc" role="1PaTwD">
           <property role="3oM_SC" value="-" />
         </node>
@@ -205,12 +267,7 @@
         <node concept="3oM_SD" id="3pz5R1DPG2x" role="1PaTwD">
           <property role="3oM_SC" value="be" />
         </node>
-        <node concept="3oM_SD" id="3pz5R1DPG2Q" role="1PaTwD">
-          <property role="3oM_SC" value="" />
-        </node>
-      </node>
-      <node concept="1PaTwC" id="3pz5R1DPG3d" role="1PaQFQ">
-        <node concept="3oM_SD" id="3pz5R1DPG3c" role="1PaTwD">
+        <node concept="3oM_SD" id="4jd8IzHxs23" role="1PaTwD">
           <property role="3oM_SC" value="implemented" />
         </node>
         <node concept="3oM_SD" id="3pz5R1DPG5l" role="1PaTwD">
@@ -235,7 +292,47 @@
           <property role="3oM_SC" value="as" />
         </node>
         <node concept="3oM_SD" id="3pz5R1DPGbw" role="1PaTwD">
-          <property role="3oM_SC" value="PlusExpression&quot;" />
+          <property role="3oM_SC" value="PlusExpression&quot;." />
+        </node>
+      </node>
+      <node concept="1PaTwC" id="4jd8IzHxrXb" role="1PaQFQ">
+        <node concept="3oM_SD" id="4jd8IzHxrXa" role="1PaTwD">
+          <property role="3oM_SC" value="" />
+        </node>
+      </node>
+      <node concept="1PaTwC" id="4jd8IzHxrYY" role="1PaQFQ">
+        <node concept="3oM_SD" id="4jd8IzHxrYX" role="1PaTwD">
+          <property role="3oM_SC" value="Casts" />
+        </node>
+        <node concept="3oM_SD" id="4jd8IzHxs0y" role="1PaTwD">
+          <property role="3oM_SC" value="to" />
+        </node>
+        <node concept="3oM_SD" id="4jd8IzHxs0_" role="1PaTwD">
+          <property role="3oM_SC" value="node&lt;&gt;" />
+        </node>
+        <node concept="3oM_SD" id="4jd8IzHxs4r" role="1PaTwD">
+          <property role="3oM_SC" value="are" />
+        </node>
+        <node concept="3oM_SD" id="4jd8IzHxs4w" role="1PaTwD">
+          <property role="3oM_SC" value="allowed," />
+        </node>
+        <node concept="3oM_SD" id="4jd8IzHxs4A" role="1PaTwD">
+          <property role="3oM_SC" value="as" />
+        </node>
+        <node concept="3oM_SD" id="4jd8IzHxs4Y" role="1PaTwD">
+          <property role="3oM_SC" value="is" />
+        </node>
+        <node concept="3oM_SD" id="4jd8IzHxs56" role="1PaTwD">
+          <property role="3oM_SC" value="casting" />
+        </node>
+        <node concept="3oM_SD" id="4jd8IzHxs5f" role="1PaTwD">
+          <property role="3oM_SC" value="null" />
+        </node>
+        <node concept="3oM_SD" id="4jd8IzHxs5p" role="1PaTwD">
+          <property role="3oM_SC" value="to" />
+        </node>
+        <node concept="3oM_SD" id="4jd8IzHxs5$" role="1PaTwD">
+          <property role="3oM_SC" value="node&lt;PlusExpression&gt;." />
         </node>
       </node>
       <node concept="1PaTwC" id="3pz5R1DPG8E" role="1PaQFQ">
@@ -330,12 +427,12 @@
         <node concept="3oM_SD" id="3pz5R1DPwNZ" role="1PaTwD">
           <property role="3oM_SC" value="(node&lt;IGenericComponent&gt;)" />
         </node>
-        <node concept="3oM_SD" id="3pz5R1DPwO0" role="1PaTwD">
+        <node concept="3oM_SD" id="4jd8IzHxshw" role="1PaTwD">
           <property role="3oM_SC" value="this.entity;" />
         </node>
       </node>
-      <node concept="1PaTwC" id="3pz5R1DPGkr" role="1PaQFQ">
-        <node concept="3oM_SD" id="3pz5R1DPGkq" role="1PaTwD">
+      <node concept="1PaTwC" id="4jd8IzHxs9O" role="1PaQFQ">
+        <node concept="3oM_SD" id="4jd8IzHxs9N" role="1PaTwD">
           <property role="3oM_SC" value="" />
         </node>
       </node>
@@ -414,6 +511,97 @@
           <property role="3oM_SC" value="IGenericComponent;" />
         </node>
       </node>
+      <node concept="1PaTwC" id="4jd8IzHxsjl" role="1PaQFQ">
+        <node concept="3oM_SD" id="4jd8IzHxsjk" role="1PaTwD">
+          <property role="3oM_SC" value="" />
+        </node>
+      </node>
+      <node concept="1PaTwC" id="4jd8IzHxsln" role="1PaQFQ">
+        <node concept="3oM_SD" id="4jd8IzHxslm" role="1PaTwD">
+          <property role="3oM_SC" value="" />
+        </node>
+        <node concept="3oM_SD" id="4jd8IzHxsnc" role="1PaTwD">
+          <property role="3oM_SC" value="" />
+        </node>
+        <node concept="3oM_SD" id="4jd8IzHxsnf" role="1PaTwD">
+          <property role="3oM_SC" value="" />
+        </node>
+        <node concept="3oM_SD" id="4jd8IzHxsnj" role="1PaTwD">
+          <property role="3oM_SC" value="" />
+        </node>
+        <node concept="3oM_SD" id="4jd8IzHxsn_" role="1PaTwD">
+          <property role="3oM_SC" value="//" />
+        </node>
+        <node concept="3oM_SD" id="4jd8IzHxsnF" role="1PaTwD">
+          <property role="3oM_SC" value="okay" />
+        </node>
+      </node>
+      <node concept="1PaTwC" id="4jd8IzHxsnN" role="1PaQFQ">
+        <node concept="3oM_SD" id="4jd8IzHxsnM" role="1PaTwD">
+          <property role="3oM_SC" value="" />
+        </node>
+        <node concept="3oM_SD" id="4jd8IzHxspT" role="1PaTwD">
+          <property role="3oM_SC" value="" />
+        </node>
+        <node concept="3oM_SD" id="4jd8IzHxspW" role="1PaTwD">
+          <property role="3oM_SC" value="" />
+        </node>
+        <node concept="3oM_SD" id="4jd8IzHxsq0" role="1PaTwD">
+          <property role="3oM_SC" value="" />
+        </node>
+        <node concept="3oM_SD" id="4jd8IzHxsq5" role="1PaTwD">
+          <property role="3oM_SC" value="return" />
+        </node>
+        <node concept="3oM_SD" id="4jd8IzHxsqq" role="1PaTwD">
+          <property role="3oM_SC" value="(node&lt;IGenericComponent&gt;)" />
+        </node>
+        <node concept="3oM_SD" id="4jd8IzHxsqx" role="1PaTwD">
+          <property role="3oM_SC" value="null;" />
+        </node>
+      </node>
+      <node concept="1PaTwC" id="4jd8IzHxsts" role="1PaQFQ">
+        <node concept="3oM_SD" id="4jd8IzHxstr" role="1PaTwD">
+          <property role="3oM_SC" value="" />
+        </node>
+        <node concept="3oM_SD" id="4jd8IzHxsvO" role="1PaTwD">
+          <property role="3oM_SC" value="" />
+        </node>
+        <node concept="3oM_SD" id="4jd8IzHxsvR" role="1PaTwD">
+          <property role="3oM_SC" value="" />
+        </node>
+        <node concept="3oM_SD" id="4jd8IzHxsvV" role="1PaTwD">
+          <property role="3oM_SC" value="" />
+        </node>
+        <node concept="3oM_SD" id="4jd8IzHxsw0" role="1PaTwD">
+          <property role="3oM_SC" value="SNode" />
+        </node>
+        <node concept="3oM_SD" id="4jd8IzHxsw6" role="1PaTwD">
+          <property role="3oM_SC" value="someNode;" />
+        </node>
+      </node>
+      <node concept="1PaTwC" id="4jd8IzHxsqE" role="1PaQFQ">
+        <node concept="3oM_SD" id="4jd8IzHxsqD" role="1PaTwD">
+          <property role="3oM_SC" value="" />
+        </node>
+        <node concept="3oM_SD" id="4jd8IzHxssU" role="1PaTwD">
+          <property role="3oM_SC" value="" />
+        </node>
+        <node concept="3oM_SD" id="4jd8IzHxssX" role="1PaTwD">
+          <property role="3oM_SC" value="" />
+        </node>
+        <node concept="3oM_SD" id="4jd8IzHxst1" role="1PaTwD">
+          <property role="3oM_SC" value="" />
+        </node>
+        <node concept="3oM_SD" id="4jd8IzHxst6" role="1PaTwD">
+          <property role="3oM_SC" value="return" />
+        </node>
+        <node concept="3oM_SD" id="4jd8IzHxstc" role="1PaTwD">
+          <property role="3oM_SC" value="(node&lt;&gt;)" />
+        </node>
+        <node concept="3oM_SD" id="4jd8IzHxstj" role="1PaTwD">
+          <property role="3oM_SC" value="someNode;" />
+        </node>
+      </node>
       <node concept="1PaTwC" id="3pz5R1DPwN6" role="1PaQFQ">
         <node concept="3oM_SD" id="3pz5R1DPwO1" role="1PaTwD">
           <property role="3oM_SC" value="" />
@@ -451,129 +639,68 @@
         </node>
         <node concept="L3pyB" id="3pz5R1DPwO7" role="3cqZAp">
           <node concept="3clFbS" id="3pz5R1DPwOa" role="L3pyw">
-            <node concept="2Gpval" id="3pz5R1DPwOf" role="3cqZAp">
-              <node concept="2GrKxI" id="3pz5R1DPwOi" role="2Gsz3X">
-                <property role="TrG5h" value="cast" />
-              </node>
-              <node concept="2OqwBi" id="3pz5R1DPwOj" role="2GsD0m">
-                <node concept="2Jgcaq" id="3pz5R1DPwOm" role="2Oq$k0" />
-                <node concept="v3k3i" id="3pz5R1DPwOn" role="2OqNvi">
-                  <node concept="chp4Y" id="3pz5R1DPwOw" role="v3oSu">
-                    <ref role="cht4Q" to="tpee:f_0QFTa" resolve="CastExpression" />
-                  </node>
+            <node concept="3clFbF" id="4jd8IzH$czS" role="3cqZAp">
+              <node concept="2OqwBi" id="4jd8IzH$d$i" role="3clFbG">
+                <node concept="37vLTw" id="4jd8IzH$czQ" role="2Oq$k0">
+                  <ref role="3cqZAo" node="3pz5R1DPwO9" resolve="res" />
                 </node>
-              </node>
-              <node concept="3clFbS" id="3pz5R1DPwOk" role="2LFqv$">
-                <node concept="Jncv_" id="3pz5R1DQB53" role="3cqZAp">
-                  <ref role="JncvD" to="tp25:gzTqbfa" resolve="SNodeType" />
-                  <node concept="3clFbS" id="3pz5R1DQB5d" role="Jncv$">
-                    <node concept="3cpWs8" id="78RogMCKbme" role="3cqZAp">
-                      <node concept="3cpWsn" id="78RogMCKbmf" role="3cpWs9">
-                        <property role="TrG5h" value="msg" />
-                        <node concept="17QB3L" id="78RogMCKbkq" role="1tU5fm" />
-                        <node concept="3cpWs3" id="78RogMCKbmg" role="33vP2m">
-                          <node concept="3cpWs3" id="78RogMCKbmh" role="3uHU7B">
-                            <node concept="2OqwBi" id="78RogMCKbmi" role="3uHU7w">
-                              <node concept="2OqwBi" id="78RogMCKbmj" role="2Oq$k0">
-                                <node concept="2JrnkZ" id="78RogMCKbmk" role="2Oq$k0">
-                                  <node concept="2OqwBi" id="78RogMCKbml" role="2JrQYb">
-                                    <node concept="2GrUjf" id="78RogMCKbmm" role="2Oq$k0">
-                                      <ref role="2Gs0qQ" node="3pz5R1DPwOi" resolve="cast" />
-                                    </node>
-                                    <node concept="I4A8Y" id="78RogMCKbmn" role="2OqNvi" />
-                                  </node>
+                <node concept="X8dFx" id="4jd8IzH$f9F" role="2OqNvi">
+                  <node concept="2OqwBi" id="4jd8IzH$k3A" role="25WWJ7">
+                    <node concept="2OqwBi" id="4jd8IzH_9wM" role="2Oq$k0">
+                      <node concept="qVDSY" id="4jd8IzH$j1V" role="2Oq$k0">
+                        <node concept="chp4Y" id="4jd8IzH$jqI" role="qVDSX">
+                          <ref role="cht4Q" to="tpee:f_0QFTa" resolve="CastExpression" />
+                        </node>
+                      </node>
+                      <node concept="3zZkjj" id="4jd8IzH_amI" role="2OqNvi">
+                        <node concept="1bVj0M" id="4jd8IzH_amK" role="23t8la">
+                          <node concept="3clFbS" id="4jd8IzH_amL" role="1bW5cS">
+                            <node concept="3clFbF" id="4jd8IzH_a_s" role="3cqZAp">
+                              <node concept="2YIFZM" id="4jd8IzH_dVd" role="3clFbG">
+                                <ref role="37wK5l" node="4jd8IzH_176" resolve="isDubiousCast" />
+                                <ref role="1Pybhc" node="4jd8IzHzPzF" resolve="NodeCasts" />
+                                <node concept="37vLTw" id="4jd8IzH_e7P" role="37wK5m">
+                                  <ref role="3cqZAo" node="4jd8IzH_amM" resolve="it" />
                                 </node>
-                                <node concept="liA8E" id="78RogMCKbmo" role="2OqNvi">
-                                  <ref role="37wK5l" to="mhbf:~SModel.getName()" resolve="getName" />
-                                </node>
-                              </node>
-                              <node concept="liA8E" id="78RogMCKbmp" role="2OqNvi">
-                                <ref role="37wK5l" to="mhbf:~SModelName.getValue()" resolve="getValue" />
-                              </node>
-                            </node>
-                            <node concept="3cpWs3" id="78RogMCKbmq" role="3uHU7B">
-                              <node concept="3cpWs3" id="78RogMCKbmr" role="3uHU7B">
-                                <node concept="2OqwBi" id="78RogMCKbms" role="3uHU7w">
-                                  <node concept="2OqwBi" id="78RogMCKbmt" role="2Oq$k0">
-                                    <node concept="2GrUjf" id="78RogMCKbmu" role="2Oq$k0">
-                                      <ref role="2Gs0qQ" node="3pz5R1DPwOi" resolve="cast" />
-                                    </node>
-                                    <node concept="2Rxl7S" id="78RogMCKbmv" role="2OqNvi" />
-                                  </node>
-                                  <node concept="2qgKlT" id="78RogMCKbmw" role="2OqNvi">
-                                    <ref role="37wK5l" to="tpcu:hEwIMiw" resolve="getPresentation" />
-                                  </node>
-                                </node>
-                                <node concept="3cpWs3" id="78RogMCKbmx" role="3uHU7B">
-                                  <node concept="3cpWs3" id="78RogMCKbmy" role="3uHU7B">
-                                    <node concept="Xl_RD" id="78RogMCKbmz" role="3uHU7B">
-                                      <property role="Xl_RC" value="dubious cast expression in '" />
-                                    </node>
-                                    <node concept="2OqwBi" id="78RogMCKbm$" role="3uHU7w">
-                                      <node concept="2OqwBi" id="78RogMCKbm_" role="2Oq$k0">
-                                        <node concept="2GrUjf" id="78RogMCKbmA" role="2Oq$k0">
-                                          <ref role="2Gs0qQ" node="3pz5R1DPwOi" resolve="cast" />
-                                        </node>
-                                        <node concept="2Xjw5R" id="78RogMCKbmB" role="2OqNvi">
-                                          <node concept="1xMEDy" id="78RogMCKbmC" role="1xVPHs">
-                                            <node concept="chp4Y" id="78RogMCKbmD" role="ri$Ld">
-                                              <ref role="cht4Q" to="tpck:h0TrEE$" resolve="INamedConcept" />
-                                            </node>
-                                          </node>
-                                        </node>
-                                      </node>
-                                      <node concept="3TrcHB" id="78RogMCKbmE" role="2OqNvi">
-                                        <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
-                                      </node>
-                                    </node>
-                                  </node>
-                                  <node concept="Xl_RD" id="78RogMCKbmF" role="3uHU7w">
-                                    <property role="Xl_RC" value="' from rootNode '" />
-                                  </node>
-                                </node>
-                              </node>
-                              <node concept="Xl_RD" id="78RogMCKbmG" role="3uHU7w">
-                                <property role="Xl_RC" value="' from model '" />
                               </node>
                             </node>
                           </node>
-                          <node concept="Xl_RD" id="78RogMCKbmH" role="3uHU7w">
-                            <property role="Xl_RC" value="'. For casting to SNodeType use 'exp : ConceptName' or 'exp as ConceptName'" />
+                          <node concept="Rh6nW" id="4jd8IzH_amM" role="1bW2Oz">
+                            <property role="TrG5h" value="it" />
+                            <node concept="2jxLKc" id="4jd8IzH_amN" role="1tU5fm" />
                           </node>
                         </node>
                       </node>
                     </node>
-                    <node concept="3clFbF" id="3pz5R1DPwPt" role="3cqZAp">
-                      <node concept="2OqwBi" id="3pz5R1DPwPN" role="3clFbG">
-                        <node concept="37vLTw" id="3pz5R1DPwQ8" role="2Oq$k0">
-                          <ref role="3cqZAo" node="3pz5R1DPwO9" resolve="res" />
-                        </node>
-                        <node concept="TSZUe" id="3pz5R1DPwQ9" role="2OqNvi">
-                          <node concept="2ShNRf" id="78RogMCKbES" role="25WWJ7">
-                            <node concept="1pGfFk" id="78RogMCKc3l" role="2ShVmc">
-                              <ref role="37wK5l" to="zn9m:~Pair.&lt;init&gt;(java.lang.Object,java.lang.Object)" resolve="Pair" />
-                              <node concept="37vLTw" id="78RogMCKc5y" role="37wK5m">
-                                <ref role="3cqZAo" node="78RogMCKbmf" resolve="msg" />
-                              </node>
-                              <node concept="2GrUjf" id="78RogMCKcim" role="37wK5m">
-                                <ref role="2Gs0qQ" node="3pz5R1DPwOi" resolve="cast" />
+                    <node concept="3$u5V9" id="4jd8IzH_ev8" role="2OqNvi">
+                      <node concept="1bVj0M" id="4jd8IzH_eva" role="23t8la">
+                        <node concept="3clFbS" id="4jd8IzH_evb" role="1bW5cS">
+                          <node concept="3clFbF" id="4jd8IzH_evc" role="3cqZAp">
+                            <node concept="2ShNRf" id="4jd8IzH_n4E" role="3clFbG">
+                              <node concept="1pGfFk" id="4jd8IzH_obz" role="2ShVmc">
+                                <property role="373rjd" value="true" />
+                                <ref role="37wK5l" to="zn9m:~Pair.&lt;init&gt;(java.lang.Object,java.lang.Object)" resolve="Pair" />
+                                <node concept="17QB3L" id="4jd8IzH_oBL" role="1pMfVU" />
+                                <node concept="3Tqbb2" id="4jd8IzH_pf8" role="1pMfVU" />
+                                <node concept="2YIFZM" id="4jd8IzH_r22" role="37wK5m">
+                                  <ref role="37wK5l" node="4jd8IzH_mDV" resolve="formatDubiousCastErrorMessage" />
+                                  <ref role="1Pybhc" node="4jd8IzHzPzF" resolve="NodeCasts" />
+                                  <node concept="37vLTw" id="4jd8IzH_rBs" role="37wK5m">
+                                    <ref role="3cqZAo" node="4jd8IzH_evf" resolve="it" />
+                                  </node>
+                                </node>
+                                <node concept="37vLTw" id="4jd8IzH_sfb" role="37wK5m">
+                                  <ref role="3cqZAo" node="4jd8IzH_evf" resolve="it" />
+                                </node>
                               </node>
                             </node>
                           </node>
                         </node>
+                        <node concept="Rh6nW" id="4jd8IzH_evf" role="1bW2Oz">
+                          <property role="TrG5h" value="it" />
+                          <node concept="2jxLKc" id="4jd8IzH_evg" role="1tU5fm" />
+                        </node>
                       </node>
-                    </node>
-                  </node>
-                  <node concept="JncvC" id="3pz5R1DQB5i" role="JncvA">
-                    <property role="TrG5h" value="tpe" />
-                    <node concept="2jxLKc" id="3pz5R1DQB5j" role="1tU5fm" />
-                  </node>
-                  <node concept="2OqwBi" id="3pz5R1DQsfj" role="JncvB">
-                    <node concept="2GrUjf" id="3pz5R1DQpj4" role="2Oq$k0">
-                      <ref role="2Gs0qQ" node="3pz5R1DPwOi" resolve="cast" />
-                    </node>
-                    <node concept="3TrEf2" id="3pz5R1DQxrm" role="2OqNvi">
-                      <ref role="3Tt5mk" to="tpee:f_0QFTb" resolve="type" />
                     </node>
                   </node>
                 </node>
@@ -589,6 +716,296 @@
         </node>
       </node>
     </node>
+  </node>
+  <node concept="312cEu" id="4jd8IzHzPzF">
+    <property role="TrG5h" value="NodeCasts" />
+    <node concept="2YIFZL" id="4jd8IzH_mDV" role="jymVt">
+      <property role="TrG5h" value="formatDubiousCastErrorMessage" />
+      <node concept="3Tm1VV" id="4jd8IzH_mUs" role="1B3o_S" />
+      <node concept="17QB3L" id="4jd8IzH_mDX" role="3clF45" />
+      <node concept="37vLTG" id="4jd8IzH_mDP" role="3clF46">
+        <property role="TrG5h" value="cast" />
+        <node concept="3Tqbb2" id="4jd8IzH_mDQ" role="1tU5fm">
+          <ref role="ehGHo" to="tpee:f_0QFTa" resolve="CastExpression" />
+        </node>
+      </node>
+      <node concept="3clFbS" id="4jd8IzH_mDl" role="3clF47">
+        <node concept="3clFbF" id="4jd8IzH_zNj" role="3cqZAp">
+          <node concept="2YIFZM" id="4jd8IzH_zRX" role="3clFbG">
+            <ref role="37wK5l" to="wyt6:~String.format(java.lang.String,java.lang.Object...)" resolve="format" />
+            <ref role="1Pybhc" to="wyt6:~String" resolve="String" />
+            <node concept="Xl_RD" id="4jd8IzH_DRA" role="37wK5m">
+              <property role="Xl_RC" value="dubious cast expression in '%s' from rootNode '%s' from model '%s'. For casting to SNodeType use 'exp : ConceptName' or 'exp as ConceptName'" />
+            </node>
+            <node concept="2OqwBi" id="4jd8IzH_$dg" role="37wK5m">
+              <node concept="2OqwBi" id="4jd8IzH_$dh" role="2Oq$k0">
+                <node concept="37vLTw" id="4jd8IzH_$di" role="2Oq$k0">
+                  <ref role="3cqZAo" node="4jd8IzH_mDP" resolve="cast" />
+                </node>
+                <node concept="2Xjw5R" id="4jd8IzH_$dj" role="2OqNvi">
+                  <node concept="1xMEDy" id="4jd8IzH_$dk" role="1xVPHs">
+                    <node concept="chp4Y" id="4jd8IzH_$dl" role="ri$Ld">
+                      <ref role="cht4Q" to="tpck:h0TrEE$" resolve="INamedConcept" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3TrcHB" id="4jd8IzH_$dm" role="2OqNvi">
+                <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+              </node>
+            </node>
+            <node concept="2OqwBi" id="4jd8IzH_$d8" role="37wK5m">
+              <node concept="2OqwBi" id="4jd8IzH_$d9" role="2Oq$k0">
+                <node concept="37vLTw" id="4jd8IzH_$da" role="2Oq$k0">
+                  <ref role="3cqZAo" node="4jd8IzH_mDP" resolve="cast" />
+                </node>
+                <node concept="2Rxl7S" id="4jd8IzH_$db" role="2OqNvi" />
+              </node>
+              <node concept="2qgKlT" id="4jd8IzH_$dc" role="2OqNvi">
+                <ref role="37wK5l" to="tpcu:hEwIMiw" resolve="getPresentation" />
+              </node>
+            </node>
+            <node concept="2OqwBi" id="4jd8IzH_$cY" role="37wK5m">
+              <node concept="2OqwBi" id="4jd8IzH_$cZ" role="2Oq$k0">
+                <node concept="2JrnkZ" id="4jd8IzH_$d0" role="2Oq$k0">
+                  <node concept="2OqwBi" id="4jd8IzH_$d1" role="2JrQYb">
+                    <node concept="37vLTw" id="4jd8IzH_$d2" role="2Oq$k0">
+                      <ref role="3cqZAo" node="4jd8IzH_mDP" resolve="cast" />
+                    </node>
+                    <node concept="I4A8Y" id="4jd8IzH_$d3" role="2OqNvi" />
+                  </node>
+                </node>
+                <node concept="liA8E" id="4jd8IzH_$d4" role="2OqNvi">
+                  <ref role="37wK5l" to="mhbf:~SModel.getName()" resolve="getName" />
+                </node>
+              </node>
+              <node concept="liA8E" id="4jd8IzH_$d5" role="2OqNvi">
+                <ref role="37wK5l" to="mhbf:~SModelName.getValue()" resolve="getValue" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="4jd8IzH_0Ww" role="jymVt" />
+    <node concept="2YIFZL" id="4jd8IzH_176" role="jymVt">
+      <property role="TrG5h" value="isDubiousCast" />
+      <node concept="3clFbS" id="4jd8IzH_179" role="3clF47">
+        <node concept="Jncv_" id="4jd8IzH_1d0" role="3cqZAp">
+          <ref role="JncvD" to="tp25:gzTqbfa" resolve="SNodeType" />
+          <node concept="3clFbS" id="4jd8IzH_1d1" role="Jncv$">
+            <node concept="3clFbJ" id="4jd8IzH_1d2" role="3cqZAp">
+              <node concept="3clFbS" id="4jd8IzH_1d3" role="3clFbx">
+                <node concept="3SKdUt" id="4jd8IzH_1d4" role="3cqZAp">
+                  <node concept="1PaTwC" id="4jd8IzH_1d5" role="1aUNEU">
+                    <node concept="3oM_SD" id="4jd8IzH_1d6" role="1PaTwD">
+                      <property role="3oM_SC" value="Allow" />
+                    </node>
+                    <node concept="3oM_SD" id="4jd8IzH_1d7" role="1PaTwD">
+                      <property role="3oM_SC" value="casts" />
+                    </node>
+                    <node concept="3oM_SD" id="4jd8IzH_1d8" role="1PaTwD">
+                      <property role="3oM_SC" value="to" />
+                    </node>
+                    <node concept="3oM_SD" id="4jd8IzH_1d9" role="1PaTwD">
+                      <property role="3oM_SC" value="node&lt;&gt;" />
+                    </node>
+                    <node concept="3oM_SD" id="4jd8IzH_1da" role="1PaTwD">
+                      <property role="3oM_SC" value="without" />
+                    </node>
+                    <node concept="3oM_SD" id="4jd8IzH_1db" role="1PaTwD">
+                      <property role="3oM_SC" value="a" />
+                    </node>
+                    <node concept="3oM_SD" id="4jd8IzH_1dc" role="1PaTwD">
+                      <property role="3oM_SC" value="specific" />
+                    </node>
+                    <node concept="3oM_SD" id="4jd8IzH_1dd" role="1PaTwD">
+                      <property role="3oM_SC" value="concept." />
+                    </node>
+                  </node>
+                </node>
+                <node concept="3cpWs6" id="4jd8IzH_1de" role="3cqZAp">
+                  <node concept="3clFbT" id="4jd8IzH_2H2" role="3cqZAk" />
+                </node>
+              </node>
+              <node concept="3clFbC" id="4jd8IzH_1dg" role="3clFbw">
+                <node concept="10Nm6u" id="4jd8IzH_1dh" role="3uHU7w" />
+                <node concept="2OqwBi" id="4jd8IzH_1di" role="3uHU7B">
+                  <node concept="Jnkvi" id="4jd8IzH_1dj" role="2Oq$k0">
+                    <ref role="1M0zk5" node="4jd8IzH_1eN" resolve="tpe" />
+                  </node>
+                  <node concept="3TrEf2" id="4jd8IzH_1dk" role="2OqNvi">
+                    <ref role="3Tt5mk" to="tp25:g$ehGDh" resolve="concept" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbH" id="4jd8IzH_1dl" role="3cqZAp" />
+            <node concept="3clFbJ" id="4jd8IzH_1dm" role="3cqZAp">
+              <node concept="3clFbS" id="4jd8IzH_1dn" role="3clFbx">
+                <node concept="3SKdUt" id="4jd8IzH_1do" role="3cqZAp">
+                  <node concept="1PaTwC" id="4jd8IzH_1dp" role="1aUNEU">
+                    <node concept="3oM_SD" id="4jd8IzH_1dq" role="1PaTwD">
+                      <property role="3oM_SC" value="Allow" />
+                    </node>
+                    <node concept="3oM_SD" id="4jd8IzH_1dr" role="1PaTwD">
+                      <property role="3oM_SC" value="casting" />
+                    </node>
+                    <node concept="3oM_SD" id="4jd8IzH_1ds" role="1PaTwD">
+                      <property role="3oM_SC" value="from" />
+                    </node>
+                    <node concept="3oM_SD" id="4jd8IzH_1dt" role="1PaTwD">
+                      <property role="3oM_SC" value="null" />
+                    </node>
+                    <node concept="3oM_SD" id="4jd8IzH_1du" role="1PaTwD">
+                      <property role="3oM_SC" value="literal" />
+                    </node>
+                    <node concept="3oM_SD" id="4jd8IzH_1dv" role="1PaTwD">
+                      <property role="3oM_SC" value="to" />
+                    </node>
+                    <node concept="3oM_SD" id="4jd8IzH_1dw" role="1PaTwD">
+                      <property role="3oM_SC" value="anything" />
+                    </node>
+                    <node concept="3oM_SD" id="4jd8IzH_1dx" role="1PaTwD">
+                      <property role="3oM_SC" value="(it" />
+                    </node>
+                    <node concept="3oM_SD" id="4jd8IzH_1dy" role="1PaTwD">
+                      <property role="3oM_SC" value="should" />
+                    </node>
+                    <node concept="3oM_SD" id="4jd8IzH_1dz" role="1PaTwD">
+                      <property role="3oM_SC" value="allow" />
+                    </node>
+                    <node concept="3oM_SD" id="4jd8IzH_1d$" role="1PaTwD">
+                      <property role="3oM_SC" value="casting" />
+                    </node>
+                    <node concept="3oM_SD" id="4jd8IzH_1d_" role="1PaTwD">
+                      <property role="3oM_SC" value="from" />
+                    </node>
+                    <node concept="3oM_SD" id="4jd8IzH_1dA" role="1PaTwD">
+                      <property role="3oM_SC" value="any" />
+                    </node>
+                    <node concept="3oM_SD" id="4jd8IzH_1dB" role="1PaTwD">
+                      <property role="3oM_SC" value="expression" />
+                    </node>
+                    <node concept="3oM_SD" id="4jd8IzH_1dC" role="1PaTwD">
+                      <property role="3oM_SC" value="that" />
+                    </node>
+                    <node concept="3oM_SD" id="4jd8IzH_1dD" role="1PaTwD">
+                      <property role="3oM_SC" value="has" />
+                    </node>
+                    <node concept="3oM_SD" id="4jd8IzH_5pO" role="1PaTwD">
+                      <property role="3oM_SC" value="type" />
+                    </node>
+                    <node concept="3oM_SD" id="4jd8IzH_1dE" role="1PaTwD">
+                      <property role="3oM_SC" value="nulltype," />
+                    </node>
+                    <node concept="3oM_SD" id="4jd8IzH_1dF" role="1PaTwD">
+                      <property role="3oM_SC" value="not" />
+                    </node>
+                    <node concept="3oM_SD" id="4jd8IzH_1dG" role="1PaTwD">
+                      <property role="3oM_SC" value="just" />
+                    </node>
+                    <node concept="3oM_SD" id="4jd8IzH_1dH" role="1PaTwD">
+                      <property role="3oM_SC" value="null" />
+                    </node>
+                    <node concept="3oM_SD" id="4jd8IzH_1dI" role="1PaTwD">
+                      <property role="3oM_SC" value="literals," />
+                    </node>
+                    <node concept="3oM_SD" id="4jd8IzH_1dJ" role="1PaTwD">
+                      <property role="3oM_SC" value="but" />
+                    </node>
+                    <node concept="3oM_SD" id="4jd8IzH_1dK" role="1PaTwD">
+                      <property role="3oM_SC" value="I" />
+                    </node>
+                    <node concept="3oM_SD" id="4jd8IzH_1dL" role="1PaTwD">
+                      <property role="3oM_SC" value="don't" />
+                    </node>
+                    <node concept="3oM_SD" id="4jd8IzH_1dM" role="1PaTwD">
+                      <property role="3oM_SC" value="want" />
+                    </node>
+                    <node concept="3oM_SD" id="4jd8IzH_1dN" role="1PaTwD">
+                      <property role="3oM_SC" value="to" />
+                    </node>
+                    <node concept="3oM_SD" id="4jd8IzH_1dO" role="1PaTwD">
+                      <property role="3oM_SC" value="involve" />
+                    </node>
+                    <node concept="3oM_SD" id="4jd8IzH_1dP" role="1PaTwD">
+                      <property role="3oM_SC" value="the" />
+                    </node>
+                    <node concept="3oM_SD" id="4jd8IzH_1dQ" role="1PaTwD">
+                      <property role="3oM_SC" value="type" />
+                    </node>
+                    <node concept="3oM_SD" id="4jd8IzH_1dR" role="1PaTwD">
+                      <property role="3oM_SC" value="system" />
+                    </node>
+                    <node concept="3oM_SD" id="4jd8IzH_1dS" role="1PaTwD">
+                      <property role="3oM_SC" value="here)." />
+                    </node>
+                  </node>
+                </node>
+                <node concept="3cpWs6" id="4jd8IzH_1dT" role="3cqZAp">
+                  <node concept="3clFbT" id="4jd8IzH_3k6" role="3cqZAk" />
+                </node>
+              </node>
+              <node concept="2OqwBi" id="4jd8IzH_1dV" role="3clFbw">
+                <node concept="2OqwBi" id="4jd8IzH_1dW" role="2Oq$k0">
+                  <node concept="37vLTw" id="4jd8IzH_1dX" role="2Oq$k0">
+                    <ref role="3cqZAo" node="4jd8IzH_1bB" resolve="cast" />
+                  </node>
+                  <node concept="3TrEf2" id="4jd8IzH_1dY" role="2OqNvi">
+                    <ref role="3Tt5mk" to="tpee:f_0QFTc" resolve="expression" />
+                  </node>
+                </node>
+                <node concept="1mIQ4w" id="4jd8IzH_1dZ" role="2OqNvi">
+                  <node concept="chp4Y" id="4jd8IzH_1e0" role="cj9EA">
+                    <ref role="cht4Q" to="tpee:f_0Nm5B" resolve="NullLiteral" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbH" id="4jd8IzH_1e1" role="3cqZAp" />
+            <node concept="3cpWs6" id="4jd8IzH_3yV" role="3cqZAp">
+              <node concept="3y3z36" id="4jd8IzH_4XA" role="3cqZAk">
+                <node concept="10Nm6u" id="4jd8IzH_4YD" role="3uHU7w" />
+                <node concept="2OqwBi" id="4jd8IzH_44j" role="3uHU7B">
+                  <node concept="Jnkvi" id="4jd8IzH_3_u" role="2Oq$k0">
+                    <ref role="1M0zk5" node="4jd8IzH_1eN" resolve="tpe" />
+                  </node>
+                  <node concept="3TrEf2" id="4jd8IzH_4F3" role="2OqNvi">
+                    <ref role="3Tt5mk" to="tp25:g$ehGDh" resolve="concept" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="JncvC" id="4jd8IzH_1eN" role="JncvA">
+            <property role="TrG5h" value="tpe" />
+            <node concept="2jxLKc" id="4jd8IzH_1eO" role="1tU5fm" />
+          </node>
+          <node concept="2OqwBi" id="4jd8IzH_1eP" role="JncvB">
+            <node concept="37vLTw" id="4jd8IzH_1eQ" role="2Oq$k0">
+              <ref role="3cqZAo" node="4jd8IzH_1bB" resolve="cast" />
+            </node>
+            <node concept="3TrEf2" id="4jd8IzH_1eR" role="2OqNvi">
+              <ref role="3Tt5mk" to="tpee:f_0QFTb" resolve="type" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="4jd8IzH_5dD" role="3cqZAp" />
+        <node concept="3cpWs6" id="4jd8IzH_5kK" role="3cqZAp">
+          <node concept="3clFbT" id="4jd8IzH_5ne" role="3cqZAk" />
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="4jd8IzH_12R" role="1B3o_S" />
+      <node concept="10P_77" id="4jd8IzH_158" role="3clF45" />
+      <node concept="37vLTG" id="4jd8IzH_1bB" role="3clF46">
+        <property role="TrG5h" value="cast" />
+        <node concept="3Tqbb2" id="4jd8IzH_1bA" role="1tU5fm">
+          <ref role="ehGHo" to="tpee:f_0QFTa" resolve="CastExpression" />
+        </node>
+      </node>
+    </node>
+    <node concept="3Tm1VV" id="4jd8IzHzPzG" role="1B3o_S" />
   </node>
 </model>
 

--- a/code/languages/org.mpsqa.lint/solutions/org.mpsqa.lint.test/models/org.mpsqa.lint.test@tests.mps
+++ b/code/languages/org.mpsqa.lint/solutions/org.mpsqa.lint.test/models/org.mpsqa.lint.test@tests.mps
@@ -4,8 +4,6 @@
   <languages>
     <use id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test" version="6" />
     <use id="f61473f9-130f-42f6-b98d-6c438812c2f6" name="jetbrains.mps.baseLanguage.unitTest" version="1" />
-    <use id="40ab19e9-751a-4433-b645-0e65160e58a0" name="org.mpsqa.lint.generic" version="0" />
-    <use id="eb56ebf4-df56-438e-af06-fc1cd08b495a" name="jetbrains.mps.kotlin.smodel" version="0" />
     <use id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel" version="19" />
   </languages>
   <imports>

--- a/code/languages/org.mpsqa.lint/solutions/org.mpsqa.lint.test/models/org.mpsqa.lint.test@tests.mps
+++ b/code/languages/org.mpsqa.lint/solutions/org.mpsqa.lint.test/models/org.mpsqa.lint.test@tests.mps
@@ -1,0 +1,213 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:2308332d-4f9c-4cb3-83a8-90d1adac76cf(org.mpsqa.lint.test@tests)">
+  <persistence version="9" />
+  <languages>
+    <use id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test" version="6" />
+    <use id="f61473f9-130f-42f6-b98d-6c438812c2f6" name="jetbrains.mps.baseLanguage.unitTest" version="1" />
+    <use id="40ab19e9-751a-4433-b645-0e65160e58a0" name="org.mpsqa.lint.generic" version="0" />
+    <use id="eb56ebf4-df56-438e-af06-fc1cd08b495a" name="jetbrains.mps.kotlin.smodel" version="0" />
+    <use id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel" version="19" />
+  </languages>
+  <imports>
+    <import index="ewdl" ref="r:8eaf8ae8-8265-4cc3-8b13-e131c55d1473(org.mpsqa.lint.mps_lang.linters_library.expressions)" />
+    <import index="mhbf" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.model(MPS.OpenAPI/)" />
+    <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" />
+  </imports>
+  <registry>
+    <language id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test">
+      <concept id="5097124989038916362" name="jetbrains.mps.lang.test.structure.TestInfo" flags="ng" index="2XOHcx">
+        <property id="5097124989038916363" name="projectPath" index="2XOHcw" />
+      </concept>
+      <concept id="1216913645126" name="jetbrains.mps.lang.test.structure.NodesTestCase" flags="lg" index="1lH9Xt">
+        <property id="2616911529524314943" name="accessMode" index="3DII0k" />
+        <child id="1217501822150" name="nodesToCheck" index="1SKRRt" />
+        <child id="1217501895093" name="testMethods" index="1SL9yI" />
+      </concept>
+      <concept id="1216989428737" name="jetbrains.mps.lang.test.structure.TestNode" flags="ng" index="1qefOq">
+        <child id="1216989461394" name="nodeToCheck" index="1qenE9" />
+      </concept>
+      <concept id="1210673684636" name="jetbrains.mps.lang.test.structure.TestNodeAnnotation" flags="ng" index="3xLA65" />
+      <concept id="1210674524691" name="jetbrains.mps.lang.test.structure.TestNodeReference" flags="nn" index="3xONca">
+        <reference id="1210674534086" name="declaration" index="3xOPvv" />
+      </concept>
+      <concept id="1225978065297" name="jetbrains.mps.lang.test.structure.SimpleNodeTest" flags="ng" index="1LZb2c" />
+    </language>
+    <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1081236700938" name="jetbrains.mps.baseLanguage.structure.StaticMethodDeclaration" flags="ig" index="2YIFZL" />
+      <concept id="1081236700937" name="jetbrains.mps.baseLanguage.structure.StaticMethodCall" flags="nn" index="2YIFZM">
+        <reference id="1144433194310" name="classConcept" index="1Pybhc" />
+      </concept>
+      <concept id="1070534058343" name="jetbrains.mps.baseLanguage.structure.NullLiteral" flags="nn" index="10Nm6u" />
+      <concept id="1070534934090" name="jetbrains.mps.baseLanguage.structure.CastExpression" flags="nn" index="10QFUN">
+        <child id="1070534934091" name="type" index="10QFUM" />
+        <child id="1070534934092" name="expression" index="10QFUP" />
+      </concept>
+      <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
+        <child id="1068431790190" name="initializer" index="33vP2m" />
+      </concept>
+      <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
+        <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
+      </concept>
+      <concept id="1068498886292" name="jetbrains.mps.baseLanguage.structure.ParameterDeclaration" flags="ir" index="37vLTG" />
+      <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
+        <child id="5680397130376446158" name="type" index="1tU5fm" />
+      </concept>
+      <concept id="1068580123132" name="jetbrains.mps.baseLanguage.structure.BaseMethodDeclaration" flags="ng" index="3clF44">
+        <child id="1068580123133" name="returnType" index="3clF45" />
+        <child id="1068580123134" name="parameter" index="3clF46" />
+        <child id="1068580123135" name="body" index="3clF47" />
+      </concept>
+      <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
+        <child id="1068581517665" name="statement" index="3cqZAp" />
+      </concept>
+      <concept id="1068581242864" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclarationStatement" flags="nn" index="3cpWs8">
+        <child id="1068581242865" name="localVariableDeclaration" index="3cpWs9" />
+      </concept>
+      <concept id="1068581242863" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclaration" flags="nr" index="3cpWsn" />
+      <concept id="1068581517677" name="jetbrains.mps.baseLanguage.structure.VoidType" flags="in" index="3cqZAl" />
+      <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ng" index="1ndlxa">
+        <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
+        <child id="1068499141038" name="actualArgument" index="37wK5m" />
+      </concept>
+      <concept id="1107535904670" name="jetbrains.mps.baseLanguage.structure.ClassifierType" flags="in" index="3uibUv">
+        <reference id="1107535924139" name="classifier" index="3uigEE" />
+      </concept>
+      <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ng" index="1B3ioH">
+        <child id="1178549979242" name="visibility" index="1B3o_S" />
+      </concept>
+      <concept id="1146644602865" name="jetbrains.mps.baseLanguage.structure.PublicVisibility" flags="nn" index="3Tm1VV" />
+    </language>
+    <language id="f61473f9-130f-42f6-b98d-6c438812c2f6" name="jetbrains.mps.baseLanguage.unitTest">
+      <concept id="1171981022339" name="jetbrains.mps.baseLanguage.unitTest.structure.AssertTrue" flags="nn" index="3vwNmj">
+        <child id="1171981057159" name="condition" index="3vwVQn" />
+      </concept>
+      <concept id="1171983834376" name="jetbrains.mps.baseLanguage.unitTest.structure.AssertFalse" flags="nn" index="3vFxKo">
+        <child id="1171983854940" name="condition" index="3vFALc" />
+      </concept>
+    </language>
+    <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
+      <concept id="1138055754698" name="jetbrains.mps.lang.smodel.structure.SNodeType" flags="in" index="3Tqbb2">
+        <reference id="1138405853777" name="concept" index="ehGHo" />
+      </concept>
+    </language>
+    <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
+        <child id="5169995583184591170" name="smodelAttribute" index="lGtFl" />
+      </concept>
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
+        <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+    </language>
+  </registry>
+  <node concept="1lH9Xt" id="4jd8IzHyHXF">
+    <property role="3DII0k" value="2hh8MJdVwqX/command" />
+    <property role="TrG5h" value="CastsToNodeTest" />
+    <node concept="1LZb2c" id="4jd8IzHyOoo" role="1SL9yI">
+      <property role="TrG5h" value="casts" />
+      <node concept="3cqZAl" id="4jd8IzHyOop" role="3clF45" />
+      <node concept="3clFbS" id="4jd8IzHyOot" role="3clF47">
+        <node concept="3vwNmj" id="4jd8IzH_ugY" role="3cqZAp">
+          <node concept="2YIFZM" id="4jd8IzH_v6x" role="3vwVQn">
+            <ref role="37wK5l" to="ewdl:4jd8IzH_176" resolve="isDubiousCast" />
+            <ref role="1Pybhc" to="ewdl:4jd8IzHzPzF" resolve="NodeCasts" />
+            <node concept="3xONca" id="4jd8IzH_vn7" role="37wK5m">
+              <ref role="3xOPvv" node="4jd8IzHyOn0" resolve="bad" />
+            </node>
+          </node>
+        </node>
+        <node concept="3vFxKo" id="4jd8IzH_vV2" role="3cqZAp">
+          <node concept="2YIFZM" id="4jd8IzH_vXi" role="3vFALc">
+            <ref role="37wK5l" to="ewdl:4jd8IzH_176" resolve="isDubiousCast" />
+            <ref role="1Pybhc" to="ewdl:4jd8IzHzPzF" resolve="NodeCasts" />
+            <node concept="3xONca" id="4jd8IzH_vXJ" role="37wK5m">
+              <ref role="3xOPvv" node="4jd8IzH$Mgr" resolve="goodNull" />
+            </node>
+          </node>
+        </node>
+        <node concept="3vFxKo" id="4jd8IzH_vZw" role="3cqZAp">
+          <node concept="2YIFZM" id="4jd8IzH_vZx" role="3vFALc">
+            <ref role="37wK5l" to="ewdl:4jd8IzH_176" resolve="isDubiousCast" />
+            <ref role="1Pybhc" to="ewdl:4jd8IzHzPzF" resolve="NodeCasts" />
+            <node concept="3xONca" id="4jd8IzH_vZy" role="37wK5m">
+              <ref role="3xOPvv" node="4jd8IzH$Mhg" resolve="goodNoConcept" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1qefOq" id="4jd8IzHyHXG" role="1SKRRt">
+      <node concept="2YIFZL" id="4jd8IzHyOe0" role="1qenE9">
+        <property role="TrG5h" value="someMethod" />
+        <node concept="37vLTG" id="4jd8IzHyOe8" role="3clF46">
+          <property role="TrG5h" value="snodeParam" />
+          <node concept="3uibUv" id="4jd8IzHyOhB" role="1tU5fm">
+            <ref role="3uigEE" to="mhbf:~SNode" resolve="SNode" />
+          </node>
+        </node>
+        <node concept="37vLTG" id="4jd8IzHyOhK" role="3clF46">
+          <property role="TrG5h" value="nodeParam" />
+          <node concept="3Tqbb2" id="4jd8IzHyOif" role="1tU5fm" />
+        </node>
+        <node concept="3cqZAl" id="4jd8IzHyOe1" role="3clF45" />
+        <node concept="3Tm1VV" id="4jd8IzHyOe2" role="1B3o_S" />
+        <node concept="3clFbS" id="4jd8IzHyOe3" role="3clF47">
+          <node concept="3cpWs8" id="4jd8IzHyOiv" role="3cqZAp">
+            <node concept="3cpWsn" id="4jd8IzHyOiy" role="3cpWs9">
+              <property role="TrG5h" value="bad" />
+              <node concept="3Tqbb2" id="4jd8IzHyOiu" role="1tU5fm">
+                <ref role="ehGHo" to="tpck:4uZwTti3_$T" resolve="Attribute" />
+              </node>
+              <node concept="10QFUN" id="4jd8IzHyOmi" role="33vP2m">
+                <node concept="37vLTw" id="4jd8IzHyOiY" role="10QFUP">
+                  <ref role="3cqZAo" node="4jd8IzHyOe8" resolve="snodeParam" />
+                </node>
+                <node concept="3Tqbb2" id="4jd8IzHyOmj" role="10QFUM">
+                  <ref role="ehGHo" to="tpck:4uZwTti3_$T" resolve="Attribute" />
+                </node>
+                <node concept="3xLA65" id="4jd8IzHyOn0" role="lGtFl">
+                  <property role="TrG5h" value="bad" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3cpWs8" id="4jd8IzH$McX" role="3cqZAp">
+            <node concept="3cpWsn" id="4jd8IzH$Md0" role="3cpWs9">
+              <property role="TrG5h" value="nullAsNode" />
+              <node concept="3Tqbb2" id="4jd8IzH$McV" role="1tU5fm">
+                <ref role="ehGHo" to="tpck:4uZwTti3_$T" resolve="Attribute" />
+              </node>
+              <node concept="10QFUN" id="4jd8IzH$MdS" role="33vP2m">
+                <node concept="3Tqbb2" id="4jd8IzH$Mek" role="10QFUM">
+                  <ref role="ehGHo" to="tpck:4uZwTti3_$T" resolve="Attribute" />
+                </node>
+                <node concept="10Nm6u" id="4jd8IzH$MdA" role="10QFUP" />
+                <node concept="3xLA65" id="4jd8IzH$Mgr" role="lGtFl">
+                  <property role="TrG5h" value="goodNull" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3cpWs8" id="4jd8IzH$Mha" role="3cqZAp">
+            <node concept="3cpWsn" id="4jd8IzH$Mhb" role="3cpWs9">
+              <property role="TrG5h" value="snodeAsNode" />
+              <node concept="3Tqbb2" id="4jd8IzH$Mhc" role="1tU5fm" />
+              <node concept="10QFUN" id="4jd8IzH$Mhd" role="33vP2m">
+                <node concept="3Tqbb2" id="4jd8IzH$Mhe" role="10QFUM" />
+                <node concept="37vLTw" id="4jd8IzH$MO_" role="10QFUP">
+                  <ref role="3cqZAo" node="4jd8IzHyOe8" resolve="snodeParam" />
+                </node>
+                <node concept="3xLA65" id="4jd8IzH$Mhg" role="lGtFl">
+                  <property role="TrG5h" value="goodNoConcept" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="2XOHcx" id="4jd8IzHzCko">
+    <property role="2XOHcw" value="${mpsqa.home}/code/languages/org.mpsqa.lint" />
+  </node>
+</model>
+

--- a/code/languages/org.mpsqa.lint/solutions/org.mpsqa.lint.test/org.mpsqa.lint.test.msd
+++ b/code/languages/org.mpsqa.lint/solutions/org.mpsqa.lint.test/org.mpsqa.lint.test.msd
@@ -22,17 +22,12 @@
     <language slang="l:fd392034-7849-419d-9071-12563d152375:jetbrains.mps.baseLanguage.closures" version="0" />
     <language slang="l:83888646-71ce-4f1c-9c53-c54016f6ad4f:jetbrains.mps.baseLanguage.collections" version="1" />
     <language slang="l:f61473f9-130f-42f6-b98d-6c438812c2f6:jetbrains.mps.baseLanguage.unitTest" version="1" />
-    <language slang="l:4caf0310-491e-41f5-8a9b-2006b3a94898:jetbrains.mps.execution.util" version="0" />
-    <language slang="l:6b3888c1-9802-44d8-8baf-f8e6c33ed689:jetbrains.mps.kotlin" version="8" />
-    <language slang="l:9e4ff22b-60f1-43ef-a50b-f9f0fcec22e0:jetbrains.mps.kotlin.javaRefs" version="0" />
     <language slang="l:eb56ebf4-df56-438e-af06-fc1cd08b495a:jetbrains.mps.kotlin.smodel" version="0" />
     <language slang="l:ceab5195-25ea-4f22-9b92-103b95ca8c0c:jetbrains.mps.lang.core" version="2" />
     <language slang="l:446c26eb-2b7b-4bf0-9b35-f83fa582753e:jetbrains.mps.lang.modelapi" version="0" />
     <language slang="l:7866978e-a0f0-4cc7-81bc-4d213d9375e1:jetbrains.mps.lang.smodel" version="19" />
     <language slang="l:8585453e-6bfb-4d80-98de-b16074f1d86c:jetbrains.mps.lang.test" version="6" />
-    <language slang="l:c7fb639f-be78-4307-89b0-b5959c3fa8c8:jetbrains.mps.lang.text" version="0" />
     <language slang="l:9ded098b-ad6a-4657-bfd9-48636cfe8bc3:jetbrains.mps.lang.traceable" version="0" />
-    <language slang="l:40ab19e9-751a-4433-b645-0e65160e58a0:org.mpsqa.lint.generic" version="0" />
   </languageVersions>
   <dependencyVersions>
     <module reference="3f233e7f-b8a6-46d2-a57f-795d56775243(Annotations)" version="0" />

--- a/code/languages/org.mpsqa.lint/solutions/org.mpsqa.lint.test/org.mpsqa.lint.test.msd
+++ b/code/languages/org.mpsqa.lint/solutions/org.mpsqa.lint.test/org.mpsqa.lint.test.msd
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<solution name="org.mpsqa.lint.test" uuid="8dea0738-32a6-4d3d-bd7c-7b5fd43da198" moduleVersion="0" compileInMPS="true">
+  <models>
+    <modelRoot contentPath="${module}" type="default">
+      <sourceRoot location="models" />
+    </modelRoot>
+  </models>
+  <facets>
+    <facet type="java">
+      <classes generated="true" path="${module}/classes_gen" />
+    </facet>
+  </facets>
+  <sourcePath />
+  <dependencies>
+    <dependency reexport="false">12a40499-ed72-4b23-9437-358c4217c97b(org.mpsqa.lint.mps_lang.linters_library)</dependency>
+    <dependency reexport="false">8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)</dependency>
+    <dependency reexport="false">ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)</dependency>
+  </dependencies>
+  <languageVersions>
+    <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="12" />
+    <language slang="l:443f4c36-fcf5-4eb6-9500-8d06ed259e3e:jetbrains.mps.baseLanguage.classifiers" version="0" />
+    <language slang="l:fd392034-7849-419d-9071-12563d152375:jetbrains.mps.baseLanguage.closures" version="0" />
+    <language slang="l:83888646-71ce-4f1c-9c53-c54016f6ad4f:jetbrains.mps.baseLanguage.collections" version="1" />
+    <language slang="l:f61473f9-130f-42f6-b98d-6c438812c2f6:jetbrains.mps.baseLanguage.unitTest" version="1" />
+    <language slang="l:4caf0310-491e-41f5-8a9b-2006b3a94898:jetbrains.mps.execution.util" version="0" />
+    <language slang="l:6b3888c1-9802-44d8-8baf-f8e6c33ed689:jetbrains.mps.kotlin" version="8" />
+    <language slang="l:9e4ff22b-60f1-43ef-a50b-f9f0fcec22e0:jetbrains.mps.kotlin.javaRefs" version="0" />
+    <language slang="l:eb56ebf4-df56-438e-af06-fc1cd08b495a:jetbrains.mps.kotlin.smodel" version="0" />
+    <language slang="l:ceab5195-25ea-4f22-9b92-103b95ca8c0c:jetbrains.mps.lang.core" version="2" />
+    <language slang="l:446c26eb-2b7b-4bf0-9b35-f83fa582753e:jetbrains.mps.lang.modelapi" version="0" />
+    <language slang="l:7866978e-a0f0-4cc7-81bc-4d213d9375e1:jetbrains.mps.lang.smodel" version="19" />
+    <language slang="l:8585453e-6bfb-4d80-98de-b16074f1d86c:jetbrains.mps.lang.test" version="6" />
+    <language slang="l:c7fb639f-be78-4307-89b0-b5959c3fa8c8:jetbrains.mps.lang.text" version="0" />
+    <language slang="l:9ded098b-ad6a-4657-bfd9-48636cfe8bc3:jetbrains.mps.lang.traceable" version="0" />
+    <language slang="l:40ab19e9-751a-4433-b645-0e65160e58a0:org.mpsqa.lint.generic" version="0" />
+  </languageVersions>
+  <dependencyVersions>
+    <module reference="3f233e7f-b8a6-46d2-a57f-795d56775243(Annotations)" version="0" />
+    <module reference="6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)" version="0" />
+    <module reference="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)" version="0" />
+    <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
+    <module reference="ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)" version="0" />
+    <module reference="12a40499-ed72-4b23-9437-358c4217c97b(org.mpsqa.lint.mps_lang.linters_library)" version="0" />
+    <module reference="8dea0738-32a6-4d3d-bd7c-7b5fd43da198(org.mpsqa.lint.test)" version="0" />
+  </dependencyVersions>
+</solution>
+

--- a/code/languages/org.mpsqa.mutant/tests/test.org.mpsqa.mutant.demolang/models/test.org.mpsqa.mutant.demolang._010_smoke_testcode.mps
+++ b/code/languages/org.mpsqa.mutant/tests/test.org.mpsqa.mutant.demolang/models/test.org.mpsqa.mutant.demolang._010_smoke_testcode.mps
@@ -152,7 +152,7 @@
       </node>
     </node>
     <node concept="3Qo$EU" id="5nCCIAzzQd0" role="3Qp43q">
-      <ref role="3Qo$EX" node="4eFGY40pl9N" resolve="_010_depth_1" />
+      <ref role="3Qo$EX" node="4eFGY40pl9N" />
     </node>
   </node>
   <node concept="13QL6U" id="4DkAay7OKhv">
@@ -175,7 +175,7 @@
       </node>
     </node>
     <node concept="3Qo$EU" id="4DkAay7OKhA" role="3Qp43q">
-      <ref role="3Qo$EX" node="4eFGY40qqTd" resolve="_020_depth_2" />
+      <ref role="3Qo$EX" node="4eFGY40qqTd" />
     </node>
   </node>
   <node concept="13QL6U" id="4DkAay7PMca">
@@ -198,7 +198,7 @@
       </node>
     </node>
     <node concept="3Qo$EU" id="4DkAay7PMch" role="3Qp43q">
-      <ref role="3Qo$EX" node="4eFGY40r84e" resolve="_030_depth_3" />
+      <ref role="3Qo$EX" node="4eFGY40r84e" />
     </node>
   </node>
   <node concept="13QL6U" id="5jW7oooqZww">
@@ -221,7 +221,7 @@
       </node>
     </node>
     <node concept="3Qo$EU" id="5jW7oooqZwB" role="3Qp43q">
-      <ref role="3Qo$EX" node="5jW7oooqZwI" resolve="_040_concept_with_two_children_depth_2" />
+      <ref role="3Qo$EX" node="5jW7oooqZwI" />
     </node>
   </node>
   <node concept="13W42U" id="5jW7oooqZwI">

--- a/code/languages/org.mpsqa.mutant/tests/test.org.mpsqa.mutant.demolang/models/test.org.mpsqa.mutant.demolang._020_smoke_constraints_testcode.mps
+++ b/code/languages/org.mpsqa.mutant/tests/test.org.mpsqa.mutant.demolang/models/test.org.mpsqa.mutant.demolang._020_smoke_constraints_testcode.mps
@@ -84,7 +84,7 @@
       </node>
     </node>
     <node concept="3Qo$EU" id="4DkAay89m$z" role="3Qp43q">
-      <ref role="3Qo$EX" node="4DkAay89oE0" resolve="_010_children_constraints" />
+      <ref role="3Qo$EX" node="4DkAay89oE0" />
     </node>
     <node concept="3dIY$q" id="4DkAay89yWf" role="3dD9PC">
       <node concept="1Xw6AR" id="4DkAay89yWh" role="3dIY_E">

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,0 +1,12 @@
+pluginManagement {
+    repositories {
+        maven {
+            url = uri("https://maven.pkg.github.com/mbeddr/*")
+            credentials {
+                username = if (extra.has("github_username")) extra.get("github_username") as String else System.getenv("GITHUB_ACTOR")
+                password = if (extra.has("github_token")) extra.get("github_token") as String else System.getenv("GITHUB_TOKEN")
+            }
+        }
+        gradlePluginPortal()
+    }
+}


### PR DESCRIPTION
This PR contains two changes:

* Modifying a linter to allow casting to `node<>` or casting `null` to `node<[any concept]>`.
* Cleaning up the build a bit and integrating tests into it.