### PR TITLE
lint: cast-to-node check now less restrictive (2021.3)

### DIFF
--- a/code/languages/org.mpsqa.lint/.mps/modules.xml
+++ b/code/languages/org.mpsqa.lint/.mps/modules.xml
@@ -6,6 +6,7 @@
       <modulePath path="$PROJECT_DIR$/solutions/org.mpsqa.lint.generic.linters_library/org.mpsqa.lint.generic.linters_library.msd" folder="" />
       <modulePath path="$PROJECT_DIR$/solutions/org.mpsqa.lint.generic.sandbox/org.mpsqa.lint.generic.sandbox.msd" folder="" />
       <modulePath path="$PROJECT_DIR$/solutions/org.mpsqa.lint.mps_lang.linters_library/org.mpsqa.lint.mps_lang.linters_library.msd" folder="" />
+      <modulePath path="$PROJECT_DIR$/solutions/org.mpsqa.lint.test/org.mpsqa.lint.test.msd" folder="" />
     </projectModules>
   </component>
 </project>

--- a/code/languages/org.mpsqa.lint/languages/org.mpsqa.lint.generic/org.mpsqa.lint.generic.mpl
+++ b/code/languages/org.mpsqa.lint/languages/org.mpsqa.lint.generic/org.mpsqa.lint.generic.mpl
@@ -51,8 +51,6 @@
         <module reference="6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)" version="0" />
         <module reference="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)" version="0" />
         <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
-        <module reference="4c6a28d1-2c60-478d-b36e-db9b3cbb21fb(closures.runtime)" version="0" />
-        <module reference="9b80526e-f0bf-4992-bdf5-cee39c1833f3(collections.runtime)" version="0" />
         <module reference="f3061a53-9226-4cc5-a443-f952ceaf5816(jetbrains.mps.baseLanguage)" version="0" />
         <module reference="52b81ac7-93fd-4e9e-b972-4995882da6d4(jetbrains.mps.baseLanguage.references.runtime)" version="0" />
         <module reference="e39e4a59-8cb6-498e-860e-8fa8361c0d90(jetbrains.mps.baseLanguage.scopes)" version="0" />
@@ -69,7 +67,6 @@
   <dependencies>
     <dependency reexport="false">f3061a53-9226-4cc5-a443-f952ceaf5816(jetbrains.mps.baseLanguage)</dependency>
     <dependency reexport="false">c7fb639f-be78-4307-89b0-b5959c3fa8c8(jetbrains.mps.lang.text)</dependency>
-    <dependency reexport="false" scope="generate-into">83888646-71ce-4f1c-9c53-c54016f6ad4f(jetbrains.mps.baseLanguage.collections)</dependency>
     <dependency reexport="false">6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)</dependency>
     <dependency reexport="false">8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)</dependency>
     <dependency reexport="false">6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)</dependency>

--- a/code/languages/org.mpsqa.lint/solutions/org.mpsqa.lint.mps_lang.linters_library/models/org.mpsqa.lint.mps_lang.linters_library.expressions.mps
+++ b/code/languages/org.mpsqa.lint/solutions/org.mpsqa.lint.mps_lang.linters_library/models/org.mpsqa.lint.mps_lang.linters_library.expressions.mps
@@ -7,6 +7,7 @@
     <use id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel" version="19" />
     <use id="83888646-71ce-4f1c-9c53-c54016f6ad4f" name="jetbrains.mps.baseLanguage.collections" version="1" />
     <use id="1a8554c4-eb84-43ba-8c34-6f0d90c6e75a" name="jetbrains.mps.lang.smodel.query" version="3" />
+    <use id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage" version="12" />
   </languages>
   <imports>
     <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" />
@@ -15,14 +16,13 @@
     <import index="zn9m" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.openapi.util(MPS.IDEA/)" />
     <import index="tpcu" ref="r:00000000-0000-4000-0000-011c89590282(jetbrains.mps.lang.core.behavior)" />
     <import index="tpee" ref="r:00000000-0000-4000-0000-011c895902ca(jetbrains.mps.baseLanguage.structure)" implicit="true" />
+    <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" implicit="true" />
   </imports>
   <registry>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
       <concept id="4836112446988635817" name="jetbrains.mps.baseLanguage.structure.UndefinedType" flags="in" index="2jxLKc" />
       <concept id="1202948039474" name="jetbrains.mps.baseLanguage.structure.InstanceMethodCallOperation" flags="nn" index="liA8E" />
-      <concept id="1154032098014" name="jetbrains.mps.baseLanguage.structure.AbstractLoopStatement" flags="nn" index="2LF5Ji">
-        <child id="1154032183016" name="body" index="2LFqv$" />
-      </concept>
+      <concept id="1465982738277781862" name="jetbrains.mps.baseLanguage.structure.PlaceholderMember" flags="nn" index="2tJIrI" />
       <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
         <child id="1197027771414" name="operand" index="2Oq$k0" />
         <child id="1197027833540" name="operation" index="2OqNvi" />
@@ -36,23 +36,45 @@
       <concept id="1070475926800" name="jetbrains.mps.baseLanguage.structure.StringLiteral" flags="nn" index="Xl_RD">
         <property id="1070475926801" name="value" index="Xl_RC" />
       </concept>
+      <concept id="1081236700938" name="jetbrains.mps.baseLanguage.structure.StaticMethodDeclaration" flags="ig" index="2YIFZL" />
+      <concept id="1081236700937" name="jetbrains.mps.baseLanguage.structure.StaticMethodCall" flags="nn" index="2YIFZM">
+        <reference id="1144433194310" name="classConcept" index="1Pybhc" />
+      </concept>
+      <concept id="1070534058343" name="jetbrains.mps.baseLanguage.structure.NullLiteral" flags="nn" index="10Nm6u" />
+      <concept id="1070534644030" name="jetbrains.mps.baseLanguage.structure.BooleanType" flags="in" index="10P_77" />
+      <concept id="1068390468198" name="jetbrains.mps.baseLanguage.structure.ClassConcept" flags="ig" index="312cEu" />
       <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
         <child id="1068431790190" name="initializer" index="33vP2m" />
+      </concept>
+      <concept id="1513279640923991009" name="jetbrains.mps.baseLanguage.structure.IGenericClassCreator" flags="ng" index="366HgL">
+        <property id="1513279640906337053" name="inferTypeParams" index="373rjd" />
       </concept>
       <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
         <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
       </concept>
+      <concept id="1068498886292" name="jetbrains.mps.baseLanguage.structure.ParameterDeclaration" flags="ir" index="37vLTG" />
       <concept id="1225271177708" name="jetbrains.mps.baseLanguage.structure.StringType" flags="in" index="17QB3L" />
       <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
         <child id="5680397130376446158" name="type" index="1tU5fm" />
       </concept>
+      <concept id="1068580123132" name="jetbrains.mps.baseLanguage.structure.BaseMethodDeclaration" flags="ng" index="3clF44">
+        <child id="1068580123133" name="returnType" index="3clF45" />
+        <child id="1068580123134" name="parameter" index="3clF46" />
+        <child id="1068580123135" name="body" index="3clF47" />
+      </concept>
+      <concept id="1068580123152" name="jetbrains.mps.baseLanguage.structure.EqualsExpression" flags="nn" index="3clFbC" />
       <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
         <child id="1068580123156" name="expression" index="3clFbG" />
+      </concept>
+      <concept id="1068580123157" name="jetbrains.mps.baseLanguage.structure.Statement" flags="nn" index="3clFbH" />
+      <concept id="1068580123159" name="jetbrains.mps.baseLanguage.structure.IfStatement" flags="nn" index="3clFbJ">
+        <child id="1068580123160" name="condition" index="3clFbw" />
+        <child id="1068580123161" name="ifTrue" index="3clFbx" />
       </concept>
       <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
         <child id="1068581517665" name="statement" index="3cqZAp" />
       </concept>
-      <concept id="1068581242875" name="jetbrains.mps.baseLanguage.structure.PlusExpression" flags="nn" index="3cpWs3" />
+      <concept id="1068580123137" name="jetbrains.mps.baseLanguage.structure.BooleanConstant" flags="nn" index="3clFbT" />
       <concept id="1068581242878" name="jetbrains.mps.baseLanguage.structure.ReturnStatement" flags="nn" index="3cpWs6">
         <child id="1068581517676" name="expression" index="3cqZAk" />
       </concept>
@@ -64,7 +86,12 @@
         <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
         <child id="1068499141038" name="actualArgument" index="37wK5m" />
       </concept>
-      <concept id="1212685548494" name="jetbrains.mps.baseLanguage.structure.ClassCreator" flags="nn" index="1pGfFk" />
+      <concept id="1212685548494" name="jetbrains.mps.baseLanguage.structure.ClassCreator" flags="nn" index="1pGfFk">
+        <child id="1212687122400" name="typeParameter" index="1pMfVU" />
+      </concept>
+      <concept id="1107461130800" name="jetbrains.mps.baseLanguage.structure.Classifier" flags="ng" index="3pOWGL">
+        <child id="5375687026011219971" name="member" index="jymVt" unordered="true" />
+      </concept>
       <concept id="1107535904670" name="jetbrains.mps.baseLanguage.structure.ClassifierType" flags="in" index="3uibUv">
         <reference id="1107535924139" name="classifier" index="3uigEE" />
         <child id="1109201940907" name="parameter" index="11_B2D" />
@@ -73,6 +100,17 @@
         <child id="1081773367579" name="rightExpression" index="3uHU7w" />
         <child id="1081773367580" name="leftExpression" index="3uHU7B" />
       </concept>
