### PR TITLE
Update PlantUML to version 2023.13 (ASL license)

### DIFF
--- a/code/languages/org.mpsqa.arch/solutions/org.mpsqa.arch.pluginSolution/models/org.mpsqa.arch.pluginSolution.plugin.mps
+++ b/code/languages/org.mpsqa.arch/solutions/org.mpsqa.arch.pluginSolution/models/org.mpsqa.arch.pluginSolution.plugin.mps
@@ -12,22 +12,16 @@
   <imports>
     <import index="81o" ref="96212ac2-423f-4cfb-b211-b58d0546b6bf/java:net.sourceforge.plantuml(org.mpsqa.arch.pluginSolution/)" />
     <import index="ryx8" ref="r:d0c25d1d-f21e-42b4-b319-5eef0584d5ca(org.mpsqa.arch.structure)" />
-    <import index="94i" ref="96212ac2-423f-4cfb-b211-b58d0546b6bf/java:net.sourceforge.plantuml.security(org.mpsqa.arch.pluginSolution/)" />
     <import index="guwi" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.io(JDK/)" />
     <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" />
-    <import index="asup" ref="96212ac2-423f-4cfb-b211-b58d0546b6bf/java:net.sourceforge.plantuml.core(org.mpsqa.arch.pluginSolution/)" />
     <import index="dxuu" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:javax.swing(JDK/)" />
     <import index="jan3" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.awt.image(JDK/)" />
     <import index="oqcp" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:javax.imageio(JDK/)" />
     <import index="qkt" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.openapi.actionSystem(MPS.IDEA/)" />
-    <import index="tp25" ref="r:00000000-0000-4000-0000-011c89590301(jetbrains.mps.lang.smodel.structure)" />
-    <import index="xlb7" ref="r:cf42fd0a-68d2-493b-8b77-961658617704(jetbrains.mps.lang.modelapi.behavior)" />
-    <import index="lui2" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.module(MPS.OpenAPI/)" />
     <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" />
     <import index="z60i" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.awt(JDK/)" />
     <import index="gsia" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:javax.swing.event(JDK/)" />
     <import index="hyam" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.awt.event(JDK/)" />
-    <import index="r791" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:javax.swing.text(JDK/)" />
     <import index="4nm9" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.openapi.project(MPS.IDEA/)" />
     <import index="tprs" ref="r:00000000-0000-4000-0000-011c895904a4(jetbrains.mps.ide.actions)" implicit="true" />
     <import index="33ny" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.util(JDK/)" implicit="true" />

--- a/code/languages/org.mpsqa.arch/solutions/org.mpsqa.arch.pluginSolution/org.mpsqa.arch.pluginSolution.msd
+++ b/code/languages/org.mpsqa.arch/solutions/org.mpsqa.arch.pluginSolution/org.mpsqa.arch.pluginSolution.msd
@@ -8,7 +8,7 @@
       <sourceRoot location="." />
     </modelRoot>
     <modelRoot contentPath="${module}/lib" type="java_classes">
-      <sourceRoot location="plantuml-epl-1.2023.13.jar" />
+      <sourceRoot location="plantuml-asl-1.2023.13.jar" />
     </modelRoot>
   </models>
   <facets>
@@ -17,7 +17,7 @@
     </facet>
   </facets>
   <stubModelEntries>
-    <stubModelEntry path="${module}/lib/plantuml-epl-1.2023.13.jar" />
+    <stubModelEntry path="${module}/lib/plantuml-asl-1.2023.13.jar" />
   </stubModelEntries>
   <sourcePath />
   <dependencies>

--- a/code/languages/org.mpsqa.arch/solutions/org.mpsqa.arch.pluginSolution/org.mpsqa.arch.pluginSolution.msd
+++ b/code/languages/org.mpsqa.arch/solutions/org.mpsqa.arch.pluginSolution/org.mpsqa.arch.pluginSolution.msd
@@ -8,7 +8,7 @@
       <sourceRoot location="." />
     </modelRoot>
     <modelRoot contentPath="${module}/lib" type="java_classes">
-      <sourceRoot location="plantuml-1.2022.6.jar" />
+      <sourceRoot location="plantuml-epl-1.2023.13.jar" />
     </modelRoot>
   </models>
   <facets>
@@ -17,7 +17,7 @@
     </facet>
   </facets>
   <stubModelEntries>
-    <stubModelEntry path="${module}/lib/plantuml-1.2022.6.jar" />
+    <stubModelEntry path="${module}/lib/plantuml-epl-1.2023.13.jar" />
   </stubModelEntries>
   <sourcePath />
   <dependencies>

--- a/code/languages/org.mpsqa.build/solutions/org.mpsqa.build/models/org.mpsqa.build._060_arch_build.mps
+++ b/code/languages/org.mpsqa.build/solutions/org.mpsqa.build/models/org.mpsqa.build._060_arch_build.mps
@@ -202,8 +202,8 @@
                 <property role="2Ry0Am" value="org.mpsqa.arch.pluginSolution" />
                 <node concept="2Ry0Ak" id="50Wzfz4sDIC" role="2Ry0An">
                   <property role="2Ry0Am" value="lib" />