+      <concept id="1073239437375" name="jetbrains.mps.baseLanguage.structure.NotEqualsExpression" flags="nn" index="3y3z36" />
+      <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ng" index="1B3ioH">
+        <child id="1178549979242" name="visibility" index="1B3o_S" />
+      </concept>
+      <concept id="5497648299878491908" name="jetbrains.mps.baseLanguage.structure.BaseVariableReference" flags="nn" index="1M0zk4">
+        <reference id="5497648299878491909" name="baseVariableDeclaration" index="1M0zk5" />
+      </concept>
+      <concept id="6329021646629104954" name="jetbrains.mps.baseLanguage.structure.SingleLineComment" flags="nn" index="3SKdUt">
+        <child id="8356039341262087992" name="line" index="1aUNEU" />
+      </concept>
+      <concept id="1146644602865" name="jetbrains.mps.baseLanguage.structure.PublicVisibility" flags="nn" index="3Tm1VV" />
     </language>
     <language id="40ab19e9-751a-4433-b645-0e65160e58a0" name="org.mpsqa.lint.generic">
       <concept id="2555875871752198907" name="org.mpsqa.lint.generic.structure.ConceptFunctionParameter_MPSProject" flags="ng" index="1MG55F" />
@@ -82,6 +120,12 @@
       </concept>
       <concept id="2555875871751904530" name="org.mpsqa.lint.generic.structure.CheckingFunction" flags="ig" index="1MIXq2" />
     </language>
+    <language id="fd392034-7849-419d-9071-12563d152375" name="jetbrains.mps.baseLanguage.closures">
+      <concept id="1199569711397" name="jetbrains.mps.baseLanguage.closures.structure.ClosureLiteral" flags="nn" index="1bVj0M">
+        <child id="1199569906740" name="parameter" index="1bW2Oz" />
+        <child id="1199569916463" name="body" index="1bW5cS" />
+      </concept>
+    </language>
     <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
       <concept id="1177026924588" name="jetbrains.mps.lang.smodel.structure.RefConcept_Reference" flags="nn" index="chp4Y">
         <reference id="1177026940964" name="conceptDeclaration" index="cht4Q" />
@@ -90,9 +134,6 @@
         <child id="1144104376918" name="parameter" index="1xVPHs" />
       </concept>
       <concept id="1179409122411" name="jetbrains.mps.lang.smodel.structure.Node_ConceptMethodCall" flags="nn" index="2qgKlT" />
-      <concept id="4693937538533521280" name="jetbrains.mps.lang.smodel.structure.OfConceptOperation" flags="ng" index="v3k3i">
-        <child id="4693937538533538124" name="requestedConcept" index="v3oSu" />
-      </concept>
       <concept id="1143234257716" name="jetbrains.mps.lang.smodel.structure.Node_GetModelOperation" flags="nn" index="I4A8Y" />
       <concept id="1883223317721008708" name="jetbrains.mps.lang.smodel.structure.IfInstanceOfStatement" flags="nn" index="Jncv_">
         <reference id="1883223317721008712" name="nodeConcept" index="JncvD" />
@@ -101,15 +142,21 @@
         <child id="1883223317721008710" name="nodeExpression" index="JncvB" />
       </concept>
       <concept id="1883223317721008713" name="jetbrains.mps.lang.smodel.structure.IfInstanceOfVariable" flags="ng" index="JncvC" />
+      <concept id="1883223317721107059" name="jetbrains.mps.lang.smodel.structure.IfInstanceOfVarReference" flags="nn" index="Jnkvi" />
       <concept id="1145404486709" name="jetbrains.mps.lang.smodel.structure.SemanticDowncastExpression" flags="nn" index="2JrnkZ">
         <child id="1145404616321" name="leftExpression" index="2JrQYb" />
       </concept>
       <concept id="1171310072040" name="jetbrains.mps.lang.smodel.structure.Node_GetContainingRootOperation" flags="nn" index="2Rxl7S" />
       <concept id="1171407110247" name="jetbrains.mps.lang.smodel.structure.Node_GetAncestorOperation" flags="nn" index="2Xjw5R" />
+      <concept id="1139621453865" name="jetbrains.mps.lang.smodel.structure.Node_IsInstanceOfOperation" flags="nn" index="1mIQ4w">
+        <child id="1177027386292" name="conceptArgument" index="cj9EA" />
+      </concept>
       <concept id="1144101972840" name="jetbrains.mps.lang.smodel.structure.OperationParm_Concept" flags="ng" index="1xMEDy">
         <child id="1207343664468" name="conceptArgument" index="ri$Ld" />
       </concept>
-      <concept id="1138055754698" name="jetbrains.mps.lang.smodel.structure.SNodeType" flags="in" index="3Tqbb2" />
+      <concept id="1138055754698" name="jetbrains.mps.lang.smodel.structure.SNodeType" flags="in" index="3Tqbb2">
+        <reference id="1138405853777" name="concept" index="ehGHo" />
+      </concept>
       <concept id="1138056022639" name="jetbrains.mps.lang.smodel.structure.SPropertyAccess" flags="nn" index="3TrcHB">
         <reference id="1138056395725" name="property" index="3TsBF5" />
       </concept>
@@ -134,32 +181,32 @@
       </concept>
     </language>
     <language id="1a8554c4-eb84-43ba-8c34-6f0d90c6e75a" name="jetbrains.mps.lang.smodel.query">
-      <concept id="2822369470875160718" name="jetbrains.mps.lang.smodel.query.structure.NodesExpression" flags="ng" index="2Jgcaq" />
+      <concept id="7738379549910147341" name="jetbrains.mps.lang.smodel.query.structure.InstancesExpression" flags="ng" index="qVDSY">
+        <child id="7738379549910147342" name="conceptArg" index="qVDSX" />
+      </concept>
       <concept id="4234138103881610891" name="jetbrains.mps.lang.smodel.query.structure.WithStatement" flags="ng" index="L3pyB">
         <child id="4234138103881610935" name="scope" index="L3pyr" />
         <child id="4234138103881610892" name="stmts" index="L3pyw" />
       </concept>
     </language>
     <language id="83888646-71ce-4f1c-9c53-c54016f6ad4f" name="jetbrains.mps.baseLanguage.collections">
+      <concept id="1204796164442" name="jetbrains.mps.baseLanguage.collections.structure.InternalSequenceOperation" flags="nn" index="23sCx2">
+        <child id="1204796294226" name="closure" index="23t8la" />
+      </concept>
       <concept id="540871147943773365" name="jetbrains.mps.baseLanguage.collections.structure.SingleArgumentSequenceOperation" flags="nn" index="25WWJ4">
         <child id="540871147943773366" name="argument" index="25WWJ7" />
       </concept>
       <concept id="1151688443754" name="jetbrains.mps.baseLanguage.collections.structure.ListType" flags="in" index="_YKpA">
         <child id="1151688676805" name="elementType" index="_ZDj9" />
       </concept>
-      <concept id="1153943597977" name="jetbrains.mps.baseLanguage.collections.structure.ForEachStatement" flags="nn" index="2Gpval">
-        <child id="1153944400369" name="variable" index="2Gsz3X" />
-        <child id="1153944424730" name="inputSequence" index="2GsD0m" />
-      </concept>
-      <concept id="1153944193378" name="jetbrains.mps.baseLanguage.collections.structure.ForEachVariable" flags="nr" index="2GrKxI" />
-      <concept id="1153944233411" name="jetbrains.mps.baseLanguage.collections.structure.ForEachVariableReference" flags="nn" index="2GrUjf">
-        <reference id="1153944258490" name="variable" index="2Gs0qQ" />
-      </concept>
       <concept id="1237721394592" name="jetbrains.mps.baseLanguage.collections.structure.AbstractContainerCreator" flags="nn" index="HWqM0">
         <child id="1237721435807" name="elementType" index="HW$YZ" />
       </concept>
+      <concept id="1203518072036" name="jetbrains.mps.baseLanguage.collections.structure.SmartClosureParameterDeclaration" flags="ig" index="Rh6nW" />
       <concept id="1160600644654" name="jetbrains.mps.baseLanguage.collections.structure.ListCreatorWithInit" flags="nn" index="Tc6Ow" />
-      <concept id="1160612413312" name="jetbrains.mps.baseLanguage.collections.structure.AddElementOperation" flags="nn" index="TSZUe" />
+      <concept id="1160666733551" name="jetbrains.mps.baseLanguage.collections.structure.AddAllElementsOperation" flags="nn" index="X8dFx" />
+      <concept id="1202120902084" name="jetbrains.mps.baseLanguage.collections.structure.WhereOperation" flags="nn" index="3zZkjj" />
+      <concept id="1202128969694" name="jetbrains.mps.baseLanguage.collections.structure.SelectOperation" flags="nn" index="3$u5V9" />
     </language>
   </registry>
   <node concept="1MIHA_" id="3pz5R1DPwMT">
@@ -184,6 +231,21 @@
         <node concept="3oM_SD" id="3pz5R1DPFXL" role="1PaTwD">
           <property role="3oM_SC" value="SNodeType" />
         </node>
+        <node concept="3oM_SD" id="4jd8IzHxs0D" role="1PaTwD">
+          <property role="3oM_SC" value="with" />
+        </node>
+        <node concept="3oM_SD" id="4jd8IzHxs0T" role="1PaTwD">
+          <property role="3oM_SC" value="a" />
+        </node>
+        <node concept="3oM_SD" id="4jd8IzHxs1a" role="1PaTwD">
+          <property role="3oM_SC" value="concept" />
+        </node>
+        <node concept="3oM_SD" id="4jd8IzHxs1s" role="1PaTwD">
+          <property role="3oM_SC" value="(e.g." />
+        </node>
+        <node concept="3oM_SD" id="4jd8IzHxs1J" role="1PaTwD">
+          <property role="3oM_SC" value="node&lt;PlusExpression&gt;)" />
+        </node>
         <node concept="3oM_SD" id="3pz5R1DPwNc" role="1PaTwD">
           <property role="3oM_SC" value="-" />
         </node>
@@ -205,12 +267,7 @@
         <node concept="3oM_SD" id="3pz5R1DPG2x" role="1PaTwD">
           <property role="3oM_SC" value="be" />
         </node>
-        <node concept="3oM_SD" id="3pz5R1DPG2Q" role="1PaTwD">
-          <property role="3oM_SC" value="" />
-        </node>
-      </node>
-      <node concept="1PaTwC" id="3pz5R1DPG3d" role="1PaQFQ">
-        <node concept="3oM_SD" id="3pz5R1DPG3c" role="1PaTwD">
+        <node concept="3oM_SD" id="4jd8IzHxs23" role="1PaTwD">
           <property role="3oM_SC" value="implemented" />
         </node>
         <node concept="3oM_SD" id="3pz5R1DPG5l" role="1PaTwD">
@@ -235,7 +292,47 @@
           <property role="3oM_SC" value="as" />
         </node>
         <node concept="3oM_SD" id="3pz5R1DPGbw" role="1PaTwD">
-          <property role="3oM_SC" value="PlusExpression&quot;" />
+          <property role="3oM_SC" value="PlusExpression&quot;." />
+        </node>
+      </node>
+      <node concept="1PaTwC" id="4jd8IzHxrXb" role="1PaQFQ">
+        <node concept="3oM_SD" id="4jd8IzHxrXa" role="1PaTwD">
+          <property role="3oM_SC" value="" />
+        </node>
+      </node>
+      <node concept="1PaTwC" id="4jd8IzHxrYY" role="1PaQFQ">
+        <node concept="3oM_SD" id="4jd8IzHxrYX" role="1PaTwD">
+          <property role="3oM_SC" value="Casts" />
+        </node>
+        <node concept="3oM_SD" id="4jd8IzHxs0y" role="1PaTwD">
+          <property role="3oM_SC" value="to" />
+        </node>
+        <node concept="3oM_SD" id="4jd8IzHxs0_" role="1PaTwD">
+          <property role="3oM_SC" value="node&lt;&gt;" />
+        </node>
+        <node concept="3oM_SD" id="4jd8IzHxs4r" role="1PaTwD">
+          <property role="3oM_SC" value="are" />
+        </node>
+        <node concept="3oM_SD" id="4jd8IzHxs4w" role="1PaTwD">
+          <property role="3oM_SC" value="allowed," />
+        </node>
+        <node concept="3oM_SD" id="4jd8IzHxs4A" role="1PaTwD">
+          <property role="3oM_SC" value="as" />
+        </node>
+        <node concept="3oM_SD" id="4jd8IzHxs4Y" role="1PaTwD">
+          <property role="3oM_SC" value="is" />
+        </node>
+        <node concept="3oM_SD" id="4jd8IzHxs56" role="1PaTwD">
+          <property role="3oM_SC" value="casting" />
+        </node>
+        <node concept="3oM_SD" id="4jd8IzHxs5f" role="1PaTwD">
+          <property role="3oM_SC" value="null" />
+        </node>
+        <node concept="3oM_SD" id="4jd8IzHxs5p" role="1PaTwD">
+          <property role="3oM_SC" value="to" />
+        </node>
+        <node concept="3oM_SD" id="4jd8IzHxs5$" role="1PaTwD">
+          <property role="3oM_SC" value="node&lt;PlusExpression&gt;." />
         </node>
       </node>
       <node concept="1PaTwC" id="3pz5R1DPG8E" role="1PaQFQ">
@@ -330,12 +427,12 @@
         <node concept="3oM_SD" id="3pz5R1DPwNZ" role="1PaTwD">
           <property role="3oM_SC" value="(node&lt;IGenericComponent&gt;)" />
         </node>
-        <node concept="3oM_SD" id="3pz5R1DPwO0" role="1PaTwD">
+        <node concept="3oM_SD" id="4jd8IzHxshw" role="1PaTwD">
           <property role="3oM_SC" value="this.entity;" />
         </node>
       </node>
-      <node concept="1PaTwC" id="3pz5R1DPGkr" role="1PaQFQ">
-        <node concept="3oM_SD" id="3pz5R1DPGkq" role="1PaTwD">
+      <node concept="1PaTwC" id="4jd8IzHxs9O" role="1PaQFQ">
+        <node concept="3oM_SD" id="4jd8IzHxs9N" role="1PaTwD">
           <property role="3oM_SC" value="" />
         </node>
       </node>
@@ -414,6 +511,97 @@
           <property role="3oM_SC" value="IGenericComponent;" />
         </node>
       </node>
+      <node concept="1PaTwC" id="4jd8IzHxsjl" role="1PaQFQ">
+        <node concept="3oM_SD" id="4jd8IzHxsjk" role="1PaTwD">
+          <property role="3oM_SC" value="" />
+        </node>
+      </node>
+      <node concept="1PaTwC" id="4jd8IzHxsln" role="1PaQFQ">
+        <node concept="3oM_SD" id="4jd8IzHxslm" role="1PaTwD">
+          <property role="3oM_SC" value="" />
+        </node>
+        <node concept="3oM_SD" id="4jd8IzHxsnc" role="1PaTwD">
+          <property role="3oM_SC" value="" />
+        </node>
+        <node concept="3oM_SD" id="4jd8IzHxsnf" role="1PaTwD">
+          <property role="3oM_SC" value="" />
+        </node>
+        <node concept="3oM_SD" id="4jd8IzHxsnj" role="1PaTwD">
+          <property role="3oM_SC" value="" />
+        </node>
+        <node concept="3oM_SD" id="4jd8IzHxsn_" role="1PaTwD">
+          <property role="3oM_SC" value="//" />
+        </node>
+        <node concept="3oM_SD" id="4jd8IzHxsnF" role="1PaTwD">
+          <property role="3oM_SC" value="okay" />
+        </node>
+      </node>
+      <node concept="1PaTwC" id="4jd8IzHxsnN" role="1PaQFQ">
+        <node concept="3oM_SD" id="4jd8IzHxsnM" role="1PaTwD">
+          <property role="3oM_SC" value="" />
+        </node>
+        <node concept="3oM_SD" id="4jd8IzHxspT" role="1PaTwD">
+          <property role="3oM_SC" value="" />
+        </node>
+        <node concept="3oM_SD" id="4jd8IzHxspW" role="1PaTwD">
+          <property role="3oM_SC" value="" />
+        </node>
+        <node concept="3oM_SD" id="4jd8IzHxsq0" role="1PaTwD">
+          <property role="3oM_SC" value="" />
+        </node>
+        <node concept="3oM_SD" id="4jd8IzHxsq5" role="1PaTwD">
+          <property role="3oM_SC" value="return" />
+        </node>
+        <node concept="3oM_SD" id="4jd8IzHxsqq" role="1PaTwD">
+          <property role="3oM_SC" value="(node&lt;IGenericComponent&gt;)" />
+        </node>
+        <node concept="3oM_SD" id="4jd8IzHxsqx" role="1PaTwD">
+          <property role="3oM_SC" value="null;" />
+        </node>
+      </node>
+      <node concept="1PaTwC" id="4jd8IzHxsts" role="1PaQFQ">
+        <node concept="3oM_SD" id="4jd8IzHxstr" role="1PaTwD">
+          <property role="3oM_SC" value="" />
+        </node>
+        <node concept="3oM_SD" id="4jd8IzHxsvO" role="1PaTwD">
+          <property role="3oM_SC" value="" />
+        </node>
+        <node concept="3oM_SD" id="4jd8IzHxsvR" role="1PaTwD">
+          <property role="3oM_SC" value="" />
+        </node>
+        <node concept="3oM_SD" id="4jd8IzHxsvV" role="1PaTwD">
+          <property role="3oM_SC" value="" />
+        </node>
+        <node concept="3oM_SD" id="4jd8IzHxsw0" role="1PaTwD">
+          <property role="3oM_SC" value="SNode" />
+        </node>
+        <node concept="3oM_SD" id="4jd8IzHxsw6" role="1PaTwD">
+          <property role="3oM_SC" value="someNode;" />
+        </node>
+      </node>
+      <node concept="1PaTwC" id="4jd8IzHxsqE" role="1PaQFQ">
+        <node concept="3oM_SD" id="4jd8IzHxsqD" role="1PaTwD">
+          <property role="3oM_SC" value="" />
+        </node>
+        <node concept="3oM_SD" id="4jd8IzHxssU" role="1PaTwD">
+          <property role="3oM_SC" value="" />
+        </node>
+        <node concept="3oM_SD" id="4jd8IzHxssX" role="1PaTwD">
+          <property role="3oM_SC" value="" />
+        </node>
+        <node concept="3oM_SD" id="4jd8IzHxst1" role="1PaTwD">
+          <property role="3oM_SC" value="" />
+        </node>
+        <node concept="3oM_SD" id="4jd8IzHxst6" role="1PaTwD">
+          <property role="3oM_SC" value="return" />
+        </node>
+        <node concept="3oM_SD" id="4jd8IzHxstc" role="1PaTwD">
+          <property role="3oM_SC" value="(node&lt;&gt;)" />
+        </node>
+        <node concept="3oM_SD" id="4jd8IzHxstj" role="1PaTwD">
+          <property role="3oM_SC" value="someNode;" />
+        </node>
+      </node>
       <node concept="1PaTwC" id="3pz5R1DPwN6" role="1PaQFQ">
         <node concept="3oM_SD" id="3pz5R1DPwO1" role="1PaTwD">
           <property role="3oM_SC" value="" />