-                  <node concept="2Ry0Ak" id="4Zex1q$69zF" role="2Ry0An">
-                    <property role="2Ry0Am" value="plantuml-epl-1.2023.13.jar" />
+                  <node concept="2Ry0Ak" id="7PMJ7Uztwp3" role="2Ry0An">
+                    <property role="2Ry0Am" value="plantuml-asl-1.2023.13.jar" />
                   </node>
                 </node>
               </node>
@@ -444,8 +444,8 @@
                   <property role="2Ry0Am" value="org.mpsqa.arch.pluginSolution" />
                   <node concept="2Ry0Ak" id="6ST145H7UsV" role="2Ry0An">
                     <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="6ST145H7UsW" role="2Ry0An">
-                      <property role="2Ry0Am" value="plantuml-epl-1.2023.13.jar" />
+                    <node concept="2Ry0Ak" id="7PMJ7UztwOq" role="2Ry0An">
+                      <property role="2Ry0Am" value="plantuml-asl-1.2023.13.jar" />
                     </node>
                   </node>
                 </node>

--- a/code/languages/org.mpsqa.build/solutions/org.mpsqa.build/models/org.mpsqa.build._060_arch_build.mps
+++ b/code/languages/org.mpsqa.build/solutions/org.mpsqa.build/models/org.mpsqa.build._060_arch_build.mps
@@ -202,8 +202,8 @@
                 <property role="2Ry0Am" value="org.mpsqa.arch.pluginSolution" />
                 <node concept="2Ry0Ak" id="50Wzfz4sDIC" role="2Ry0An">
                   <property role="2Ry0Am" value="lib" />
-                  <node concept="2Ry0Ak" id="1$4Qbt$B9yr" role="2Ry0An">
-                    <property role="2Ry0Am" value="plantuml-1.2022.6.jar" />
+                  <node concept="2Ry0Ak" id="4Zex1q$69zF" role="2Ry0An">
+                    <property role="2Ry0Am" value="plantuml-epl-1.2023.13.jar" />
                   </node>
                 </node>
               </node>
@@ -396,25 +396,6 @@
             <ref role="3bR37D" node="50Wzfz4shzn" resolve="org.mpsqa.arch" />
           </node>
         </node>
-        <node concept="1SiIV0" id="50Wzfz4sh_t" role="3bR37C">
-          <node concept="1BurEX" id="50Wzfz4sh_u" role="1SiIV1">
-            <node concept="398BVA" id="50Wzfz4sh_g" role="1BurEY">
-              <ref role="398BVh" node="50Wzfz4shz5" resolve="mpsqa.arch.home" />
-              <node concept="2Ry0Ak" id="50Wzfz4sh_h" role="iGT6I">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="50Wzfz4sh_i" role="2Ry0An">
-                  <property role="2Ry0Am" value="org.mpsqa.arch.pluginSolution" />
-                  <node concept="2Ry0Ak" id="50Wzfz4sh_j" role="2Ry0An">
-                    <property role="2Ry0Am" value="lib" />
-                    <node concept="2Ry0Ak" id="1$4Qbt$B9z4" role="2Ry0An">
-                      <property role="2Ry0Am" value="plantuml-1.2022.6.jar" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
         <node concept="1BupzO" id="50Wzfz4sh_E" role="3bR31x">
           <property role="3ZfqAx" value="models" />
           <property role="1Hdu6h" value="true" />
@@ -450,6 +431,25 @@
             </node>
             <node concept="3qWCbU" id="1$4Qbt$B9zq" role="3LXTna">
               <property role="3qWCbO" value="icons/**" />
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="6ST145H7Ut5" role="3bR37C">
+          <node concept="1BurEX" id="6ST145H7Ut6" role="1SiIV1">
+            <node concept="398BVA" id="6ST145H7UsS" role="1BurEY">
+              <ref role="398BVh" node="50Wzfz4shz5" resolve="mpsqa.arch.home" />
+              <node concept="2Ry0Ak" id="6ST145H7UsT" role="iGT6I">
+                <property role="2Ry0Am" value="solutions" />
+                <node concept="2Ry0Ak" id="6ST145H7UsU" role="2Ry0An">
+                  <property role="2Ry0Am" value="org.mpsqa.arch.pluginSolution" />
+                  <node concept="2Ry0Ak" id="6ST145H7UsV" role="2Ry0An">
+                    <property role="2Ry0Am" value="lib" />
+                    <node concept="2Ry0Ak" id="6ST145H7UsW" role="2Ry0An">
+                      <property role="2Ry0Am" value="plantuml-epl-1.2023.13.jar" />
+                    </node>
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>


### PR DESCRIPTION
Because of licensing issues, we have to use the version of PlantUML that uses the EPL license.