@@ -451,129 +639,68 @@
         </node>
         <node concept="L3pyB" id="3pz5R1DPwO7" role="3cqZAp">
           <node concept="3clFbS" id="3pz5R1DPwOa" role="L3pyw">
-            <node concept="2Gpval" id="3pz5R1DPwOf" role="3cqZAp">
-              <node concept="2GrKxI" id="3pz5R1DPwOi" role="2Gsz3X">
-                <property role="TrG5h" value="cast" />
-              </node>
-              <node concept="2OqwBi" id="3pz5R1DPwOj" role="2GsD0m">
-                <node concept="2Jgcaq" id="3pz5R1DPwOm" role="2Oq$k0" />
-                <node concept="v3k3i" id="3pz5R1DPwOn" role="2OqNvi">
-                  <node concept="chp4Y" id="3pz5R1DPwOw" role="v3oSu">
-                    <ref role="cht4Q" to="tpee:f_0QFTa" resolve="CastExpression" />
-                  </node>
+            <node concept="3clFbF" id="4jd8IzH$czS" role="3cqZAp">
+              <node concept="2OqwBi" id="4jd8IzH$d$i" role="3clFbG">
+                <node concept="37vLTw" id="4jd8IzH$czQ" role="2Oq$k0">
+                  <ref role="3cqZAo" node="3pz5R1DPwO9" resolve="res" />
                 </node>
-              </node>
-              <node concept="3clFbS" id="3pz5R1DPwOk" role="2LFqv$">
-                <node concept="Jncv_" id="3pz5R1DQB53" role="3cqZAp">
-                  <ref role="JncvD" to="tp25:gzTqbfa" resolve="SNodeType" />
-                  <node concept="3clFbS" id="3pz5R1DQB5d" role="Jncv$">
-                    <node concept="3cpWs8" id="78RogMCKbme" role="3cqZAp">
-                      <node concept="3cpWsn" id="78RogMCKbmf" role="3cpWs9">
-                        <property role="TrG5h" value="msg" />
-                        <node concept="17QB3L" id="78RogMCKbkq" role="1tU5fm" />
-                        <node concept="3cpWs3" id="78RogMCKbmg" role="33vP2m">
-                          <node concept="3cpWs3" id="78RogMCKbmh" role="3uHU7B">
-                            <node concept="2OqwBi" id="78RogMCKbmi" role="3uHU7w">
-                              <node concept="2OqwBi" id="78RogMCKbmj" role="2Oq$k0">
-                                <node concept="2JrnkZ" id="78RogMCKbmk" role="2Oq$k0">
-                                  <node concept="2OqwBi" id="78RogMCKbml" role="2JrQYb">
-                                    <node concept="2GrUjf" id="78RogMCKbmm" role="2Oq$k0">
-                                      <ref role="2Gs0qQ" node="3pz5R1DPwOi" resolve="cast" />
-                                    </node>
-                                    <node concept="I4A8Y" id="78RogMCKbmn" role="2OqNvi" />
-                                  </node>
+                <node concept="X8dFx" id="4jd8IzH$f9F" role="2OqNvi">
+                  <node concept="2OqwBi" id="4jd8IzH$k3A" role="25WWJ7">
+                    <node concept="2OqwBi" id="4jd8IzH_9wM" role="2Oq$k0">
+                      <node concept="qVDSY" id="4jd8IzH$j1V" role="2Oq$k0">
+                        <node concept="chp4Y" id="4jd8IzH$jqI" role="qVDSX">
+                          <ref role="cht4Q" to="tpee:f_0QFTa" resolve="CastExpression" />
+                        </node>
+                      </node>
+                      <node concept="3zZkjj" id="4jd8IzH_amI" role="2OqNvi">
+                        <node concept="1bVj0M" id="4jd8IzH_amK" role="23t8la">
+                          <node concept="3clFbS" id="4jd8IzH_amL" role="1bW5cS">
+                            <node concept="3clFbF" id="4jd8IzH_a_s" role="3cqZAp">
+                              <node concept="2YIFZM" id="4jd8IzH_dVd" role="3clFbG">
+                                <ref role="37wK5l" node="4jd8IzH_176" resolve="isDubiousCast" />
+                                <ref role="1Pybhc" node="4jd8IzHzPzF" resolve="NodeCasts" />
+                                <node concept="37vLTw" id="4jd8IzH_e7P" role="37wK5m">
+                                  <ref role="3cqZAo" node="4jd8IzH_amM" resolve="it" />
                                 </node>
-                                <node concept="liA8E" id="78RogMCKbmo" role="2OqNvi">
-                                  <ref role="37wK5l" to="mhbf:~SModel.getName()" resolve="getName" />
-                                </node>
-                              </node>
-                              <node concept="liA8E" id="78RogMCKbmp" role="2OqNvi">
-                                <ref role="37wK5l" to="mhbf:~SModelName.getValue()" resolve="getValue" />
-                              </node>
-                            </node>
-                            <node concept="3cpWs3" id="78RogMCKbmq" role="3uHU7B">
-                              <node concept="3cpWs3" id="78RogMCKbmr" role="3uHU7B">
-                                <node concept="2OqwBi" id="78RogMCKbms" role="3uHU7w">
-                                  <node concept="2OqwBi" id="78RogMCKbmt" role="2Oq$k0">
-                                    <node concept="2GrUjf" id="78RogMCKbmu" role="2Oq$k0">
-                                      <ref role="2Gs0qQ" node="3pz5R1DPwOi" resolve="cast" />
-                                    </node>
-                                    <node concept="2Rxl7S" id="78RogMCKbmv" role="2OqNvi" />
-                                  </node>
-                                  <node concept="2qgKlT" id="78RogMCKbmw" role="2OqNvi">
-                                    <ref role="37wK5l" to="tpcu:hEwIMiw" resolve="getPresentation" />
-                                  </node>
-                                </node>
-                                <node concept="3cpWs3" id="78RogMCKbmx" role="3uHU7B">
-                                  <node concept="3cpWs3" id="78RogMCKbmy" role="3uHU7B">
-                                    <node concept="Xl_RD" id="78RogMCKbmz" role="3uHU7B">
-                                      <property role="Xl_RC" value="dubious cast expression in '" />
-                                    </node>
-                                    <node concept="2OqwBi" id="78RogMCKbm$" role="3uHU7w">
-                                      <node concept="2OqwBi" id="78RogMCKbm_" role="2Oq$k0">
-                                        <node concept="2GrUjf" id="78RogMCKbmA" role="2Oq$k0">
-                                          <ref role="2Gs0qQ" node="3pz5R1DPwOi" resolve="cast" />
-                                        </node>
-                                        <node concept="2Xjw5R" id="78RogMCKbmB" role="2OqNvi">
-                                          <node concept="1xMEDy" id="78RogMCKbmC" role="1xVPHs">
-                                            <node concept="chp4Y" id="78RogMCKbmD" role="ri$Ld">
-                                              <ref role="cht4Q" to="tpck:h0TrEE$" resolve="INamedConcept" />
-                                            </node>
-                                          </node>
-                                        </node>
-                                      </node>
-                                      <node concept="3TrcHB" id="78RogMCKbmE" role="2OqNvi">
-                                        <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
-                                      </node>
-                                    </node>
-                                  </node>
-                                  <node concept="Xl_RD" id="78RogMCKbmF" role="3uHU7w">
-                                    <property role="Xl_RC" value="' from rootNode '" />
-                                  </node>
-                                </node>
-                              </node>
-                              <node concept="Xl_RD" id="78RogMCKbmG" role="3uHU7w">
-                                <property role="Xl_RC" value="' from model '" />
                               </node>
                             </node>
                           </node>
-                          <node concept="Xl_RD" id="78RogMCKbmH" role="3uHU7w">
-                            <property role="Xl_RC" value="'. For casting to SNodeType use 'exp : ConceptName' or 'exp as ConceptName'" />
+                          <node concept="Rh6nW" id="4jd8IzH_amM" role="1bW2Oz">
+                            <property role="TrG5h" value="it" />
+                            <node concept="2jxLKc" id="4jd8IzH_amN" role="1tU5fm" />
                           </node>
                         </node>
                       </node>
                     </node>
-                    <node concept="3clFbF" id="3pz5R1DPwPt" role="3cqZAp">
-                      <node concept="2OqwBi" id="3pz5R1DPwPN" role="3clFbG">
-                        <node concept="37vLTw" id="3pz5R1DPwQ8" role="2Oq$k0">
-                          <ref role="3cqZAo" node="3pz5R1DPwO9" resolve="res" />
-                        </node>
-                        <node concept="TSZUe" id="3pz5R1DPwQ9" role="2OqNvi">
-                          <node concept="2ShNRf" id="78RogMCKbES" role="25WWJ7">
-                            <node concept="1pGfFk" id="78RogMCKc3l" role="2ShVmc">
-                              <ref role="37wK5l" to="zn9m:~Pair.&lt;init&gt;(java.lang.Object,java.lang.Object)" resolve="Pair" />
-                              <node concept="37vLTw" id="78RogMCKc5y" role="37wK5m">
-                                <ref role="3cqZAo" node="78RogMCKbmf" resolve="msg" />
-                              </node>
-                              <node concept="2GrUjf" id="78RogMCKcim" role="37wK5m">
-                                <ref role="2Gs0qQ" node="3pz5R1DPwOi" resolve="cast" />
+                    <node concept="3$u5V9" id="4jd8IzH_ev8" role="2OqNvi">
+                      <node concept="1bVj0M" id="4jd8IzH_eva" role="23t8la">
+                        <node concept="3clFbS" id="4jd8IzH_evb" role="1bW5cS">
+                          <node concept="3clFbF" id="4jd8IzH_evc" role="3cqZAp">
+                            <node concept="2ShNRf" id="4jd8IzH_n4E" role="3clFbG">
+                              <node concept="1pGfFk" id="4jd8IzH_obz" role="2ShVmc">
+                                <property role="373rjd" value="true" />
+                                <ref role="37wK5l" to="zn9m:~Pair.&lt;init&gt;(java.lang.Object,java.lang.Object)" resolve="Pair" />
+                                <node concept="17QB3L" id="4jd8IzH_oBL" role="1pMfVU" />
+                                <node concept="3Tqbb2" id="4jd8IzH_pf8" role="1pMfVU" />
+                                <node concept="2YIFZM" id="4jd8IzH_r22" role="37wK5m">
+                                  <ref role="37wK5l" node="4jd8IzH_mDV" resolve="formatDubiousCastErrorMessage" />
+                                  <ref role="1Pybhc" node="4jd8IzHzPzF" resolve="NodeCasts" />
+                                  <node concept="37vLTw" id="4jd8IzH_rBs" role="37wK5m">
+                                    <ref role="3cqZAo" node="4jd8IzH_evf" resolve="it" />
+                                  </node>
+                                </node>
+                                <node concept="37vLTw" id="4jd8IzH_sfb" role="37wK5m">
+                                  <ref role="3cqZAo" node="4jd8IzH_evf" resolve="it" />
+                                </node>
                               </node>
                             </node>
                           </node>
                         </node>
+                        <node concept="Rh6nW" id="4jd8IzH_evf" role="1bW2Oz">
+                          <property role="TrG5h" value="it" />
+                          <node concept="2jxLKc" id="4jd8IzH_evg" role="1tU5fm" />
+                        </node>
                       </node>
-                    </node>
-                  </node>
-                  <node concept="JncvC" id="3pz5R1DQB5i" role="JncvA">
-                    <property role="TrG5h" value="tpe" />
-                    <node concept="2jxLKc" id="3pz5R1DQB5j" role="1tU5fm" />
-                  </node>
-                  <node concept="2OqwBi" id="3pz5R1DQsfj" role="JncvB">
-                    <node concept="2GrUjf" id="3pz5R1DQpj4" role="2Oq$k0">
-                      <ref role="2Gs0qQ" node="3pz5R1DPwOi" resolve="cast" />
-                    </node>
-                    <node concept="3TrEf2" id="3pz5R1DQxrm" role="2OqNvi">
-                      <ref role="3Tt5mk" to="tpee:f_0QFTb" resolve="type" />
                     </node>
                   </node>
                 </node>
@@ -589,6 +716,296 @@
         </node>
       </node>
     </node>
+  </node>
+  <node concept="312cEu" id="4jd8IzHzPzF">
+    <property role="TrG5h" value="NodeCasts" />
+    <node concept="2YIFZL" id="4jd8IzH_mDV" role="jymVt">
+      <property role="TrG5h" value="formatDubiousCastErrorMessage" />
+      <node concept="3Tm1VV" id="4jd8IzH_mUs" role="1B3o_S" />
+      <node concept="17QB3L" id="4jd8IzH_mDX" role="3clF45" />
+      <node concept="37vLTG" id="4jd8IzH_mDP" role="3clF46">
+        <property role="TrG5h" value="cast" />
+        <node concept="3Tqbb2" id="4jd8IzH_mDQ" role="1tU5fm">
+          <ref role="ehGHo" to="tpee:f_0QFTa" resolve="CastExpression" />
+        </node>
+      </node>
+      <node concept="3clFbS" id="4jd8IzH_mDl" role="3clF47">
+        <node concept="3clFbF" id="4jd8IzH_zNj" role="3cqZAp">
+          <node concept="2YIFZM" id="4jd8IzH_zRX" role="3clFbG">
+            <ref role="37wK5l" to="wyt6:~String.format(java.lang.String,java.lang.Object...)" resolve="format" />
+            <ref role="1Pybhc" to="wyt6:~String" resolve="String" />
+            <node concept="Xl_RD" id="4jd8IzH_DRA" role="37wK5m">
+              <property role="Xl_RC" value="dubious cast expression in '%s' from rootNode '%s' from model '%s'. For casting to SNodeType use 'exp : ConceptName' or 'exp as ConceptName'" />
+            </node>
+            <node concept="2OqwBi" id="4jd8IzH_$dg" role="37wK5m">
+              <node concept="2OqwBi" id="4jd8IzH_$dh" role="2Oq$k0">
+                <node concept="37vLTw" id="4jd8IzH_$di" role="2Oq$k0">
+                  <ref role="3cqZAo" node="4jd8IzH_mDP" resolve="cast" />
+                </node>
+                <node concept="2Xjw5R" id="4jd8IzH_$dj" role="2OqNvi">
+                  <node concept="1xMEDy" id="4jd8IzH_$dk" role="1xVPHs">
+                    <node concept="chp4Y" id="4jd8IzH_$dl" role="ri$Ld">
+                      <ref role="cht4Q" to="tpck:h0TrEE$" resolve="INamedConcept" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3TrcHB" id="4jd8IzH_$dm" role="2OqNvi">
+                <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+              </node>
+            </node>
+            <node concept="2OqwBi" id="4jd8IzH_$d8" role="37wK5m">
+              <node concept="2OqwBi" id="4jd8IzH_$d9" role="2Oq$k0">
+                <node concept="37vLTw" id="4jd8IzH_$da" role="2Oq$k0">
+                  <ref role="3cqZAo" node="4jd8IzH_mDP" resolve="cast" />
+                </node>
+                <node concept="2Rxl7S" id="4jd8IzH_$db" role="2OqNvi" />
+              </node>
+              <node concept="2qgKlT" id="4jd8IzH_$dc" role="2OqNvi">
+                <ref role="37wK5l" to="tpcu:hEwIMiw" resolve="getPresentation" />
+              </node>
+            </node>
+            <node concept="2OqwBi" id="4jd8IzH_$cY" role="37wK5m">
+              <node concept="2OqwBi" id="4jd8IzH_$cZ" role="2Oq$k0">
+                <node concept="2JrnkZ" id="4jd8IzH_$d0" role="2Oq$k0">
+                  <node concept="2OqwBi" id="4jd8IzH_$d1" role="2JrQYb">
+                    <node concept="37vLTw" id="4jd8IzH_$d2" role="2Oq$k0">
+                      <ref role="3cqZAo" node="4jd8IzH_mDP" resolve="cast" />
+                    </node>
+                    <node concept="I4A8Y" id="4jd8IzH_$d3" role="2OqNvi" />
+                  </node>
+                </node>
+                <node concept="liA8E" id="4jd8IzH_$d4" role="2OqNvi">
+                  <ref role="37wK5l" to="mhbf:~SModel.getName()" resolve="getName" />
+                </node>
+              </node>
+              <node concept="liA8E" id="4jd8IzH_$d5" role="2OqNvi">
+                <ref role="37wK5l" to="mhbf:~SModelName.getValue()" resolve="getValue" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="4jd8IzH_0Ww" role="jymVt" />
+    <node concept="2YIFZL" id="4jd8IzH_176" role="jymVt">
+      <property role="TrG5h" value="isDubiousCast" />
+      <node concept="3clFbS" id="4jd8IzH_179" role="3clF47">
+        <node concept="Jncv_" id="4jd8IzH_1d0" role="3cqZAp">
+          <ref role="JncvD" to="tp25:gzTqbfa" resolve="SNodeType" />
+          <node concept="3clFbS" id="4jd8IzH_1d1" role="Jncv$">
+            <node concept="3clFbJ" id="4jd8IzH_1d2" role="3cqZAp">
+              <node concept="3clFbS" id="4jd8IzH_1d3" role="3clFbx">
+                <node concept="3SKdUt" id="4jd8IzH_1d4" role="3cqZAp">
+                  <node concept="1PaTwC" id="4jd8IzH_1d5" role="1aUNEU">
+                    <node concept="3oM_SD" id="4jd8IzH_1d6" role="1PaTwD">
+                      <property role="3oM_SC" value="Allow" />
+                    </node>
+                    <node concept="3oM_SD" id="4jd8IzH_1d7" role="1PaTwD">
+                      <property role="3oM_SC" value="casts" />
+                    </node>
+                    <node concept="3oM_SD" id="4jd8IzH_1d8" role="1PaTwD">
+                      <property role="3oM_SC" value="to" />
+                    </node>
+                    <node concept="3oM_SD" id="4jd8IzH_1d9" role="1PaTwD">
+                      <property role="3oM_SC" value="node&lt;&gt;" />
+                    </node>
+                    <node concept="3oM_SD" id="4jd8IzH_1da" role="1PaTwD">
+                      <property role="3oM_SC" value="without" />
+                    </node>
+                    <node concept="3oM_SD" id="4jd8IzH_1db" role="1PaTwD">
+                      <property role="3oM_SC" value="a" />
+                    </node>
+                    <node concept="3oM_SD" id="4jd8IzH_1dc" role="1PaTwD">
+                      <property role="3oM_SC" value="specific" />
+                    </node>
+                    <node concept="3oM_SD" id="4jd8IzH_1dd" role="1PaTwD">
+                      <property role="3oM_SC" value="concept." />
+                    </node>
+                  </node>
+                </node>
+                <node concept="3cpWs6" id="4jd8IzH_1de" role="3cqZAp">
+                  <node concept="3clFbT" id="4jd8IzH_2H2" role="3cqZAk" />
+                </node>
+              </node>
+              <node concept="3clFbC" id="4jd8IzH_1dg" role="3clFbw">
+                <node concept="10Nm6u" id="4jd8IzH_1dh" role="3uHU7w" />
+                <node concept="2OqwBi" id="4jd8IzH_1di" role="3uHU7B">
+                  <node concept="Jnkvi" id="4jd8IzH_1dj" role="2Oq$k0">
+                    <ref role="1M0zk5" node="4jd8IzH_1eN" resolve="tpe" />
+                  </node>
+                  <node concept="3TrEf2" id="4jd8IzH_1dk" role="2OqNvi">
+                    <ref role="3Tt5mk" to="tp25:g$ehGDh" resolve="concept" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbH" id="4jd8IzH_1dl" role="3cqZAp" />
+            <node concept="3clFbJ" id="4jd8IzH_1dm" role="3cqZAp">
+              <node concept="3clFbS" id="4jd8IzH_1dn" role="3clFbx">
+                <node concept="3SKdUt" id="4jd8IzH_1do" role="3cqZAp">
+                  <node concept="1PaTwC" id="4jd8IzH_1dp" role="1aUNEU">
+                    <node concept="3oM_SD" id="4jd8IzH_1dq" role="1PaTwD">
+                      <property role="3oM_SC" value="Allow" />
+                    </node>
+                    <node concept="3oM_SD" id="4jd8IzH_1dr" role="1PaTwD">
+                      <property role="3oM_SC" value="casting" />
+                    </node>
+                    <node concept="3oM_SD" id="4jd8IzH_1ds" role="1PaTwD">
+                      <property role="3oM_SC" value="from" />
+                    </node>
+                    <node concept="3oM_SD" id="4jd8IzH_1dt" role="1PaTwD">
+                      <property role="3oM_SC" value="null" />
+                    </node>
+                    <node concept="3oM_SD" id="4jd8IzH_1du" role="1PaTwD">
+                      <property role="3oM_SC" value="literal" />
+                    </node>
+                    <node concept="3oM_SD" id="4jd8IzH_1dv" role="1PaTwD">
+                      <property role="3oM_SC" value="to" />
+                    </node>
+                    <node concept="3oM_SD" id="4jd8IzH_1dw" role="1PaTwD">
+                      <property role="3oM_SC" value="anything" />
+                    </node>
+                    <node concept="3oM_SD" id="4jd8IzH_1dx" role="1PaTwD">
+                      <property role="3oM_SC" value="(it" />
+                    </node>
+                    <node concept="3oM_SD" id="4jd8IzH_1dy" role="1PaTwD">
+                      <property role="3oM_SC" value="should" />
+                    </node>
+                    <node concept="3oM_SD" id="4jd8IzH_1dz" role="1PaTwD">
+                      <property role="3oM_SC" value="allow" />
+                    </node>
+                    <node concept="3oM_SD" id="4jd8IzH_1d$" role="1PaTwD">
+                      <property role="3oM_SC" value="casting" />
+                    </node>
+                    <node concept="3oM_SD" id="4jd8IzH_1d_" role="1PaTwD">
+                      <property role="3oM_SC" value="from" />
+                    </node>
+                    <node concept="3oM_SD" id="4jd8IzH_1dA" role="1PaTwD">
+                      <property role="3oM_SC" value="any" />
+                    </node>
+                    <node concept="3oM_SD" id="4jd8IzH_1dB" role="1PaTwD">
+                      <property role="3oM_SC" value="expression" />
+                    </node>
+                    <node concept="3oM_SD" id="4jd8IzH_1dC" role="1PaTwD">
+                      <property role="3oM_SC" value="that" />
+                    </node>
+                    <node concept="3oM_SD" id="4jd8IzH_1dD" role="1PaTwD">
+                      <property role="3oM_SC" value="has" />
+                    </node>
+                    <node concept="3oM_SD" id="4jd8IzH_5pO" role="1PaTwD">
+                      <property role="3oM_SC" value="type" />
+                    </node>
+                    <node concept="3oM_SD" id="4jd8IzH_1dE" role="1PaTwD">
+                      <property role="3oM_SC" value="nulltype," />
+                    </node>
+                    <node concept="3oM_SD" id="4jd8IzH_1dF" role="1PaTwD">
+                      <property role="3oM_SC" value="not" />
+                    </node>
+                    <node concept="3oM_SD" id="4jd8IzH_1dG" role="1PaTwD">
+                      <property role="3oM_SC" value="just" />
+                    </node>
+                    <node concept="3oM_SD" id="4jd8IzH_1dH" role="1PaTwD">
+                      <property role="3oM_SC" value="null" />
+                    </node>
+                    <node concept="3oM_SD" id="4jd8IzH_1dI" role="1PaTwD">
+                      <property role="3oM_SC" value="literals," />
+                    </node>
+                    <node concept="3oM_SD" id="4jd8IzH_1dJ" role="1PaTwD">
+                      <property role="3oM_SC" value="but" />
+                    </node>
+                    <node concept="3oM_SD" id="4jd8IzH_1dK" role="1PaTwD">
+                      <property role="3oM_SC" value="I" />
+                    </node>
+                    <node concept="3oM_SD" id="4jd8IzH_1dL" role="1PaTwD">
+                      <property role="3oM_SC" value="don't" />
+                    </node>
+                    <node concept="3oM_SD" id="4jd8IzH_1dM" role="1PaTwD">
+                      <property role="3oM_SC" value="want" />
+                    </node>
+                    <node concept="3oM_SD" id="4jd8IzH_1dN" role="1PaTwD">
+                      <property role="3oM_SC" value="to" />
+                    </node>
+                    <node concept="3oM_SD" id="4jd8IzH_1dO" role="1PaTwD">
+                      <property role="3oM_SC" value="involve" />
+                    </node>
+                    <node concept="3oM_SD" id="4jd8IzH_1dP" role="1PaTwD">
+                      <property role="3oM_SC" value="the" />
+                    </node>
+                    <node concept="3oM_SD" id="4jd8IzH_1dQ" role="1PaTwD">
+                      <property role="3oM_SC" value="type" />
+                    </node>
+                    <node concept="3oM_SD" id="4jd8IzH_1dR" role="1PaTwD">
+                      <property role="3oM_SC" value="system" />
+                    </node>
+                    <node concept="3oM_SD" id="4jd8IzH_1dS" role="1PaTwD">
+                      <property role="3oM_SC" value="here)." />
+                    </node>
+                  </node>
+                </node>
+                <node concept="3cpWs6" id="4jd8IzH_1dT" role="3cqZAp">
+                  <node concept="3clFbT" id="4jd8IzH_3k6" role="3cqZAk" />
+                </node>
+              </node>
+              <node concept="2OqwBi" id="4jd8IzH_1dV" role="3clFbw">
+                <node concept="2OqwBi" id="4jd8IzH_1dW" role="2Oq$k0">
+                  <node concept="37vLTw" id="4jd8IzH_1dX" role="2Oq$k0">
+                    <ref role="3cqZAo" node="4jd8IzH_1bB" resolve="cast" />
+                  </node>
+                  <node concept="3TrEf2" id="4jd8IzH_1dY" role="2OqNvi">
+                    <ref role="3Tt5mk" to="tpee:f_0QFTc" resolve="expression" />
+                  </node>
+                </node>
+                <node concept="1mIQ4w" id="4jd8IzH_1dZ" role="2OqNvi">
+                  <node concept="chp4Y" id="4jd8IzH_1e0" role="cj9EA">
+                    <ref role="cht4Q" to="tpee:f_0Nm5B" resolve="NullLiteral" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbH" id="4jd8IzH_1e1" role="3cqZAp" />
+            <node concept="3cpWs6" id="4jd8IzH_3yV" role="3cqZAp">
+              <node concept="3y3z36" id="4jd8IzH_4XA" role="3cqZAk">
+                <node concept="10Nm6u" id="4jd8IzH_4YD" role="3uHU7w" />
+                <node concept="2OqwBi" id="4jd8IzH_44j" role="3uHU7B">
+                  <node concept="Jnkvi" id="4jd8IzH_3_u" role="2Oq$k0">
+                    <ref role="1M0zk5" node="4jd8IzH_1eN" resolve="tpe" />
+                  </node>
+                  <node concept="3TrEf2" id="4jd8IzH_4F3" role="2OqNvi">
+                    <ref role="3Tt5mk" to="tp25:g$ehGDh" resolve="concept" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="JncvC" id="4jd8IzH_1eN" role="JncvA">
+            <property role="TrG5h" value="tpe" />
+            <node concept="2jxLKc" id="4jd8IzH_1eO" role="1tU5fm" />
+          </node>
+          <node concept="2OqwBi" id="4jd8IzH_1eP" role="JncvB">
+            <node concept="37vLTw" id="4jd8IzH_1eQ" role="2Oq$k0">
+              <ref role="3cqZAo" node="4jd8IzH_1bB" resolve="cast" />
+            </node>
+            <node concept="3TrEf2" id="4jd8IzH_1eR" role="2OqNvi">
+              <ref role="3Tt5mk" to="tpee:f_0QFTb" resolve="type" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="4jd8IzH_5dD" role="3cqZAp" />
+        <node concept="3cpWs6" id="4jd8IzH_5kK" role="3cqZAp">
+          <node concept="3clFbT" id="4jd8IzH_5ne" role="3cqZAk" />
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="4jd8IzH_12R" role="1B3o_S" />
+      <node concept="10P_77" id="4jd8IzH_158" role="3clF45" />
+      <node concept="37vLTG" id="4jd8IzH_1bB" role="3clF46">
+        <property role="TrG5h" value="cast" />
+        <node concept="3Tqbb2" id="4jd8IzH_1bA" role="1tU5fm">
+          <ref role="ehGHo" to="tpee:f_0QFTa" resolve="CastExpression" />
+        </node>
+      </node>
+    </node>
+    <node concept="3Tm1VV" id="4jd8IzHzPzG" role="1B3o_S" />
   </node>
 </model>
 

--- a/code/languages/org.mpsqa.lint/solutions/org.mpsqa.lint.test/models/org.mpsqa.lint.test@tests.mps
+++ b/code/languages/org.mpsqa.lint/solutions/org.mpsqa.lint.test/models/org.mpsqa.lint.test@tests.mps
@@ -1,0 +1,209 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:2308332d-4f9c-4cb3-83a8-90d1adac76cf(org.mpsqa.lint.test@tests)">
+  <persistence version="9" />
+  <languages>
+    <use id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test" version="6" />
+    <use id="f61473f9-130f-42f6-b98d-6c438812c2f6" name="jetbrains.mps.baseLanguage.unitTest" version="1" />
+    <use id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel" version="19" />
+  </languages>
+  <imports>
+    <import index="ewdl" ref="r:8eaf8ae8-8265-4cc3-8b13-e131c55d1473(org.mpsqa.lint.mps_lang.linters_library.expressions)" />
+    <import index="mhbf" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.model(MPS.OpenAPI/)" />
+    <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" />
+  </imports>
+  <registry>
+    <language id="8585453e-6bfb-4d80-98de-b16074f1d86c" name="jetbrains.mps.lang.test">
+      <concept id="5097124989038916362" name="jetbrains.mps.lang.test.structure.TestInfo" flags="ng" index="2XOHcx">
+        <property id="5097124989038916363" name="projectPath" index="2XOHcw" />
+      </concept>
+      <concept id="1216913645126" name="jetbrains.mps.lang.test.structure.NodesTestCase" flags="lg" index="1lH9Xt">
+        <child id="1217501822150" name="nodesToCheck" index="1SKRRt" />
+        <child id="1217501895093" name="testMethods" index="1SL9yI" />
+      </concept>
+      <concept id="1216989428737" name="jetbrains.mps.lang.test.structure.TestNode" flags="ng" index="1qefOq">
+        <child id="1216989461394" name="nodeToCheck" index="1qenE9" />
+      </concept>
+      <concept id="1210673684636" name="jetbrains.mps.lang.test.structure.TestNodeAnnotation" flags="ng" index="3xLA65" />
+      <concept id="1210674524691" name="jetbrains.mps.lang.test.structure.TestNodeReference" flags="nn" index="3xONca">
+        <reference id="1210674534086" name="declaration" index="3xOPvv" />
+      </concept>
+      <concept id="1225978065297" name="jetbrains.mps.lang.test.structure.SimpleNodeTest" flags="ng" index="1LZb2c" />
+    </language>
+    <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1081236700938" name="jetbrains.mps.baseLanguage.structure.StaticMethodDeclaration" flags="ig" index="2YIFZL" />
+      <concept id="1081236700937" name="jetbrains.mps.baseLanguage.structure.StaticMethodCall" flags="nn" index="2YIFZM">
+        <reference id="1144433194310" name="classConcept" index="1Pybhc" />
+      </concept>
+      <concept id="1070534058343" name="jetbrains.mps.baseLanguage.structure.NullLiteral" flags="nn" index="10Nm6u" />
+      <concept id="1070534934090" name="jetbrains.mps.baseLanguage.structure.CastExpression" flags="nn" index="10QFUN">
+        <child id="1070534934091" name="type" index="10QFUM" />
+        <child id="1070534934092" name="expression" index="10QFUP" />
+      </concept>
+      <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
+        <child id="1068431790190" name="initializer" index="33vP2m" />
+      </concept>
+      <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
+        <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
+      </concept>
+      <concept id="1068498886292" name="jetbrains.mps.baseLanguage.structure.ParameterDeclaration" flags="ir" index="37vLTG" />
+      <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
+        <child id="5680397130376446158" name="type" index="1tU5fm" />
+      </concept>
+      <concept id="1068580123132" name="jetbrains.mps.baseLanguage.structure.BaseMethodDeclaration" flags="ng" index="3clF44">
+        <child id="1068580123133" name="returnType" index="3clF45" />
+        <child id="1068580123134" name="parameter" index="3clF46" />
+        <child id="1068580123135" name="body" index="3clF47" />
+      </concept>
+      <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
+        <child id="1068581517665" name="statement" index="3cqZAp" />
+      </concept>
+      <concept id="1068581242864" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclarationStatement" flags="nn" index="3cpWs8">
+        <child id="1068581242865" name="localVariableDeclaration" index="3cpWs9" />
+      </concept>
+      <concept id="1068581242863" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclaration" flags="nr" index="3cpWsn" />
+      <concept id="1068581517677" name="jetbrains.mps.baseLanguage.structure.VoidType" flags="in" index="3cqZAl" />
+      <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ng" index="1ndlxa">
+        <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
+        <child id="1068499141038" name="actualArgument" index="37wK5m" />
+      </concept>
+      <concept id="1107535904670" name="jetbrains.mps.baseLanguage.structure.ClassifierType" flags="in" index="3uibUv">
+        <reference id="1107535924139" name="classifier" index="3uigEE" />
+      </concept>
+      <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ng" index="1B3ioH">
+        <child id="1178549979242" name="visibility" index="1B3o_S" />
+      </concept>
+      <concept id="1146644602865" name="jetbrains.mps.baseLanguage.structure.PublicVisibility" flags="nn" index="3Tm1VV" />
+    </language>
+    <language id="f61473f9-130f-42f6-b98d-6c438812c2f6" name="jetbrains.mps.baseLanguage.unitTest">
+      <concept id="1171981022339" name="jetbrains.mps.baseLanguage.unitTest.structure.AssertTrue" flags="nn" index="3vwNmj">
+        <child id="1171981057159" name="condition" index="3vwVQn" />
+      </concept>
+      <concept id="1171983834376" name="jetbrains.mps.baseLanguage.unitTest.structure.AssertFalse" flags="nn" index="3vFxKo">
+        <child id="1171983854940" name="condition" index="3vFALc" />
+      </concept>
+    </language>
+    <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
+      <concept id="1138055754698" name="jetbrains.mps.lang.smodel.structure.SNodeType" flags="in" index="3Tqbb2">
+        <reference id="1138405853777" name="concept" index="ehGHo" />
+      </concept>
+    </language>
+    <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
+        <child id="5169995583184591170" name="smodelAttribute" index="lGtFl" />
+      </concept>
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
+        <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+    </language>
+  </registry>
+  <node concept="1lH9Xt" id="4jd8IzHyHXF">
+    <property role="TrG5h" value="CastsToNodeTest" />
+    <node concept="1LZb2c" id="4jd8IzHyOoo" role="1SL9yI">
+      <property role="TrG5h" value="casts" />
+      <node concept="3cqZAl" id="4jd8IzHyOop" role="3clF45" />
+      <node concept="3clFbS" id="4jd8IzHyOot" role="3clF47">
+        <node concept="3vwNmj" id="4jd8IzH_ugY" role="3cqZAp">
+          <node concept="2YIFZM" id="4jd8IzH_v6x" role="3vwVQn">
+            <ref role="37wK5l" to="ewdl:4jd8IzH_176" resolve="isDubiousCast" />
+            <ref role="1Pybhc" to="ewdl:4jd8IzHzPzF" resolve="NodeCasts" />
+            <node concept="3xONca" id="4jd8IzH_vn7" role="37wK5m">
+              <ref role="3xOPvv" node="4jd8IzHyOn0" resolve="bad" />
+            </node>
+          </node>
+        </node>
+        <node concept="3vFxKo" id="4jd8IzH_vV2" role="3cqZAp">
+          <node concept="2YIFZM" id="4jd8IzH_vXi" role="3vFALc">
+            <ref role="37wK5l" to="ewdl:4jd8IzH_176" resolve="isDubiousCast" />
+            <ref role="1Pybhc" to="ewdl:4jd8IzHzPzF" resolve="NodeCasts" />
+            <node concept="3xONca" id="4jd8IzH_vXJ" role="37wK5m">
+              <ref role="3xOPvv" node="4jd8IzH$Mgr" resolve="goodNull" />
+            </node>
+          </node>
+        </node>
+        <node concept="3vFxKo" id="4jd8IzH_vZw" role="3cqZAp">
+          <node concept="2YIFZM" id="4jd8IzH_vZx" role="3vFALc">
+            <ref role="37wK5l" to="ewdl:4jd8IzH_176" resolve="isDubiousCast" />
+            <ref role="1Pybhc" to="ewdl:4jd8IzHzPzF" resolve="NodeCasts" />
+            <node concept="3xONca" id="4jd8IzH_vZy" role="37wK5m">
+              <ref role="3xOPvv" node="4jd8IzH$Mhg" resolve="goodNoConcept" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1qefOq" id="4jd8IzHyHXG" role="1SKRRt">
+      <node concept="2YIFZL" id="4jd8IzHyOe0" role="1qenE9">
+        <property role="TrG5h" value="someMethod" />
+        <node concept="37vLTG" id="4jd8IzHyOe8" role="3clF46">
+          <property role="TrG5h" value="snodeParam" />
+          <node concept="3uibUv" id="4jd8IzHyOhB" role="1tU5fm">
+            <ref role="3uigEE" to="mhbf:~SNode" resolve="SNode" />
+          </node>
+        </node>
+        <node concept="37vLTG" id="4jd8IzHyOhK" role="3clF46">
+          <property role="TrG5h" value="nodeParam" />
+          <node concept="3Tqbb2" id="4jd8IzHyOif" role="1tU5fm" />
+        </node>
+        <node concept="3cqZAl" id="4jd8IzHyOe1" role="3clF45" />
+        <node concept="3Tm1VV" id="4jd8IzHyOe2" role="1B3o_S" />
+        <node concept="3clFbS" id="4jd8IzHyOe3" role="3clF47">
+          <node concept="3cpWs8" id="4jd8IzHyOiv" role="3cqZAp">
+            <node concept="3cpWsn" id="4jd8IzHyOiy" role="3cpWs9">
+              <property role="TrG5h" value="bad" />
+              <node concept="3Tqbb2" id="4jd8IzHyOiu" role="1tU5fm">
+                <ref role="ehGHo" to="tpck:4uZwTti3_$T" resolve="Attribute" />
+              </node>
+              <node concept="10QFUN" id="4jd8IzHyOmi" role="33vP2m">
+                <node concept="37vLTw" id="4jd8IzHyOiY" role="10QFUP">
+                  <ref role="3cqZAo" node="4jd8IzHyOe8" resolve="snodeParam" />
+                </node>
+                <node concept="3Tqbb2" id="4jd8IzHyOmj" role="10QFUM">
+                  <ref role="ehGHo" to="tpck:4uZwTti3_$T" resolve="Attribute" />
+                </node>
+                <node concept="3xLA65" id="4jd8IzHyOn0" role="lGtFl">
+                  <property role="TrG5h" value="bad" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3cpWs8" id="4jd8IzH$McX" role="3cqZAp">
+            <node concept="3cpWsn" id="4jd8IzH$Md0" role="3cpWs9">
+              <property role="TrG5h" value="nullAsNode" />
+              <node concept="3Tqbb2" id="4jd8IzH$McV" role="1tU5fm">
+                <ref role="ehGHo" to="tpck:4uZwTti3_$T" resolve="Attribute" />
+              </node>
+              <node concept="10QFUN" id="4jd8IzH$MdS" role="33vP2m">
+                <node concept="3Tqbb2" id="4jd8IzH$Mek" role="10QFUM">
+                  <ref role="ehGHo" to="tpck:4uZwTti3_$T" resolve="Attribute" />
+                </node>
+                <node concept="10Nm6u" id="4jd8IzH$MdA" role="10QFUP" />
+                <node concept="3xLA65" id="4jd8IzH$Mgr" role="lGtFl">
+                  <property role="TrG5h" value="goodNull" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3cpWs8" id="4jd8IzH$Mha" role="3cqZAp">
+            <node concept="3cpWsn" id="4jd8IzH$Mhb" role="3cpWs9">
+              <property role="TrG5h" value="snodeAsNode" />
+              <node concept="3Tqbb2" id="4jd8IzH$Mhc" role="1tU5fm" />
+              <node concept="10QFUN" id="4jd8IzH$Mhd" role="33vP2m">
+                <node concept="3Tqbb2" id="4jd8IzH$Mhe" role="10QFUM" />
+                <node concept="37vLTw" id="4jd8IzH$MO_" role="10QFUP">
+                  <ref role="3cqZAo" node="4jd8IzHyOe8" resolve="snodeParam" />
+                </node>
+                <node concept="3xLA65" id="4jd8IzH$Mhg" role="lGtFl">
+                  <property role="TrG5h" value="goodNoConcept" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="2XOHcx" id="4jd8IzHzCko">
+    <property role="2XOHcw" value="${mpsqa.home}/code/languages/org.mpsqa.lint" />
+  </node>
+</model>
+

--- a/code/languages/org.mpsqa.lint/solutions/org.mpsqa.lint.test/org.mpsqa.lint.test.msd
+++ b/code/languages/org.mpsqa.lint/solutions/org.mpsqa.lint.test/org.mpsqa.lint.test.msd
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<solution name="org.mpsqa.lint.test" uuid="8dea0738-32a6-4d3d-bd7c-7b5fd43da198" moduleVersion="0" compileInMPS="true">
+  <models>
+    <modelRoot contentPath="${module}" type="default">
+      <sourceRoot location="models" />
+    </modelRoot>
+  </models>
+  <facets>
+    <facet type="java">
+      <classes generated="true" path="${module}/classes_gen" />
+    </facet>
+  </facets>
+  <sourcePath />
+  <dependencies>
+    <dependency reexport="false">12a40499-ed72-4b23-9437-358c4217c97b(org.mpsqa.lint.mps_lang.linters_library)</dependency>
+    <dependency reexport="false">8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)</dependency>
+    <dependency reexport="false">ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)</dependency>
+  </dependencies>
+  <languageVersions>
+    <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="12" />
+    <language slang="l:443f4c36-fcf5-4eb6-9500-8d06ed259e3e:jetbrains.mps.baseLanguage.classifiers" version="0" />
+    <language slang="l:fd392034-7849-419d-9071-12563d152375:jetbrains.mps.baseLanguage.closures" version="0" />
+    <language slang="l:83888646-71ce-4f1c-9c53-c54016f6ad4f:jetbrains.mps.baseLanguage.collections" version="1" />
+    <language slang="l:f61473f9-130f-42f6-b98d-6c438812c2f6:jetbrains.mps.baseLanguage.unitTest" version="1" />
+    <language slang="l:eb56ebf4-df56-438e-af06-fc1cd08b495a:jetbrains.mps.kotlin.smodel" version="0" />
+    <language slang="l:ceab5195-25ea-4f22-9b92-103b95ca8c0c:jetbrains.mps.lang.core" version="2" />
+    <language slang="l:446c26eb-2b7b-4bf0-9b35-f83fa582753e:jetbrains.mps.lang.modelapi" version="0" />
+    <language slang="l:7866978e-a0f0-4cc7-81bc-4d213d9375e1:jetbrains.mps.lang.smodel" version="19" />
+    <language slang="l:8585453e-6bfb-4d80-98de-b16074f1d86c:jetbrains.mps.lang.test" version="6" />
+    <language slang="l:9ded098b-ad6a-4657-bfd9-48636cfe8bc3:jetbrains.mps.lang.traceable" version="0" />
+  </languageVersions>
+  <dependencyVersions>
+    <module reference="3f233e7f-b8a6-46d2-a57f-795d56775243(Annotations)" version="0" />
+    <module reference="6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)" version="0" />
+    <module reference="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)" version="0" />
+    <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
+    <module reference="ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)" version="0" />
+    <module reference="12a40499-ed72-4b23-9437-358c4217c97b(org.mpsqa.lint.mps_lang.linters_library)" version="0" />
+    <module reference="8dea0738-32a6-4d3d-bd7c-7b5fd43da198(org.mpsqa.lint.test)" version="0" />
+  </dependencyVersions>
+</solution>
+

--- a/code/languages/org.mpsqa.mutant/tests/test.org.mpsqa.mutant.demolang/models/test.org.mpsqa.mutant.demolang._010_smoke_testcode.mps
+++ b/code/languages/org.mpsqa.mutant/tests/test.org.mpsqa.mutant.demolang/models/test.org.mpsqa.mutant.demolang._010_smoke_testcode.mps
@@ -152,7 +152,7 @@
       </node>
     </node>
     <node concept="3Qo$EU" id="5nCCIAzzQd0" role="3Qp43q">
-      <ref role="3Qo$EX" node="4eFGY40pl9N" resolve="_010_depth_1" />
+      <ref role="3Qo$EX" node="4eFGY40pl9N" />
     </node>
   </node>
   <node concept="13QL6U" id="4DkAay7OKhv">
@@ -175,7 +175,7 @@
       </node>
     </node>
     <node concept="3Qo$EU" id="4DkAay7OKhA" role="3Qp43q">
-      <ref role="3Qo$EX" node="4eFGY40qqTd" resolve="_020_depth_2" />
+      <ref role="3Qo$EX" node="4eFGY40qqTd" />
     </node>
   </node>
   <node concept="13QL6U" id="4DkAay7PMca">
@@ -198,7 +198,7 @@
       </node>
     </node>
     <node concept="3Qo$EU" id="4DkAay7PMch" role="3Qp43q">
-      <ref role="3Qo$EX" node="4eFGY40r84e" resolve="_030_depth_3" />
+      <ref role="3Qo$EX" node="4eFGY40r84e" />
     </node>
   </node>
   <node concept="13QL6U" id="5jW7oooqZww">
@@ -221,7 +221,7 @@
       </node>
     </node>
     <node concept="3Qo$EU" id="5jW7oooqZwB" role="3Qp43q">
-      <ref role="3Qo$EX" node="5jW7oooqZwI" resolve="_040_concept_with_two_children_depth_2" />
+      <ref role="3Qo$EX" node="5jW7oooqZwI" />
     </node>
   </node>
   <node concept="13W42U" id="5jW7oooqZwI">

--- a/code/languages/org.mpsqa.mutant/tests/test.org.mpsqa.mutant.demolang/models/test.org.mpsqa.mutant.demolang._020_smoke_constraints_testcode.mps
+++ b/code/languages/org.mpsqa.mutant/tests/test.org.mpsqa.mutant.demolang/models/test.org.mpsqa.mutant.demolang._020_smoke_constraints_testcode.mps
@@ -84,7 +84,7 @@
       </node>
     </node>
     <node concept="3Qo$EU" id="4DkAay89m$z" role="3Qp43q">
-      <ref role="3Qo$EX" node="4DkAay89oE0" resolve="_010_children_constraints" />
+      <ref role="3Qo$EX" node="4DkAay89oE0" />
     </node>
     <node concept="3dIY$q" id="4DkAay89yWf" role="3dD9PC">
       <node concept="1Xw6AR" id="4DkAay89yWh" role="3dIY_E">


### PR DESCRIPTION
* Check allows to cast to `node<>`, or cast `null` to `node<SomeConcept>`.
* Tests for the check added, not running as part of the build (not on this branch, only on master).