### PR TITLE
Separate build of base and testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ test_gen.caches
 # RCP
 artifacts/*
 build/*
+!/build/scripts/build_all_scripts.xml

--- a/build/scripts/build_all_scripts.xml
+++ b/build/scripts/build_all_scripts.xml
@@ -51,7 +51,7 @@
     <delete dir="${build.layout}" />
   </target>
   
-  <target name="compileJava" depends="java.compile.org.mpsqa.build.allScripts, java.compile.org.mpsqa.build, java.compile.org.mpsqa.build.sandboxes, java.compile.org.mpsqa.clones.build, java.compile.org.mpsqa.lint.build, java.compile.org.mpsqa.testing.tests.build" />
+  <target name="compileJava" depends="java.compile.org.mpsqa.build.allScripts, java.compile.org.mpsqa.base.build, java.compile.org.mpsqa.build, java.compile.org.mpsqa.build.sandboxes, java.compile.org.mpsqa.clones.build, java.compile.org.mpsqa.lint.build, java.compile.org.mpsqa.testing.tests.build" />
   
   <target name="processResources" />
   
@@ -156,6 +156,7 @@
       <library file="${artifacts.mps}/languages/util/jetbrains.mps.runtime.jar" />
       <library file="${artifacts.mps}/languages/xml/jetbrains.mps.core.xml.jar" />
       <chunk>
+        <module file="${basedir}/code/languages/org.mpsqa.base/solutions/org.mpsqa.base.build/org.mpsqa.base.build.msd" />
         <module file="${basedir}/code/languages/org.mpsqa.build/solutions/org.mpsqa.build/org.mpsqa.build.msd" />
         <module file="${basedir}/code/languages/org.mpsqa.build/solutions/org.mpsqa.build.allScripts/org.mpsqa.build.allScripts.msd" />
         <module file="${basedir}/code/languages/org.mpsqa.build/solutions/org.mpsqa.build.sandboxes/org.mpsqa.build.sandboxes.msd" />
@@ -175,7 +176,7 @@
   
   <target name="makeDependents" />
   
-  <target name="java.compile.org.mpsqa.build.allScripts">
+  <target name="java.compile.org.mpsqa.build.allScripts" depends="java.compile.org.mpsqa.build">
     <mkdir dir="${basedir}/code/languages/org.mpsqa.build/solutions/org.mpsqa.build.allScripts/source_gen" />
     <mkdir dir="${build.tmp}/java/out/org.mpsqa.build.allScripts" />
     <javac destdir="${build.tmp}/java/out/org.mpsqa.build.allScripts" fork="false" encoding="utf8" includeantruntime="false" debug="true">
@@ -183,14 +184,29 @@
       <src>
         <path location="${basedir}/code/languages/org.mpsqa.build/solutions/org.mpsqa.build.allScripts/source_gen" />
       </src>
-      <classpath />
+      <classpath path="${build.tmp}/java/out/org.mpsqa.build" />
     </javac>
     <copy todir="${build.tmp}/java/out/org.mpsqa.build.allScripts">
       <fileset dir="${basedir}/code/languages/org.mpsqa.build/solutions/org.mpsqa.build.allScripts/source_gen" excludes="**/*.java" />
     </copy>
   </target>
   
-  <target name="java.compile.org.mpsqa.build">
+  <target name="java.compile.org.mpsqa.base.build">
+    <mkdir dir="${basedir}/code/languages/org.mpsqa.base/solutions/org.mpsqa.base.build/source_gen" />
+    <mkdir dir="${build.tmp}/java/out/org.mpsqa.base.build" />
+    <javac destdir="${build.tmp}/java/out/org.mpsqa.base.build" fork="false" encoding="utf8" includeantruntime="false" debug="true">
+      <compilerarg value="-Xlint:none" />
+      <src>
+        <path location="${basedir}/code/languages/org.mpsqa.base/solutions/org.mpsqa.base.build/source_gen" />
+      </src>
+      <classpath />
+    </javac>
+    <copy todir="${build.tmp}/java/out/org.mpsqa.base.build">
+      <fileset dir="${basedir}/code/languages/org.mpsqa.base/solutions/org.mpsqa.base.build/source_gen" excludes="**/*.java" />
+    </copy>
+  </target>
+  
+  <target name="java.compile.org.mpsqa.build" depends="java.compile.org.mpsqa.base.build">
     <mkdir dir="${basedir}/code/languages/org.mpsqa.build/solutions/org.mpsqa.build/source_gen" />
     <mkdir dir="${build.tmp}/java/out/org.mpsqa.build" />
     <javac destdir="${build.tmp}/java/out/org.mpsqa.build" fork="false" encoding="utf8" includeantruntime="false" debug="true">
@@ -198,14 +214,14 @@
       <src>
         <path location="${basedir}/code/languages/org.mpsqa.build/solutions/org.mpsqa.build/source_gen" />
       </src>
-      <classpath />
+      <classpath path="${build.tmp}/java/out/org.mpsqa.base.build" />
     </javac>
     <copy todir="${build.tmp}/java/out/org.mpsqa.build">
       <fileset dir="${basedir}/code/languages/org.mpsqa.build/solutions/org.mpsqa.build/source_gen" excludes="**/*.java" />
     </copy>
   </target>
   
-  <target name="java.compile.org.mpsqa.build.sandboxes" depends="java.compile.org.mpsqa.build">
+  <target name="java.compile.org.mpsqa.build.sandboxes" depends="java.compile.org.mpsqa.base.build, java.compile.org.mpsqa.build">
     <mkdir dir="${basedir}/code/languages/org.mpsqa.build/solutions/org.mpsqa.build.sandboxes/source_gen" />
     <mkdir dir="${build.tmp}/java/out/org.mpsqa.build.sandboxes" />
     <javac destdir="${build.tmp}/java/out/org.mpsqa.build.sandboxes" fork="false" encoding="utf8" includeantruntime="false" debug="true">
@@ -213,7 +229,10 @@
       <src>
         <path location="${basedir}/code/languages/org.mpsqa.build/solutions/org.mpsqa.build.sandboxes/source_gen" />
       </src>
-      <classpath path="${build.tmp}/java/out/org.mpsqa.build" />
+      <classpath>
+        <pathelement path="${build.tmp}/java/out/org.mpsqa.base.build" />
+        <pathelement path="${build.tmp}/java/out/org.mpsqa.build" />
+      </classpath>
     </javac>
     <copy todir="${build.tmp}/java/out/org.mpsqa.build.sandboxes">
       <fileset dir="${basedir}/code/languages/org.mpsqa.build/solutions/org.mpsqa.build.sandboxes/source_gen" excludes="**/*.java" />
@@ -266,6 +285,7 @@
   </target>
   
   <target name="cleanSources">
+    <delete dir="${basedir}/code/languages/org.mpsqa.base/solutions/org.mpsqa.base.build/source_gen" />
     <delete dir="${basedir}/code/languages/org.mpsqa.build/solutions/org.mpsqa.build/source_gen" />
     <delete dir="${basedir}/code/languages/org.mpsqa.build/solutions/org.mpsqa.build.allScripts/source_gen" />
     <delete dir="${basedir}/code/languages/org.mpsqa.build/solutions/org.mpsqa.build.sandboxes/source_gen" />

--- a/build/scripts/build_all_scripts.xml
+++ b/build/scripts/build_all_scripts.xml
@@ -51,7 +51,7 @@
     <delete dir="${build.layout}" />
   </target>
   
-  <target name="compileJava" depends="java.compile.org.mpsqa.build.allScripts, java.compile.org.mpsqa.base.build, java.compile.org.mpsqa.build, java.compile.org.mpsqa.build.sandboxes, java.compile.org.mpsqa.clones.build, java.compile.org.mpsqa.lint.build, java.compile.org.mpsqa.testing.tests.build" />
+  <target name="compileJava" depends="java.compile.org.mpsqa.build.allScripts, java.compile.org.mpsqa.base.build, java.compile.org.mpsqa.build, java.compile.org.mpsqa.build.sandboxes, java.compile.org.mpsqa.clones.build, java.compile.org.mpsqa.lint.build, java.compile.org.mpsqa.testing.build, java.compile.org.mpsqa.testing.tests.build" />
   
   <target name="processResources" />
   
@@ -162,6 +162,7 @@
         <module file="${basedir}/code/languages/org.mpsqa.build/solutions/org.mpsqa.build.sandboxes/org.mpsqa.build.sandboxes.msd" />
         <module file="${basedir}/code/languages/org.mpsqa.clones/solutions/org.mpsqa.clones.build/org.mpsqa.clones.build.msd" />
         <module file="${basedir}/code/languages/org.mpsqa.lint/solutions/org.mpsqa.lint.build/org.mpsqa.lint.build.msd" />
+        <module file="${basedir}/code/languages/org.mpsqa.testing/solutions/org.mpsqa.testing.build/org.mpsqa.testing.build.msd" />
         <module file="${basedir}/code/languages/org.mpsqa.testing/solutions/org.mpsqa.testing.tests.build/org.mpsqa.testing.tests.build.msd" />
       </chunk>
       <jvmargs>
@@ -206,7 +207,7 @@
     </copy>
   </target>
   
-  <target name="java.compile.org.mpsqa.build" depends="java.compile.org.mpsqa.base.build">
+  <target name="java.compile.org.mpsqa.build" depends="java.compile.org.mpsqa.base.build, java.compile.org.mpsqa.testing.build">
     <mkdir dir="${basedir}/code/languages/org.mpsqa.build/solutions/org.mpsqa.build/source_gen" />
     <mkdir dir="${build.tmp}/java/out/org.mpsqa.build" />
     <javac destdir="${build.tmp}/java/out/org.mpsqa.build" fork="false" encoding="utf8" includeantruntime="false" debug="true">
@@ -214,7 +215,10 @@
       <src>
         <path location="${basedir}/code/languages/org.mpsqa.build/solutions/org.mpsqa.build/source_gen" />
       </src>
-      <classpath path="${build.tmp}/java/out/org.mpsqa.base.build" />
+      <classpath>
+        <pathelement path="${build.tmp}/java/out/org.mpsqa.base.build" />
+        <pathelement path="${build.tmp}/java/out/org.mpsqa.testing.build" />
+      </classpath>
     </javac>
     <copy todir="${build.tmp}/java/out/org.mpsqa.build">
       <fileset dir="${basedir}/code/languages/org.mpsqa.build/solutions/org.mpsqa.build/source_gen" excludes="**/*.java" />
@@ -269,7 +273,22 @@
     </copy>
   </target>
   
-  <target name="java.compile.org.mpsqa.testing.tests.build" depends="java.compile.org.mpsqa.build">
+  <target name="java.compile.org.mpsqa.testing.build" depends="java.compile.org.mpsqa.base.build">
+    <mkdir dir="${basedir}/code/languages/org.mpsqa.testing/solutions/org.mpsqa.testing.build/source_gen" />
+    <mkdir dir="${build.tmp}/java/out/org.mpsqa.testing.build" />
+    <javac destdir="${build.tmp}/java/out/org.mpsqa.testing.build" fork="false" encoding="utf8" includeantruntime="false" debug="true">
+      <compilerarg value="-Xlint:none" />
+      <src>
+        <path location="${basedir}/code/languages/org.mpsqa.testing/solutions/org.mpsqa.testing.build/source_gen" />
+      </src>
+      <classpath path="${build.tmp}/java/out/org.mpsqa.base.build" />
+    </javac>
+    <copy todir="${build.tmp}/java/out/org.mpsqa.testing.build">
+      <fileset dir="${basedir}/code/languages/org.mpsqa.testing/solutions/org.mpsqa.testing.build/source_gen" excludes="**/*.java" />
+    </copy>
+  </target>
+  
+  <target name="java.compile.org.mpsqa.testing.tests.build" depends="java.compile.org.mpsqa.base.build, java.compile.org.mpsqa.build, java.compile.org.mpsqa.testing.build">
     <mkdir dir="${basedir}/code/languages/org.mpsqa.testing/solutions/org.mpsqa.testing.tests.build/source_gen" />
     <mkdir dir="${build.tmp}/java/out/org.mpsqa.testing.tests.build" />
     <javac destdir="${build.tmp}/java/out/org.mpsqa.testing.tests.build" fork="false" encoding="utf8" includeantruntime="false" debug="true">
@@ -277,7 +296,11 @@
       <src>
         <path location="${basedir}/code/languages/org.mpsqa.testing/solutions/org.mpsqa.testing.tests.build/source_gen" />
       </src>
-      <classpath path="${build.tmp}/java/out/org.mpsqa.build" />
+      <classpath>
+        <pathelement path="${build.tmp}/java/out/org.mpsqa.base.build" />
+        <pathelement path="${build.tmp}/java/out/org.mpsqa.build" />
+        <pathelement path="${build.tmp}/java/out/org.mpsqa.testing.build" />
+      </classpath>
     </javac>
     <copy todir="${build.tmp}/java/out/org.mpsqa.testing.tests.build">
       <fileset dir="${basedir}/code/languages/org.mpsqa.testing/solutions/org.mpsqa.testing.tests.build/source_gen" excludes="**/*.java" />
@@ -291,6 +314,7 @@
     <delete dir="${basedir}/code/languages/org.mpsqa.build/solutions/org.mpsqa.build.sandboxes/source_gen" />
     <delete dir="${basedir}/code/languages/org.mpsqa.clones/solutions/org.mpsqa.clones.build/source_gen" />
     <delete dir="${basedir}/code/languages/org.mpsqa.lint/solutions/org.mpsqa.lint.build/source_gen" />
+    <delete dir="${basedir}/code/languages/org.mpsqa.testing/solutions/org.mpsqa.testing.build/source_gen" />
     <delete dir="${basedir}/code/languages/org.mpsqa.testing/solutions/org.mpsqa.testing.tests.build/source_gen" />
   </target>
 </project>

--- a/code/languages/org.mpsqa.base/.mps/modules.xml
+++ b/code/languages/org.mpsqa.base/.mps/modules.xml
@@ -2,6 +2,7 @@
 <project version="4">
   <component name="MPSProject">
     <projectModules>
+      <modulePath path="$PROJECT_DIR$/solutions/org.mpsqa.base.build/org.mpsqa.base.build.msd" folder="" />
       <modulePath path="$PROJECT_DIR$/solutions/org.mpsqa.base.lib/org.mpsqa.base.lib.msd" folder="" />
       <modulePath path="$PROJECT_DIR$/solutions/org.mpsqa.base.utils/org.mpsqa.base.utils.msd" folder="" />
       <modulePath path="$PROJECT_DIR$/solutions/org.mpsqa.treemap.lib/org.mpsqa.treemap.lib.msd" folder="" />

--- a/code/languages/org.mpsqa.base/solutions/org.mpsqa.base.build/models/org.mpsqa.base.build.mps
+++ b/code/languages/org.mpsqa.base/solutions/org.mpsqa.base.build/models/org.mpsqa.base.build.mps
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<model ref="r:18bebd8f-6332-4ffd-b628-cc9dad4ef421(org.mpsqa.build._010_base_build)">
+<model ref="r:18bebd8f-6332-4ffd-b628-cc9dad4ef421(org.mpsqa.base.build)">
   <persistence version="9" />
   <languages>
     <use id="798100da-4f0a-421a-b991-71f8c50ce5d2" name="jetbrains.mps.build" version="0" />
@@ -181,6 +181,10 @@
       </node>
     </node>
     <node concept="1l3spV" id="7C9PHv6FBIN" role="1l3spN">
+      <node concept="m$_wl" id="32O483pJLHC" role="39821P">
+        <ref role="m_rDy" node="32O483pJLpG" resolve="org.mpsqa.base.build" />
+        <node concept="pUk6x" id="32O483pJLMK" role="pUk7w" />
+      </node>
       <node concept="m$_wl" id="7C9PHv6FBJ6" role="39821P">
         <ref role="m_rDy" node="7C9PHv6FBIO" resolve="org.mpsqa.base" />
         <node concept="28jJK3" id="7C9PHv6FBJk" role="39821P">
@@ -332,6 +336,30 @@
       <property role="2_Ic$$" value="true" />
       <property role="2_Ic$B" value="true" />
     </node>
+    <node concept="m$_wf" id="32O483pJLpG" role="3989C9">
+      <property role="m$_wk" value="org.mpsqa.base.build" />
+      <node concept="3_J27D" id="32O483pJLpI" role="m$_yQ">
+        <node concept="3Mxwew" id="32O483pJLzi" role="3MwsjC">
+          <property role="3MwjfP" value="org.mpsqa.base.build" />
+        </node>
+      </node>
+      <node concept="3_J27D" id="32O483pJLpK" role="m_cZH">
+        <node concept="3Mxwew" id="32O483pJLzl" role="3MwsjC">
+          <property role="3MwjfP" value="org.mpsqa.base.build" />
+        </node>
+      </node>
+      <node concept="3_J27D" id="32O483pJLpM" role="m$_w8">
+        <node concept="3Mxwew" id="32O483pJL_4" role="3MwsjC">
+          <property role="3MwjfP" value="1.0" />
+        </node>
+      </node>
+      <node concept="m$f5U" id="32O483pJLAN" role="m$_yh">
+        <ref role="m$f5T" node="32O483pJKTQ" resolve="build" />
+      </node>
+      <node concept="m$_yC" id="32O483pJLCy" role="m$_yJ">
+        <ref role="m$_y1" to="ffeo:5HVSRHdVm9a" resolve="jetbrains.mps.build" />
+      </node>
+    </node>
     <node concept="m$_wf" id="7C9PHv6FBIO" role="3989C9">
       <property role="m$_wk" value="org.mpsqa.base" />
       <node concept="3_J27D" id="7C9PHv6FBIW" role="m$_yQ">
@@ -353,6 +381,69 @@
       <node concept="3_J27D" id="7C9PHv6FBJ0" role="m_cZH">
         <node concept="3Mxwew" id="7C9PHv6FBJ9" role="3MwsjC">
           <property role="3MwjfP" value="org.mpsqa.base" />
+        </node>
+      </node>
+    </node>
+    <node concept="2G$12M" id="32O483pJKTQ" role="3989C9">
+      <property role="TrG5h" value="build" />
+      <node concept="1E1JtA" id="32O483pJL16" role="2G$12L">
+        <property role="BnDLt" value="true" />
+        <property role="TrG5h" value="org.mpsqa.base.build" />
+        <property role="3LESm3" value="5e8cea6b-997f-49b1-a8d8-dc2a7a6fa657" />
+        <node concept="398BVA" id="32O483pJL2S" role="3LF7KH">
+          <ref role="398BVh" node="7C9PHv6FBIL" resolve="mpsqa.base.home" />
+          <node concept="2Ry0Ak" id="32O483pJL6o" role="iGT6I">
+            <property role="2Ry0Am" value="solutions" />
+            <node concept="2Ry0Ak" id="32O483pJL9R" role="2Ry0An">
+              <property role="2Ry0Am" value="org.mpsqa.base.build" />
+              <node concept="2Ry0Ak" id="32O483pJLdm" role="2Ry0An">
+                <property role="2Ry0Am" value="org.mpsqa.base.build.msd" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1SiIV0" id="32O483pJLf5" role="3bR37C">
+          <node concept="3bR9La" id="32O483pJLf6" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:78GwwOvB3tw" resolve="jetbrains.mps.ide.build" />
+          </node>
+        </node>
+        <node concept="1BupzO" id="32O483pJLfi" role="3bR31x">
+          <property role="3ZfqAx" value="models" />
+          <property role="1Hdu6h" value="true" />
+          <property role="1HemKv" value="true" />
+          <node concept="3LXTmp" id="32O483pJLfj" role="1HemKq">
+            <node concept="398BVA" id="32O483pJLf7" role="3LXTmr">
+              <ref role="398BVh" node="7C9PHv6FBIL" resolve="mpsqa.base.home" />
+              <node concept="2Ry0Ak" id="32O483pJLf8" role="iGT6I">
+                <property role="2Ry0Am" value="solutions" />
+                <node concept="2Ry0Ak" id="32O483pJLf9" role="2Ry0An">
+                  <property role="2Ry0Am" value="org.mpsqa.base.build" />
+                  <node concept="2Ry0Ak" id="32O483pJLfa" role="2Ry0An">
+                    <property role="2Ry0Am" value="models" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3qWCbU" id="32O483pJLfk" role="3LXTna">
+              <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
+            </node>
+          </node>
+        </node>
+        <node concept="3rtmxn" id="21OXhlXmeAy" role="3bR31x">
+          <node concept="3LXTmp" id="21OXhlXmeAz" role="3rtmxm">
+            <node concept="3qWCbU" id="21OXhlXmeA$" role="3LXTna">
+              <property role="3qWCbO" value="icons/**, resources/**" />
+            </node>
+            <node concept="398BVA" id="21OXhlXmeA_" role="3LXTmr">
+              <ref role="398BVh" node="7C9PHv6FBIL" resolve="mpsqa.base.home" />
+              <node concept="2Ry0Ak" id="21OXhlXmeAA" role="iGT6I">
+                <property role="2Ry0Am" value="solutions" />
+                <node concept="2Ry0Ak" id="21OXhlXmeAB" role="2Ry0An">
+                  <property role="2Ry0Am" value="org.mpsqa.base.build" />
+                </node>
+              </node>
+            </node>
+          </node>
         </node>
       </node>
     </node>

--- a/code/languages/org.mpsqa.base/solutions/org.mpsqa.base.build/org.mpsqa.base.build.msd
+++ b/code/languages/org.mpsqa.base/solutions/org.mpsqa.base.build/org.mpsqa.base.build.msd
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<solution name="org.mpsqa.build.allScripts" uuid="b90ee918-6cd5-44ed-9ed3-6696d29afea4" moduleVersion="0" compileInMPS="true">
+<solution name="org.mpsqa.base.build" uuid="5e8cea6b-997f-49b1-a8d8-dc2a7a6fa657" moduleVersion="0" compileInMPS="true">
   <models>
     <modelRoot contentPath="${module}" type="default">
       <sourceRoot location="models" />
@@ -13,7 +13,6 @@
   <sourcePath />
   <dependencies>
     <dependency reexport="false">422c2909-59d6-41a9-b318-40e6256b250f(jetbrains.mps.ide.build)</dependency>
-    <dependency reexport="false">11d4368a-a7e8-4dd9-bfc6-c2de268d1994(org.mpsqa.build)</dependency>
   </dependencies>
   <languageVersions>
     <language slang="l:798100da-4f0a-421a-b991-71f8c50ce5d2:jetbrains.mps.build" version="0" />
@@ -22,8 +21,7 @@
   </languageVersions>
   <dependencyVersions>
     <module reference="422c2909-59d6-41a9-b318-40e6256b250f(jetbrains.mps.ide.build)" version="0" />
-    <module reference="11d4368a-a7e8-4dd9-bfc6-c2de268d1994(org.mpsqa.build)" version="0" />
-    <module reference="b90ee918-6cd5-44ed-9ed3-6696d29afea4(org.mpsqa.build.allScripts)" version="0" />
+    <module reference="5e8cea6b-997f-49b1-a8d8-dc2a7a6fa657(org.mpsqa.base.build)" version="0" />
   </dependencyVersions>
 </solution>
 

--- a/code/languages/org.mpsqa.build/.mps/libraries.xml
+++ b/code/languages/org.mpsqa.build/.mps/libraries.xml
@@ -11,6 +11,14 @@
             </Library>
           </value>
         </entry>
+        <entry key="testing">
+          <value>
+            <Library>
+              <option name="name" value="testing" />
+              <option name="path" value="$PROJECT_DIR$/../org.mpsqa.testing" />
+            </Library>
+          </value>
+        </entry>
       </map>
     </option>
   </component>

--- a/code/languages/org.mpsqa.build/solutions/org.mpsqa.build.allScripts/models/org.mpsqa.build.allScripts.mps
+++ b/code/languages/org.mpsqa.build/solutions/org.mpsqa.build.allScripts/models/org.mpsqa.build.allScripts.mps
@@ -7,6 +7,7 @@
   </languages>
   <imports>
     <import index="ffeo" ref="r:874d959d-e3b4-4d04-b931-ca849af130dd(jetbrains.mps.ide.build)" />
+    <import index="jrpl" ref="r:f9ac9a52-9b52-485f-a0e9-7c4ea505964a(org.mpsqa.build._100_allInOne_build)" />
   </imports>
   <registry>
     <language id="798100da-4f0a-421a-b991-71f8c50ce5d2" name="jetbrains.mps.build">
@@ -215,6 +216,95 @@
           </node>
         </node>
       </node>
+      <node concept="1SiIV0" id="32O483pJKM3" role="3bR37C">
+        <node concept="3bR9La" id="32O483pJKM4" role="1SiIV1">
+          <ref role="3bR37D" node="5Xjjs0Nf2r4" resolve="org.mpsqa.build" />
+        </node>
+      </node>
+    </node>
+    <node concept="1E1JtA" id="32O483pJKIF" role="3989C9">
+      <property role="BnDLt" value="true" />
+      <property role="TrG5h" value="org.mpsqa.base.build" />
+      <property role="3LESm3" value="5e8cea6b-997f-49b1-a8d8-dc2a7a6fa657" />
+      <node concept="55IIr" id="32O483pJKIH" role="3LF7KH">
+        <node concept="2Ry0Ak" id="32O483pJKLC" role="iGT6I">
+          <property role="2Ry0Am" value="code" />
+          <node concept="2Ry0Ak" id="32O483pJKLH" role="2Ry0An">
+            <property role="2Ry0Am" value="languages" />
+            <node concept="2Ry0Ak" id="32O483pJKLM" role="2Ry0An">
+              <property role="2Ry0Am" value="org.mpsqa.base" />
+              <node concept="2Ry0Ak" id="32O483pJKLR" role="2Ry0An">
+                <property role="2Ry0Am" value="solutions" />
+                <node concept="2Ry0Ak" id="32O483pJKLW" role="2Ry0An">
+                  <property role="2Ry0Am" value="org.mpsqa.base.build" />
+                  <node concept="2Ry0Ak" id="32O483pJKM1" role="2Ry0An">
+                    <property role="2Ry0Am" value="org.mpsqa.base.build.msd" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="1SiIV0" id="32O483pJKMc" role="3bR37C">
+        <node concept="3bR9La" id="32O483pJKMd" role="1SiIV1">
+          <ref role="3bR37D" to="ffeo:78GwwOvB3tw" resolve="jetbrains.mps.ide.build" />
+        </node>
+      </node>
+      <node concept="1BupzO" id="32O483pJKMl" role="3bR31x">
+        <property role="3ZfqAx" value="models" />
+        <property role="1Hdu6h" value="true" />
+        <property role="1HemKv" value="true" />
+        <node concept="3LXTmp" id="32O483pJKMm" role="1HemKq">
+          <node concept="55IIr" id="32O483pJKMe" role="3LXTmr">
+            <node concept="2Ry0Ak" id="32O483pJKMf" role="iGT6I">
+              <property role="2Ry0Am" value="code" />
+              <node concept="2Ry0Ak" id="32O483pJKMg" role="2Ry0An">
+                <property role="2Ry0Am" value="languages" />
+                <node concept="2Ry0Ak" id="32O483pJKMh" role="2Ry0An">
+                  <property role="2Ry0Am" value="org.mpsqa.base" />
+                  <node concept="2Ry0Ak" id="32O483pJKMi" role="2Ry0An">
+                    <property role="2Ry0Am" value="solutions" />
+                    <node concept="2Ry0Ak" id="32O483pJKMj" role="2Ry0An">
+                      <property role="2Ry0Am" value="org.mpsqa.base.build" />
+                      <node concept="2Ry0Ak" id="32O483pJKMk" role="2Ry0An">
+                        <property role="2Ry0Am" value="models" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3qWCbU" id="32O483pJKMn" role="3LXTna">
+            <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
+          </node>
+        </node>
+      </node>
+      <node concept="3rtmxn" id="21OXhlXm300" role="3bR31x">
+        <node concept="3LXTmp" id="21OXhlXm301" role="3rtmxm">
+          <node concept="3qWCbU" id="21OXhlXm302" role="3LXTna">
+            <property role="3qWCbO" value="icons/**, resources/**" />
+          </node>
+          <node concept="55IIr" id="21OXhlXm303" role="3LXTmr">
+            <node concept="2Ry0Ak" id="21OXhlXm304" role="iGT6I">
+              <property role="2Ry0Am" value="code" />
+              <node concept="2Ry0Ak" id="21OXhlXm305" role="2Ry0An">
+                <property role="2Ry0Am" value="languages" />
+                <node concept="2Ry0Ak" id="21OXhlXm306" role="2Ry0An">
+                  <property role="2Ry0Am" value="org.mpsqa.base" />
+                  <node concept="2Ry0Ak" id="21OXhlXm307" role="2Ry0An">
+                    <property role="2Ry0Am" value="solutions" />
+                    <node concept="2Ry0Ak" id="21OXhlXm308" role="2Ry0An">
+                      <property role="2Ry0Am" value="org.mpsqa.base.build" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
     </node>
     <node concept="1E1JtA" id="5Xjjs0Nf2r4" role="3989C9">
       <property role="TrG5h" value="org.mpsqa.build" />
@@ -297,6 +387,11 @@
               </node>
             </node>
           </node>
+        </node>
+      </node>
+      <node concept="1SiIV0" id="32O483pJKNE" role="3bR37C">
+        <node concept="3bR9La" id="32O483pJKNF" role="1SiIV1">
+          <ref role="3bR37D" node="32O483pJKIF" resolve="org.mpsqa.base.build" />
         </node>
       </node>
     </node>
@@ -389,6 +484,11 @@
               </node>
             </node>
           </node>
+        </node>
+      </node>
+      <node concept="1SiIV0" id="32O483pKBix" role="3bR37C">
+        <node concept="3bR9La" id="32O483pKBiy" role="1SiIV1">
+          <ref role="3bR37D" node="32O483pJKIF" resolve="org.mpsqa.base.build" />
         </node>
       </node>
     </node>

--- a/code/languages/org.mpsqa.build/solutions/org.mpsqa.build.allScripts/models/org.mpsqa.build.allScripts.mps
+++ b/code/languages/org.mpsqa.build/solutions/org.mpsqa.build.allScripts/models/org.mpsqa.build.allScripts.mps
@@ -394,6 +394,11 @@
           <ref role="3bR37D" node="32O483pJKIF" resolve="org.mpsqa.base.build" />
         </node>
       </node>
+      <node concept="1SiIV0" id="3ALipV_2ngc" role="3bR37C">
+        <node concept="3bR9La" id="3ALipV_2ngd" role="1SiIV1">
+          <ref role="3bR37D" node="3ALipV_2nar" resolve="org.mpsqa.testing.build" />
+        </node>
+      </node>
     </node>
     <node concept="2igEWh" id="3GDqItDloKJ" role="1hWBAP">
       <property role="3UIfUI" value="1024" />
@@ -670,6 +675,95 @@
         </node>
       </node>
     </node>
+    <node concept="1E1JtA" id="3ALipV_2nar" role="3989C9">
+      <property role="BnDLt" value="true" />
+      <property role="TrG5h" value="org.mpsqa.testing.build" />
+      <property role="3LESm3" value="3bf16f17-7850-4b1d-804b-c60206298996" />
+      <node concept="55IIr" id="3ALipV_2nat" role="3LF7KH">
+        <node concept="2Ry0Ak" id="3ALipV_2ndX" role="iGT6I">
+          <property role="2Ry0Am" value="code" />
+          <node concept="2Ry0Ak" id="3ALipV_2ne2" role="2Ry0An">
+            <property role="2Ry0Am" value="languages" />
+            <node concept="2Ry0Ak" id="3ALipV_2ne7" role="2Ry0An">
+              <property role="2Ry0Am" value="org.mpsqa.testing" />
+              <node concept="2Ry0Ak" id="3ALipV_2nec" role="2Ry0An">
+                <property role="2Ry0Am" value="solutions" />
+                <node concept="2Ry0Ak" id="3ALipV_2neh" role="2Ry0An">
+                  <property role="2Ry0Am" value="org.mpsqa.testing.build" />
+                  <node concept="2Ry0Ak" id="3ALipV_2nem" role="2Ry0An">
+                    <property role="2Ry0Am" value="org.mpsqa.testing.build.msd" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="1SiIV0" id="3ALipV_2nf2" role="3bR37C">
+        <node concept="3bR9La" id="3ALipV_2nf3" role="1SiIV1">
+          <ref role="3bR37D" node="32O483pJKIF" resolve="org.mpsqa.base.build" />
+        </node>
+      </node>
+      <node concept="1SiIV0" id="3ALipV_2nf4" role="3bR37C">
+        <node concept="3bR9La" id="3ALipV_2nf5" role="1SiIV1">
+          <ref role="3bR37D" to="ffeo:78GwwOvB3tw" resolve="jetbrains.mps.ide.build" />
+        </node>
+      </node>
+      <node concept="1BupzO" id="3ALipV_2nfd" role="3bR31x">
+        <property role="3ZfqAx" value="models" />
+        <property role="1Hdu6h" value="true" />
+        <property role="1HemKv" value="true" />
+        <node concept="3LXTmp" id="3ALipV_2nfe" role="1HemKq">
+          <node concept="55IIr" id="3ALipV_2nf6" role="3LXTmr">
+            <node concept="2Ry0Ak" id="3ALipV_2nf7" role="iGT6I">
+              <property role="2Ry0Am" value="code" />
+              <node concept="2Ry0Ak" id="3ALipV_2nf8" role="2Ry0An">
+                <property role="2Ry0Am" value="languages" />
+                <node concept="2Ry0Ak" id="3ALipV_2nf9" role="2Ry0An">
+                  <property role="2Ry0Am" value="org.mpsqa.testing" />
+                  <node concept="2Ry0Ak" id="3ALipV_2nfa" role="2Ry0An">
+                    <property role="2Ry0Am" value="solutions" />
+                    <node concept="2Ry0Ak" id="3ALipV_2nfb" role="2Ry0An">
+                      <property role="2Ry0Am" value="org.mpsqa.testing.build" />
+                      <node concept="2Ry0Ak" id="3ALipV_2nfc" role="2Ry0An">
+                        <property role="2Ry0Am" value="models" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3qWCbU" id="3ALipV_2nff" role="3LXTna">
+            <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
+          </node>
+        </node>
+      </node>
+      <node concept="3rtmxn" id="3ALipV_2nh8" role="3bR31x">
+        <node concept="3LXTmp" id="3ALipV_2nh9" role="3rtmxm">
+          <node concept="55IIr" id="3ALipV_2nha" role="3LXTmr">
+            <node concept="2Ry0Ak" id="3ALipV_2nhb" role="iGT6I">
+              <property role="2Ry0Am" value="code" />
+              <node concept="2Ry0Ak" id="3ALipV_2nhc" role="2Ry0An">
+                <property role="2Ry0Am" value="languages" />
+                <node concept="2Ry0Ak" id="3ALipV_2nhd" role="2Ry0An">
+                  <property role="2Ry0Am" value="org.mpsqa.testing" />
+                  <node concept="2Ry0Ak" id="3ALipV_2nhe" role="2Ry0An">
+                    <property role="2Ry0Am" value="solutions" />
+                    <node concept="2Ry0Ak" id="3ALipV_2nhf" role="2Ry0An">
+                      <property role="2Ry0Am" value="org.mpsqa.testing.build" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3qWCbU" id="3ALipV_2nhh" role="3LXTna">
+            <property role="3qWCbO" value="icons/**" />
+          </node>
+        </node>
+      </node>
+    </node>
     <node concept="1E1JtA" id="2WwuhUZ0zTl" role="3989C9">
       <property role="BnDLt" value="true" />
       <property role="TrG5h" value="org.mpsqa.testing.tests.build" />
@@ -756,6 +850,16 @@
               </node>
             </node>
           </node>
+        </node>
+      </node>
+      <node concept="1SiIV0" id="3ALipV_2nfg" role="3bR37C">
+        <node concept="3bR9La" id="3ALipV_2nfh" role="1SiIV1">
+          <ref role="3bR37D" node="32O483pJKIF" resolve="org.mpsqa.base.build" />
+        </node>
+      </node>
+      <node concept="1SiIV0" id="3ALipV_2ngL" role="3bR37C">
+        <node concept="3bR9La" id="3ALipV_2ngM" role="1SiIV1">
+          <ref role="3bR37D" node="3ALipV_2nar" resolve="org.mpsqa.testing.build" />
         </node>
       </node>
     </node>

--- a/code/languages/org.mpsqa.build/solutions/org.mpsqa.build.sandboxes/models/org.mpsqa.build.sandboxes.mps
+++ b/code/languages/org.mpsqa.build/solutions/org.mpsqa.build.sandboxes/models/org.mpsqa.build.sandboxes.mps
@@ -8,7 +8,8 @@
   <imports>
     <import index="m9y5" ref="r:f769f949-59da-40a3-b1a7-86c225f998f5(org.mpsqa.build._050_unused_build)" />
     <import index="ffeo" ref="r:874d959d-e3b4-4d04-b931-ca849af130dd(jetbrains.mps.ide.build)" />
-    <import index="2tou" ref="r:18bebd8f-6332-4ffd-b628-cc9dad4ef421(org.mpsqa.build._010_base_build)" />
+    <import index="2tou" ref="r:18bebd8f-6332-4ffd-b628-cc9dad4ef421(org.mpsqa.base.build)" />
+    <import index="hx16" ref="r:b207e9c3-ef31-40d7-92fc-7e446d92ce2a(org.mpsqa.testing.build)" />
   </imports>
   <registry>
     <language id="798100da-4f0a-421a-b991-71f8c50ce5d2" name="jetbrains.mps.build">
@@ -462,6 +463,9 @@
     </node>
     <node concept="2sgV4H" id="57r710zgJtK" role="1l3spa">
       <ref role="1l3spb" to="2tou:7C9PHv6FBIG" resolve="org.mpsqa.base" />
+    </node>
+    <node concept="2sgV4H" id="4L8SKciIAv3" role="1l3spa">
+      <ref role="1l3spb" to="hx16:2JVMSZMFXgi" resolve="org.mpsqa.testing" />
     </node>
   </node>
 </model>

--- a/code/languages/org.mpsqa.build/solutions/org.mpsqa.build.sandboxes/org.mpsqa.build.sandboxes.msd
+++ b/code/languages/org.mpsqa.build/solutions/org.mpsqa.build.sandboxes/org.mpsqa.build.sandboxes.msd
@@ -14,6 +14,7 @@
   <dependencies>
     <dependency reexport="false">11d4368a-a7e8-4dd9-bfc6-c2de268d1994(org.mpsqa.build)</dependency>
     <dependency reexport="false">422c2909-59d6-41a9-b318-40e6256b250f(jetbrains.mps.ide.build)</dependency>
+    <dependency reexport="false">5e8cea6b-997f-49b1-a8d8-dc2a7a6fa657(org.mpsqa.base.build)</dependency>
   </dependencies>
   <languageVersions>
     <language slang="l:798100da-4f0a-421a-b991-71f8c50ce5d2:jetbrains.mps.build" version="0" />
@@ -22,6 +23,7 @@
   </languageVersions>
   <dependencyVersions>
     <module reference="422c2909-59d6-41a9-b318-40e6256b250f(jetbrains.mps.ide.build)" version="0" />
+    <module reference="5e8cea6b-997f-49b1-a8d8-dc2a7a6fa657(org.mpsqa.base.build)" version="0" />
     <module reference="11d4368a-a7e8-4dd9-bfc6-c2de268d1994(org.mpsqa.build)" version="0" />
     <module reference="597901b4-55d9-4f1d-923a-6bff55b6cc3e(org.mpsqa.build.sandboxes)" version="0" />
   </dependencyVersions>

--- a/code/languages/org.mpsqa.build/solutions/org.mpsqa.build/models/org.mpsqa.build._020_testing_build.mps
+++ b/code/languages/org.mpsqa.build/solutions/org.mpsqa.build/models/org.mpsqa.build._020_testing_build.mps
@@ -175,6 +175,18 @@
     </node>
     <node concept="2sgV4H" id="7C9PHv6FFm2" role="1l3spa">
       <ref role="1l3spb" to="2tou:7C9PHv6FBIG" resolve="org.mpsqa.base" />
+      <node concept="398BVA" id="32O483pN5Hx" role="2JcizS">
+        <ref role="398BVh" node="1GhTetdAZXl" resolve="mpsqa.home" />
+        <node concept="2Ry0Ak" id="32O483pN5HB" role="iGT6I">
+          <property role="2Ry0Am" value="build" />
+          <node concept="2Ry0Ak" id="32O483pN5HG" role="2Ry0An">
+            <property role="2Ry0Am" value="artifacts" />
+            <node concept="2Ry0Ak" id="32O483pN5HL" role="2Ry0An">
+              <property role="2Ry0Am" value="org.mpsqa.base" />
+            </node>
+          </node>
+        </node>
+      </node>
     </node>
     <node concept="1l3spV" id="2JVMSZMFXhb" role="1l3spN">
       <node concept="m$_wl" id="2JVMSZMFXhf" role="39821P">

--- a/code/languages/org.mpsqa.build/solutions/org.mpsqa.build/models/org.mpsqa.build._030_clones_build.mps
+++ b/code/languages/org.mpsqa.build/solutions/org.mpsqa.build/models/org.mpsqa.build._030_clones_build.mps
@@ -172,21 +172,6 @@
         </node>
       </node>
     </node>
-    <node concept="398rNT" id="34utZfVcg95" role="1l3spd">
-      <property role="TrG5h" value="dependencies.mpsqa.base" />
-      <node concept="398BVA" id="34utZfVcgdj" role="398pKh">
-        <ref role="398BVh" node="1GhTetdAZXl" resolve="mpsqa.home" />
-        <node concept="2Ry0Ak" id="34utZfVcgdk" role="iGT6I">
-          <property role="2Ry0Am" value="build" />
-          <node concept="2Ry0Ak" id="34utZfVcgdl" role="2Ry0An">
-            <property role="2Ry0Am" value="artifacts" />
-            <node concept="2Ry0Ak" id="34utZfVcgdm" role="2Ry0An">
-              <property role="2Ry0Am" value="org.mpsqa.base" />
-            </node>
-          </node>
-        </node>
-      </node>
-    </node>
     <node concept="2sgV4H" id="2JVMSZMFXgm" role="1l3spa">
       <ref role="1l3spb" to="ffeo:3IKDaVZmzS6" resolve="mps" />
       <node concept="398BVA" id="2JVMSZMFXgn" role="2JcizS">
@@ -195,8 +180,17 @@
     </node>
     <node concept="2sgV4H" id="7C9PHv6FDQo" role="1l3spa">
       <ref role="1l3spb" to="2tou:7C9PHv6FBIG" resolve="org.mpsqa.base" />
-      <node concept="398BVA" id="67NgLmjV$iW" role="2JcizS">
-        <ref role="398BVh" node="34utZfVcg95" resolve="dependencies.mpsqa.base" />
+      <node concept="398BVA" id="32O483pN5Hx" role="2JcizS">
+        <ref role="398BVh" node="1GhTetdAZXl" resolve="mpsqa.home" />
+        <node concept="2Ry0Ak" id="32O483pN5HB" role="iGT6I">
+          <property role="2Ry0Am" value="build" />
+          <node concept="2Ry0Ak" id="32O483pN5HG" role="2Ry0An">
+            <property role="2Ry0Am" value="artifacts" />
+            <node concept="2Ry0Ak" id="32O483pN5HL" role="2Ry0An">
+              <property role="2Ry0Am" value="org.mpsqa.base" />
+            </node>
+          </node>
+        </node>
       </node>
     </node>
     <node concept="1l3spV" id="2JVMSZMFXhb" role="1l3spN">

--- a/code/languages/org.mpsqa.build/solutions/org.mpsqa.build/models/org.mpsqa.build._030_clones_build.mps
+++ b/code/languages/org.mpsqa.build/solutions/org.mpsqa.build/models/org.mpsqa.build._030_clones_build.mps
@@ -7,7 +7,7 @@
   </languages>
   <imports>
     <import index="ffeo" ref="r:874d959d-e3b4-4d04-b931-ca849af130dd(jetbrains.mps.ide.build)" />
-    <import index="2tou" ref="r:18bebd8f-6332-4ffd-b628-cc9dad4ef421(org.mpsqa.build._010_base_build)" />
+    <import index="2tou" ref="r:18bebd8f-6332-4ffd-b628-cc9dad4ef421(org.mpsqa.base.build)" />
   </imports>
   <registry>
     <language id="798100da-4f0a-421a-b991-71f8c50ce5d2" name="jetbrains.mps.build">

--- a/code/languages/org.mpsqa.build/solutions/org.mpsqa.build/models/org.mpsqa.build._040_mutant_build.mps
+++ b/code/languages/org.mpsqa.build/solutions/org.mpsqa.build/models/org.mpsqa.build._040_mutant_build.mps
@@ -133,6 +133,18 @@
     <property role="turDy" value="build-mutant-languages.xml" />
     <node concept="2sgV4H" id="3PN66LDqBYO" role="1l3spa">
       <ref role="1l3spb" to="2tou:7C9PHv6FBIG" resolve="org.mpsqa.base" />
+      <node concept="398BVA" id="32O483pN5Hx" role="2JcizS">
+        <ref role="398BVh" node="3PN66LDqBYR" resolve="mpsqa.home" />
+        <node concept="2Ry0Ak" id="32O483pN5HB" role="iGT6I">
+          <property role="2Ry0Am" value="build" />
+          <node concept="2Ry0Ak" id="32O483pN5HG" role="2Ry0An">
+            <property role="2Ry0Am" value="artifacts" />
+            <node concept="2Ry0Ak" id="32O483pN5HL" role="2Ry0An">
+              <property role="2Ry0Am" value="org.mpsqa.base" />
+            </node>
+          </node>
+        </node>
+      </node>
     </node>
     <node concept="10PD9b" id="3PN66LDqBYP" role="10PD9s" />
     <node concept="3b7kt6" id="3PN66LDqBYQ" role="10PD9s" />

--- a/code/languages/org.mpsqa.build/solutions/org.mpsqa.build/models/org.mpsqa.build._040_mutant_build.mps
+++ b/code/languages/org.mpsqa.build/solutions/org.mpsqa.build/models/org.mpsqa.build._040_mutant_build.mps
@@ -7,7 +7,7 @@
   </languages>
   <imports>
     <import index="ffeo" ref="r:874d959d-e3b4-4d04-b931-ca849af130dd(jetbrains.mps.ide.build)" />
-    <import index="2tou" ref="r:18bebd8f-6332-4ffd-b628-cc9dad4ef421(org.mpsqa.build._010_base_build)" />
+    <import index="2tou" ref="r:18bebd8f-6332-4ffd-b628-cc9dad4ef421(org.mpsqa.base.build)" />
   </imports>
   <registry>
     <language id="798100da-4f0a-421a-b991-71f8c50ce5d2" name="jetbrains.mps.build">

--- a/code/languages/org.mpsqa.build/solutions/org.mpsqa.build/models/org.mpsqa.build._050_unused_build.mps
+++ b/code/languages/org.mpsqa.build/solutions/org.mpsqa.build/models/org.mpsqa.build._050_unused_build.mps
@@ -133,6 +133,18 @@
     <property role="turDy" value="build-unused-languages-analysis.xml" />
     <node concept="2sgV4H" id="1YSnQiVh0x2" role="1l3spa">
       <ref role="1l3spb" to="2tou:7C9PHv6FBIG" resolve="org.mpsqa.base" />
+      <node concept="398BVA" id="32O483pN5Hx" role="2JcizS">
+        <ref role="398BVh" node="1YSnQiVh0x5" resolve="mpsqa.home" />
+        <node concept="2Ry0Ak" id="32O483pN5HB" role="iGT6I">
+          <property role="2Ry0Am" value="build" />
+          <node concept="2Ry0Ak" id="32O483pN5HG" role="2Ry0An">
+            <property role="2Ry0Am" value="artifacts" />
+            <node concept="2Ry0Ak" id="32O483pN5HL" role="2Ry0An">
+              <property role="2Ry0Am" value="org.mpsqa.base" />
+            </node>
+          </node>
+        </node>
+      </node>
     </node>
     <node concept="10PD9b" id="1YSnQiVh0x3" role="10PD9s" />
     <node concept="3b7kt6" id="1YSnQiVh0x4" role="10PD9s" />

--- a/code/languages/org.mpsqa.build/solutions/org.mpsqa.build/models/org.mpsqa.build._050_unused_build.mps
+++ b/code/languages/org.mpsqa.build/solutions/org.mpsqa.build/models/org.mpsqa.build._050_unused_build.mps
@@ -8,7 +8,7 @@
   </languages>
   <imports>
     <import index="ffeo" ref="r:874d959d-e3b4-4d04-b931-ca849af130dd(jetbrains.mps.ide.build)" />
-    <import index="2tou" ref="r:18bebd8f-6332-4ffd-b628-cc9dad4ef421(org.mpsqa.build._010_base_build)" />
+    <import index="2tou" ref="r:18bebd8f-6332-4ffd-b628-cc9dad4ef421(org.mpsqa.base.build)" />
   </imports>
   <registry>
     <language id="798100da-4f0a-421a-b991-71f8c50ce5d2" name="jetbrains.mps.build">

--- a/code/languages/org.mpsqa.build/solutions/org.mpsqa.build/models/org.mpsqa.build._060_arch_build.mps
+++ b/code/languages/org.mpsqa.build/solutions/org.mpsqa.build/models/org.mpsqa.build._060_arch_build.mps
@@ -137,6 +137,18 @@
     <property role="turDy" value="build-arch-analysis-languages.xml" />
     <node concept="2sgV4H" id="50Wzfz4shz0" role="1l3spa">
       <ref role="1l3spb" to="2tou:7C9PHv6FBIG" resolve="org.mpsqa.base" />
+      <node concept="398BVA" id="32O483pN5Hx" role="2JcizS">
+        <ref role="398BVh" node="50Wzfz4shz3" resolve="mpsqa.home" />
+        <node concept="2Ry0Ak" id="32O483pN5HB" role="iGT6I">
+          <property role="2Ry0Am" value="build" />
+          <node concept="2Ry0Ak" id="32O483pN5HG" role="2Ry0An">
+            <property role="2Ry0Am" value="artifacts" />
+            <node concept="2Ry0Ak" id="32O483pN5HL" role="2Ry0An">
+              <property role="2Ry0Am" value="org.mpsqa.base" />
+            </node>
+          </node>
+        </node>
+      </node>
     </node>
     <node concept="10PD9b" id="50Wzfz4shz1" role="10PD9s" />
     <node concept="3b7kt6" id="50Wzfz4shz2" role="10PD9s" />

--- a/code/languages/org.mpsqa.build/solutions/org.mpsqa.build/models/org.mpsqa.build._060_arch_build.mps
+++ b/code/languages/org.mpsqa.build/solutions/org.mpsqa.build/models/org.mpsqa.build._060_arch_build.mps
@@ -8,7 +8,7 @@
   </languages>
   <imports>
     <import index="ffeo" ref="r:874d959d-e3b4-4d04-b931-ca849af130dd(jetbrains.mps.ide.build)" />
-    <import index="2tou" ref="r:18bebd8f-6332-4ffd-b628-cc9dad4ef421(org.mpsqa.build._010_base_build)" />
+    <import index="2tou" ref="r:18bebd8f-6332-4ffd-b628-cc9dad4ef421(org.mpsqa.base.build)" />
   </imports>
   <registry>
     <language id="798100da-4f0a-421a-b991-71f8c50ce5d2" name="jetbrains.mps.build">

--- a/code/languages/org.mpsqa.build/solutions/org.mpsqa.build/models/org.mpsqa.build._070_deprecated_build.mps
+++ b/code/languages/org.mpsqa.build/solutions/org.mpsqa.build/models/org.mpsqa.build._070_deprecated_build.mps
@@ -130,6 +130,18 @@
     <property role="turDy" value="build-deprecated-analysis-languages.xml" />
     <node concept="2sgV4H" id="3dqUbgQmcyq" role="1l3spa">
       <ref role="1l3spb" to="2tou:7C9PHv6FBIG" resolve="org.mpsqa.base" />
+      <node concept="398BVA" id="32O483pN5Hx" role="2JcizS">
+        <ref role="398BVh" node="3dqUbgQmcyt" resolve="mpsqa.home" />
+        <node concept="2Ry0Ak" id="32O483pN5HB" role="iGT6I">
+          <property role="2Ry0Am" value="build" />
+          <node concept="2Ry0Ak" id="32O483pN5HG" role="2Ry0An">
+            <property role="2Ry0Am" value="artifacts" />
+            <node concept="2Ry0Ak" id="32O483pN5HL" role="2Ry0An">
+              <property role="2Ry0Am" value="org.mpsqa.base" />
+            </node>
+          </node>
+        </node>
+      </node>
     </node>
     <node concept="10PD9b" id="3dqUbgQmcyr" role="10PD9s" />
     <node concept="3b7kt6" id="3dqUbgQmcys" role="10PD9s" />

--- a/code/languages/org.mpsqa.build/solutions/org.mpsqa.build/models/org.mpsqa.build._070_deprecated_build.mps
+++ b/code/languages/org.mpsqa.build/solutions/org.mpsqa.build/models/org.mpsqa.build._070_deprecated_build.mps
@@ -8,7 +8,7 @@
   </languages>
   <imports>
     <import index="ffeo" ref="r:874d959d-e3b4-4d04-b931-ca849af130dd(jetbrains.mps.ide.build)" />
-    <import index="2tou" ref="r:18bebd8f-6332-4ffd-b628-cc9dad4ef421(org.mpsqa.build._010_base_build)" />
+    <import index="2tou" ref="r:18bebd8f-6332-4ffd-b628-cc9dad4ef421(org.mpsqa.base.build)" />
   </imports>
   <registry>
     <language id="798100da-4f0a-421a-b991-71f8c50ce5d2" name="jetbrains.mps.build">

--- a/code/languages/org.mpsqa.build/solutions/org.mpsqa.build/models/org.mpsqa.build._080_lint_build.mps
+++ b/code/languages/org.mpsqa.build/solutions/org.mpsqa.build/models/org.mpsqa.build._080_lint_build.mps
@@ -139,6 +139,18 @@
     <property role="turDy" value="build-lint-analysis-languages.xml" />
     <node concept="2sgV4H" id="3dqUbgQmcyq" role="1l3spa">
       <ref role="1l3spb" to="2tou:7C9PHv6FBIG" resolve="org.mpsqa.base" />
+      <node concept="398BVA" id="32O483pN5Hx" role="2JcizS">
+        <ref role="398BVh" node="3dqUbgQmcyt" resolve="mpsqa.home" />
+        <node concept="2Ry0Ak" id="32O483pN5HB" role="iGT6I">
+          <property role="2Ry0Am" value="build" />
+          <node concept="2Ry0Ak" id="32O483pN5HG" role="2Ry0An">
+            <property role="2Ry0Am" value="artifacts" />
+            <node concept="2Ry0Ak" id="32O483pN5HL" role="2Ry0An">
+              <property role="2Ry0Am" value="org.mpsqa.base" />
+            </node>
+          </node>
+        </node>
+      </node>
     </node>
     <node concept="10PD9b" id="3dqUbgQmcyr" role="10PD9s" />
     <node concept="3b7kt6" id="3dqUbgQmcys" role="10PD9s" />

--- a/code/languages/org.mpsqa.build/solutions/org.mpsqa.build/models/org.mpsqa.build._080_lint_build.mps
+++ b/code/languages/org.mpsqa.build/solutions/org.mpsqa.build/models/org.mpsqa.build._080_lint_build.mps
@@ -6,7 +6,7 @@
     <use id="798100da-4f0a-421a-b991-71f8c50ce5d2" name="jetbrains.mps.build" version="0" />
   </languages>
   <imports>
-    <import index="2tou" ref="r:18bebd8f-6332-4ffd-b628-cc9dad4ef421(org.mpsqa.build._010_base_build)" />
+    <import index="2tou" ref="r:18bebd8f-6332-4ffd-b628-cc9dad4ef421(org.mpsqa.base.build)" />
     <import index="ffeo" ref="r:874d959d-e3b4-4d04-b931-ca849af130dd(jetbrains.mps.ide.build)" />
   </imports>
   <registry>

--- a/code/languages/org.mpsqa.build/solutions/org.mpsqa.build/models/org.mpsqa.build._100_allInOne_build.mps
+++ b/code/languages/org.mpsqa.build/solutions/org.mpsqa.build/models/org.mpsqa.build._100_allInOne_build.mps
@@ -143,102 +143,30 @@
           <property role="3MwjfP" value="0.1" />
         </node>
       </node>
-      <node concept="m$_yB" id="fm3v0X36N2" role="m$_yh">
-        <ref role="m$_yA" node="5Xjjs0Nf2r4" resolve="org.mpsqa.build" />
-      </node>
       <node concept="m$_yC" id="fm3v0X36N4" role="m$_yJ">
         <ref role="m$_y1" to="ffeo:5HVSRHdVm9a" resolve="jetbrains.mps.build" />
       </node>
-    </node>
-    <node concept="1E1JtA" id="5Xjjs0Nf2r4" role="3989C9">
-      <property role="TrG5h" value="org.mpsqa.build" />
-      <property role="3LESm3" value="11d4368a-a7e8-4dd9-bfc6-c2de268d1994" />
-      <property role="BnDLt" value="true" />
-      <node concept="398BVA" id="5Xjjs0Nf2su" role="3LF7KH">
-        <ref role="398BVh" node="3PN66LDqBU_" resolve="mpsqa.home" />
-        <node concept="2Ry0Ak" id="67NgLmjP_aw" role="iGT6I">
-          <property role="2Ry0Am" value="code" />
-          <node concept="2Ry0Ak" id="2WwuhUZ1NBr" role="2Ry0An">
-            <property role="2Ry0Am" value="languages" />
-            <node concept="2Ry0Ak" id="2WwuhUZ1NBs" role="2Ry0An">
-              <property role="2Ry0Am" value="org.mpsqa.build" />
-              <node concept="2Ry0Ak" id="2WwuhUZ1NB$" role="2Ry0An">
-                <property role="2Ry0Am" value="solutions" />
-                <node concept="2Ry0Ak" id="2WwuhUZ1NB_" role="2Ry0An">
-                  <property role="2Ry0Am" value="org.mpsqa.build" />
-                  <node concept="2Ry0Ak" id="2WwuhUZ1NBA" role="2Ry0An">
-                    <property role="2Ry0Am" value="org.mpsqa.build.msd" />
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
+      <node concept="m$_yC" id="32O483pJM7u" role="m$_yJ">
+        <ref role="m$_y1" to="2tou:32O483pJLpG" resolve="org.mpsqa.base.build" />
       </node>
-      <node concept="1SiIV0" id="5Xjjs0Nf2sZ" role="3bR37C">
-        <node concept="3bR9La" id="5Xjjs0Nf2t0" role="1SiIV1">
-          <ref role="3bR37D" to="ffeo:78GwwOvB3tw" resolve="jetbrains.mps.ide.build" />
-        </node>
-      </node>
-      <node concept="1BupzO" id="5Xjjs0Nf2te" role="3bR31x">
-        <property role="3ZfqAx" value="models" />
-        <property role="1Hdu6h" value="true" />
-        <property role="1HemKv" value="true" />
-        <node concept="3LXTmp" id="2WwuhUZ1NBL" role="1HemKq">
-          <node concept="398BVA" id="2WwuhUZ1NBE" role="3LXTmr">
-            <ref role="398BVh" node="3PN66LDqBU_" resolve="mpsqa.home" />
-            <node concept="2Ry0Ak" id="2WwuhUZ1NBF" role="iGT6I">
-              <property role="2Ry0Am" value="code" />
-              <node concept="2Ry0Ak" id="2WwuhUZ1NBG" role="2Ry0An">
-                <property role="2Ry0Am" value="languages" />
-                <node concept="2Ry0Ak" id="2WwuhUZ1NBH" role="2Ry0An">
-                  <property role="2Ry0Am" value="org.mpsqa.build" />
-                  <node concept="2Ry0Ak" id="2WwuhUZ1NBI" role="2Ry0An">
-                    <property role="2Ry0Am" value="solutions" />
-                    <node concept="2Ry0Ak" id="2WwuhUZ1NBJ" role="2Ry0An">
-                      <property role="2Ry0Am" value="org.mpsqa.build" />
-                      <node concept="2Ry0Ak" id="2WwuhUZ1NBK" role="2Ry0An">
-                        <property role="2Ry0Am" value="models" />
-                      </node>
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-          <node concept="3qWCbU" id="2WwuhUZ1NBM" role="3LXTna">
-            <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
-          </node>
-        </node>
-      </node>
-      <node concept="3rtmxn" id="46QW9mm7Jc7" role="3bR31x">
-        <node concept="3LXTmp" id="46QW9mm7Jc8" role="3rtmxm">
-          <node concept="3qWCbU" id="46QW9mm7Jc9" role="3LXTna">
-            <property role="3qWCbO" value="icons/**, resources/**" />
-          </node>
-          <node concept="398BVA" id="46QW9mm7Jca" role="3LXTmr">
-            <ref role="398BVh" node="3PN66LDqBU_" resolve="mpsqa.home" />
-            <node concept="2Ry0Ak" id="46QW9mm7Jcb" role="iGT6I">
-              <property role="2Ry0Am" value="code" />
-              <node concept="2Ry0Ak" id="46QW9mm7Jcc" role="2Ry0An">
-                <property role="2Ry0Am" value="languages" />
-                <node concept="2Ry0Ak" id="46QW9mm7Jcd" role="2Ry0An">
-                  <property role="2Ry0Am" value="org.mpsqa.build" />
-                  <node concept="2Ry0Ak" id="46QW9mm7Jce" role="2Ry0An">
-                    <property role="2Ry0Am" value="solutions" />
-                    <node concept="2Ry0Ak" id="46QW9mm7Jcf" role="2Ry0An">
-                      <property role="2Ry0Am" value="org.mpsqa.build" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
+      <node concept="m$_yB" id="fm3v0X36N2" role="m$_yh">
+        <ref role="m$_yA" node="5Xjjs0Nf2r4" resolve="org.mpsqa.build" />
       </node>
     </node>
     <node concept="2sgV4H" id="3PN66LDqBUy" role="1l3spa">
       <ref role="1l3spb" to="2tou:7C9PHv6FBIG" resolve="org.mpsqa.base" />
+      <node concept="398BVA" id="32O483pN5Hx" role="2JcizS">
+        <ref role="398BVh" node="3PN66LDqBU_" resolve="mpsqa.home" />
+        <node concept="2Ry0Ak" id="32O483pN5HB" role="iGT6I">
+          <property role="2Ry0Am" value="build" />
+          <node concept="2Ry0Ak" id="32O483pN5HG" role="2Ry0An">
+            <property role="2Ry0Am" value="artifacts" />
+            <node concept="2Ry0Ak" id="32O483pN5HL" role="2Ry0An">
+              <property role="2Ry0Am" value="org.mpsqa.base" />
+            </node>
+          </node>
+        </node>
+      </node>
     </node>
     <node concept="2sgV4H" id="3PN66LDqBWI" role="1l3spa">
       <ref role="1l3spb" to="hx16:2JVMSZMFXgi" resolve="org.mpsqa.testing" />
@@ -328,6 +256,98 @@
       </node>
     </node>
     <node concept="55IIr" id="3PN66LDqBUG" role="auvoZ" />
+    <node concept="1E1JtA" id="5Xjjs0Nf2r4" role="3989C9">
+      <property role="TrG5h" value="org.mpsqa.build" />
+      <property role="3LESm3" value="11d4368a-a7e8-4dd9-bfc6-c2de268d1994" />
+      <property role="BnDLt" value="true" />
+      <node concept="398BVA" id="5Xjjs0Nf2su" role="3LF7KH">
+        <ref role="398BVh" node="3PN66LDqBU_" resolve="mpsqa.home" />
+        <node concept="2Ry0Ak" id="67NgLmjP_aw" role="iGT6I">
+          <property role="2Ry0Am" value="code" />
+          <node concept="2Ry0Ak" id="2WwuhUZ1NBr" role="2Ry0An">
+            <property role="2Ry0Am" value="languages" />
+            <node concept="2Ry0Ak" id="2WwuhUZ1NBs" role="2Ry0An">
+              <property role="2Ry0Am" value="org.mpsqa.build" />
+              <node concept="2Ry0Ak" id="2WwuhUZ1NB$" role="2Ry0An">
+                <property role="2Ry0Am" value="solutions" />
+                <node concept="2Ry0Ak" id="2WwuhUZ1NB_" role="2Ry0An">
+                  <property role="2Ry0Am" value="org.mpsqa.build" />
+                  <node concept="2Ry0Ak" id="2WwuhUZ1NBA" role="2Ry0An">
+                    <property role="2Ry0Am" value="org.mpsqa.build.msd" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="1SiIV0" id="5Xjjs0Nf2sZ" role="3bR37C">
+        <node concept="3bR9La" id="5Xjjs0Nf2t0" role="1SiIV1">
+          <ref role="3bR37D" to="ffeo:78GwwOvB3tw" resolve="jetbrains.mps.ide.build" />
+        </node>
+      </node>
+      <node concept="1BupzO" id="5Xjjs0Nf2te" role="3bR31x">
+        <property role="3ZfqAx" value="models" />
+        <property role="1Hdu6h" value="true" />
+        <property role="1HemKv" value="true" />
+        <node concept="3LXTmp" id="2WwuhUZ1NBL" role="1HemKq">
+          <node concept="398BVA" id="2WwuhUZ1NBE" role="3LXTmr">
+            <ref role="398BVh" node="3PN66LDqBU_" resolve="mpsqa.home" />
+            <node concept="2Ry0Ak" id="2WwuhUZ1NBF" role="iGT6I">
+              <property role="2Ry0Am" value="code" />
+              <node concept="2Ry0Ak" id="2WwuhUZ1NBG" role="2Ry0An">
+                <property role="2Ry0Am" value="languages" />
+                <node concept="2Ry0Ak" id="2WwuhUZ1NBH" role="2Ry0An">
+                  <property role="2Ry0Am" value="org.mpsqa.build" />
+                  <node concept="2Ry0Ak" id="2WwuhUZ1NBI" role="2Ry0An">
+                    <property role="2Ry0Am" value="solutions" />
+                    <node concept="2Ry0Ak" id="2WwuhUZ1NBJ" role="2Ry0An">
+                      <property role="2Ry0Am" value="org.mpsqa.build" />
+                      <node concept="2Ry0Ak" id="2WwuhUZ1NBK" role="2Ry0An">
+                        <property role="2Ry0Am" value="models" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3qWCbU" id="2WwuhUZ1NBM" role="3LXTna">
+            <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
+          </node>
+        </node>
+      </node>
+      <node concept="3rtmxn" id="46QW9mm7Jc7" role="3bR31x">
+        <node concept="3LXTmp" id="46QW9mm7Jc8" role="3rtmxm">
+          <node concept="3qWCbU" id="46QW9mm7Jc9" role="3LXTna">
+            <property role="3qWCbO" value="icons/**, resources/**" />
+          </node>
+          <node concept="398BVA" id="46QW9mm7Jca" role="3LXTmr">
+            <ref role="398BVh" node="3PN66LDqBU_" resolve="mpsqa.home" />
+            <node concept="2Ry0Ak" id="46QW9mm7Jcb" role="iGT6I">
+              <property role="2Ry0Am" value="code" />
+              <node concept="2Ry0Ak" id="46QW9mm7Jcc" role="2Ry0An">
+                <property role="2Ry0Am" value="languages" />
+                <node concept="2Ry0Ak" id="46QW9mm7Jcd" role="2Ry0An">
+                  <property role="2Ry0Am" value="org.mpsqa.build" />
+                  <node concept="2Ry0Ak" id="46QW9mm7Jce" role="2Ry0An">
+                    <property role="2Ry0Am" value="solutions" />
+                    <node concept="2Ry0Ak" id="46QW9mm7Jcf" role="2Ry0An">
+                      <property role="2Ry0Am" value="org.mpsqa.build" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="1SiIV0" id="32O483pJM7h" role="3bR37C">
+        <node concept="3bR9La" id="32O483pJM7i" role="1SiIV1">
+          <ref role="3bR37D" to="2tou:32O483pJL16" resolve="org.mpsqa.base.build" />
+        </node>
+      </node>
+    </node>
   </node>
 </model>
 

--- a/code/languages/org.mpsqa.build/solutions/org.mpsqa.build/models/org.mpsqa.build._100_allInOne_build.mps
+++ b/code/languages/org.mpsqa.build/solutions/org.mpsqa.build/models/org.mpsqa.build._100_allInOne_build.mps
@@ -7,8 +7,8 @@
   </languages>
   <imports>
     <import index="ffeo" ref="r:874d959d-e3b4-4d04-b931-ca849af130dd(jetbrains.mps.ide.build)" />
-    <import index="2tou" ref="r:18bebd8f-6332-4ffd-b628-cc9dad4ef421(org.mpsqa.build._010_base_build)" />
-    <import index="hx16" ref="r:b207e9c3-ef31-40d7-92fc-7e446d92ce2a(org.mpsqa.build._020_testing_build)" />
+    <import index="2tou" ref="r:18bebd8f-6332-4ffd-b628-cc9dad4ef421(org.mpsqa.base.build)" />
+    <import index="hx16" ref="r:b207e9c3-ef31-40d7-92fc-7e446d92ce2a(org.mpsqa.testing.build)" />
     <import index="5g2w" ref="r:eecfcc09-6fb4-4fd4-bb99-b3d1712ec5a4(org.mpsqa.build._030_clones_build)" />
     <import index="c8rw" ref="r:2377d435-973d-4687-839a-7353546ffa8d(org.mpsqa.build._040_mutant_build)" />
     <import index="m9y5" ref="r:f769f949-59da-40a3-b1a7-86c225f998f5(org.mpsqa.build._050_unused_build)" />
@@ -149,6 +149,9 @@
       <node concept="m$_yC" id="32O483pJM7u" role="m$_yJ">
         <ref role="m$_y1" to="2tou:32O483pJLpG" resolve="org.mpsqa.base.build" />
       </node>
+      <node concept="m$_yC" id="3ALipV_2n6_" role="m$_yJ">
+        <ref role="m$_y1" to="hx16:2XCAdv5uaeq" resolve="org.mpsqa.testing.build" />
+      </node>
       <node concept="m$_yB" id="fm3v0X36N2" role="m$_yh">
         <ref role="m$_yA" node="5Xjjs0Nf2r4" resolve="org.mpsqa.build" />
       </node>
@@ -170,6 +173,18 @@
     </node>
     <node concept="2sgV4H" id="3PN66LDqBWI" role="1l3spa">
       <ref role="1l3spb" to="hx16:2JVMSZMFXgi" resolve="org.mpsqa.testing" />
+      <node concept="398BVA" id="3ALipV_2n6H" role="2JcizS">
+        <ref role="398BVh" node="3PN66LDqBU_" resolve="mpsqa.home" />
+        <node concept="2Ry0Ak" id="3ALipV_2n6N" role="iGT6I">
+          <property role="2Ry0Am" value="build" />
+          <node concept="2Ry0Ak" id="3ALipV_2n6S" role="2Ry0An">
+            <property role="2Ry0Am" value="artifacts" />
+            <node concept="2Ry0Ak" id="3ALipV_2n6X" role="2Ry0An">
+              <property role="2Ry0Am" value="org.mpsqa.testing" />
+            </node>
+          </node>
+        </node>
+      </node>
     </node>
     <node concept="2sgV4H" id="3PN66LDqBWU" role="1l3spa">
       <ref role="1l3spb" to="5g2w:2JVMSZMFXgi" resolve="org.mpsqa.clones" />
@@ -345,6 +360,11 @@
       <node concept="1SiIV0" id="32O483pJM7h" role="3bR37C">
         <node concept="3bR9La" id="32O483pJM7i" role="1SiIV1">
           <ref role="3bR37D" to="2tou:32O483pJL16" resolve="org.mpsqa.base.build" />
+        </node>
+      </node>
+      <node concept="1SiIV0" id="3ALipV_2n6m" role="3bR37C">
+        <node concept="3bR9La" id="3ALipV_2n6n" role="1SiIV1">
+          <ref role="3bR37D" to="hx16:2XCAdv5uaH8" resolve="org.mpsqa.testing.build" />
         </node>
       </node>
     </node>

--- a/code/languages/org.mpsqa.build/solutions/org.mpsqa.build/org.mpsqa.build.msd
+++ b/code/languages/org.mpsqa.build/solutions/org.mpsqa.build/org.mpsqa.build.msd
@@ -13,6 +13,7 @@
   <sourcePath />
   <dependencies>
     <dependency reexport="false">422c2909-59d6-41a9-b318-40e6256b250f(jetbrains.mps.ide.build)</dependency>
+    <dependency reexport="false">5e8cea6b-997f-49b1-a8d8-dc2a7a6fa657(org.mpsqa.base.build)</dependency>
   </dependencies>
   <languageVersions>
     <language slang="l:798100da-4f0a-421a-b991-71f8c50ce5d2:jetbrains.mps.build" version="0" />
@@ -21,6 +22,7 @@
   </languageVersions>
   <dependencyVersions>
     <module reference="422c2909-59d6-41a9-b318-40e6256b250f(jetbrains.mps.ide.build)" version="0" />
+    <module reference="5e8cea6b-997f-49b1-a8d8-dc2a7a6fa657(org.mpsqa.base.build)" version="0" />
     <module reference="11d4368a-a7e8-4dd9-bfc6-c2de268d1994(org.mpsqa.build)" version="0" />
   </dependencyVersions>
 </solution>

--- a/code/languages/org.mpsqa.testing/.mps/modules.xml
+++ b/code/languages/org.mpsqa.testing/.mps/modules.xml
@@ -10,6 +10,7 @@
       <modulePath path="$PROJECT_DIR$/solutions/org.mpsqa.testcov.buildIntegration.jacoco.codeowners.tests/org.mpsqa.testcov.buildIntegration.jacoco.codeowners.tests.msd" folder="buildIntegration.tests" />
       <modulePath path="$PROJECT_DIR$/solutions/org.mpsqa.testcov.jacoco.rt/org.mpsqa.testcov.jacoco.rt.msd" folder="testcov" />
       <modulePath path="$PROJECT_DIR$/solutions/org.mpsqa.testcov.jacoco.sandbox/org.mpsqa.testcov.jacoco.sandbox.msd" folder="testcov" />
+      <modulePath path="$PROJECT_DIR$/solutions/org.mpsqa.testing.build/org.mpsqa.testing.build.msd" folder="_build" />
       <modulePath path="$PROJECT_DIR$/solutions/org.mpsqa.testing.tests.build/org.mpsqa.testing.tests.build.msd" folder="_build" />
     </projectModules>
   </component>

--- a/code/languages/org.mpsqa.testing/solutions/org.mpsqa.testing.build/models/org.mpsqa.testing.build.mps
+++ b/code/languages/org.mpsqa.testing/solutions/org.mpsqa.testing.build/models/org.mpsqa.testing.build.mps
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<model ref="r:b207e9c3-ef31-40d7-92fc-7e446d92ce2a(org.mpsqa.build._020_testing_build)">
+<model ref="r:b207e9c3-ef31-40d7-92fc-7e446d92ce2a(org.mpsqa.testing.build)">
   <persistence version="9" />
   <languages>
     <use id="798100da-4f0a-421a-b991-71f8c50ce5d2" name="jetbrains.mps.build" version="0" />
@@ -86,6 +86,9 @@
       <concept id="6592112598314498926" name="jetbrains.mps.build.mps.structure.BuildMpsLayout_Plugin" flags="ng" index="m$_wl">
         <reference id="6592112598314801433" name="plugin" index="m_rDy" />
         <child id="3570488090019868128" name="packagingType" index="pUk7w" />
+      </concept>
+      <concept id="6592112598314499036" name="jetbrains.mps.build.mps.structure.BuildMps_IdeaPluginModule" flags="ng" index="m$_yB">
+        <reference id="6592112598314499037" name="target" index="m$_yA" />
       </concept>
       <concept id="6592112598314499027" name="jetbrains.mps.build.mps.structure.BuildMps_IdeaPluginDependency" flags="ng" index="m$_yC">
         <reference id="6592112598314499066" name="target" index="m$_y1" />
@@ -189,6 +192,10 @@
       </node>
     </node>
     <node concept="1l3spV" id="2JVMSZMFXhb" role="1l3spN">
+      <node concept="m$_wl" id="2XCAdv5ub7B" role="39821P">
+        <ref role="m_rDy" node="2XCAdv5uaeq" resolve="org.mpsqa.testing.build" />
+        <node concept="pUk6x" id="2XCAdv5ubbf" role="pUk7w" />
+      </node>
       <node concept="m$_wl" id="2JVMSZMFXhf" role="39821P">
         <ref role="m_rDy" node="2JVMSZMFXh0" resolve="org.mpsqa.testing" />
         <node concept="pUk6x" id="52XWqlKvt_S" role="pUk7w" />
@@ -298,6 +305,33 @@
       <property role="2_Ic$$" value="true" />
       <property role="2_Ic$B" value="true" />
     </node>
+    <node concept="m$_wf" id="2XCAdv5uaeq" role="3989C9">
+      <property role="m$_wk" value="org.mpsqa.testing.build" />
+      <node concept="3_J27D" id="2XCAdv5uaer" role="m$_yQ">
+        <node concept="3Mxwew" id="2XCAdv5uaes" role="3MwsjC">
+          <property role="3MwjfP" value="org.mpsqa.testing.build" />
+        </node>
+      </node>
+      <node concept="3_J27D" id="2XCAdv5uaet" role="m$_w8">
+        <node concept="3Mxwew" id="2XCAdv5uaeu" role="3MwsjC">
+          <property role="3MwjfP" value="1.0" />
+        </node>
+      </node>
+      <node concept="m$_yB" id="2XCAdv5ub40" role="m$_yh">
+        <ref role="m$_yA" node="2XCAdv5uaH8" resolve="org.mpsqa.testing.build" />
+      </node>
+      <node concept="m$_yC" id="2XCAdv5uaew" role="m$_yJ">
+        <ref role="m$_y1" to="ffeo:5HVSRHdVm9a" resolve="jetbrains.mps.build" />
+      </node>
+      <node concept="m$_yC" id="2XCAdv5uaex" role="m$_yJ">
+        <ref role="m$_y1" to="2tou:32O483pJLpG" resolve="org.mpsqa.base.build" />
+      </node>
+      <node concept="3_J27D" id="2XCAdv5uaey" role="m_cZH">
+        <node concept="3Mxwew" id="2XCAdv5uaez" role="3MwsjC">
+          <property role="3MwjfP" value="org.mpsqa.testing.build" />
+        </node>
+      </node>
+    </node>
     <node concept="m$_wf" id="2JVMSZMFXh0" role="3989C9">
       <property role="m$_wk" value="org.mpsqa.testing" />
       <node concept="3_J27D" id="2JVMSZMFXh1" role="m$_yQ">
@@ -322,6 +356,71 @@
       <node concept="3_J27D" id="2JVMSZMFXh7" role="m_cZH">
         <node concept="3Mxwew" id="2JVMSZMFXh8" role="3MwsjC">
           <property role="3MwjfP" value="org.mpsqa.testing" />
+        </node>
+      </node>
+    </node>
+    <node concept="1E1JtA" id="2XCAdv5uaH8" role="3989C9">
+      <property role="BnDLt" value="true" />
+      <property role="TrG5h" value="org.mpsqa.testing.build" />
+      <property role="3LESm3" value="3bf16f17-7850-4b1d-804b-c60206298996" />
+      <node concept="398BVA" id="2XCAdv5uaQC" role="3LF7KH">
+        <ref role="398BVh" node="2JVMSZMFXgq" resolve="mpsqa.testing.home" />
+        <node concept="2Ry0Ak" id="2XCAdv5uaT6" role="iGT6I">
+          <property role="2Ry0Am" value="solutions" />
+          <node concept="2Ry0Ak" id="2XCAdv5uaVz" role="2Ry0An">
+            <property role="2Ry0Am" value="org.mpsqa.testing.build" />
+            <node concept="2Ry0Ak" id="2XCAdv5uaY0" role="2Ry0An">
+              <property role="2Ry0Am" value="org.mpsqa.testing.build.msd" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="1SiIV0" id="2XCAdv5ub1R" role="3bR37C">
+        <node concept="3bR9La" id="2XCAdv5ub1S" role="1SiIV1">
+          <ref role="3bR37D" to="2tou:32O483pJL16" resolve="org.mpsqa.base.build" />
+        </node>
+      </node>
+      <node concept="1SiIV0" id="2XCAdv5ub1T" role="3bR37C">
+        <node concept="3bR9La" id="2XCAdv5ub1U" role="1SiIV1">
+          <ref role="3bR37D" to="ffeo:78GwwOvB3tw" resolve="jetbrains.mps.ide.build" />
+        </node>
+      </node>
+      <node concept="1BupzO" id="2XCAdv5ub26" role="3bR31x">
+        <property role="3ZfqAx" value="models" />
+        <property role="1Hdu6h" value="true" />
+        <property role="1HemKv" value="true" />
+        <node concept="3LXTmp" id="2XCAdv5ub27" role="1HemKq">
+          <node concept="398BVA" id="2XCAdv5ub1V" role="3LXTmr">
+            <ref role="398BVh" node="2JVMSZMFXgq" resolve="mpsqa.testing.home" />
+            <node concept="2Ry0Ak" id="2XCAdv5ub1W" role="iGT6I">
+              <property role="2Ry0Am" value="solutions" />
+              <node concept="2Ry0Ak" id="2XCAdv5ub1X" role="2Ry0An">
+                <property role="2Ry0Am" value="org.mpsqa.testing.build" />
+                <node concept="2Ry0Ak" id="2XCAdv5ub1Y" role="2Ry0An">
+                  <property role="2Ry0Am" value="models" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3qWCbU" id="2XCAdv5ub28" role="3LXTna">
+            <property role="3qWCbO" value="**/*.mps, **/*.mpsr, **/.model" />
+          </node>
+        </node>
+      </node>
+      <node concept="3rtmxn" id="2XCAdv5ubcu" role="3bR31x">
+        <node concept="3LXTmp" id="2XCAdv5ubcv" role="3rtmxm">
+          <node concept="398BVA" id="2XCAdv5ubcw" role="3LXTmr">
+            <ref role="398BVh" node="2JVMSZMFXgq" resolve="mpsqa.testing.home" />
+            <node concept="2Ry0Ak" id="2XCAdv5ubcx" role="iGT6I">
+              <property role="2Ry0Am" value="solutions" />
+              <node concept="2Ry0Ak" id="2XCAdv5ubcy" role="2Ry0An">
+                <property role="2Ry0Am" value="org.mpsqa.testing.build" />
+              </node>
+            </node>
+          </node>
+          <node concept="3qWCbU" id="2XCAdv5ubc$" role="3LXTna">
+            <property role="3qWCbO" value="icons/**" />
+          </node>
         </node>
       </node>
     </node>

--- a/code/languages/org.mpsqa.testing/solutions/org.mpsqa.testing.build/org.mpsqa.testing.build.msd
+++ b/code/languages/org.mpsqa.testing/solutions/org.mpsqa.testing.build/org.mpsqa.testing.build.msd
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<solution name="org.mpsqa.build" uuid="11d4368a-a7e8-4dd9-bfc6-c2de268d1994" moduleVersion="0" compileInMPS="true">
+<solution name="org.mpsqa.testing.build" uuid="3bf16f17-7850-4b1d-804b-c60206298996" moduleVersion="0" compileInMPS="true">
   <models>
     <modelRoot contentPath="${module}" type="default">
       <sourceRoot location="models" />
@@ -12,9 +12,8 @@
   </facets>
   <sourcePath />
   <dependencies>
-    <dependency reexport="false">422c2909-59d6-41a9-b318-40e6256b250f(jetbrains.mps.ide.build)</dependency>
     <dependency reexport="false">5e8cea6b-997f-49b1-a8d8-dc2a7a6fa657(org.mpsqa.base.build)</dependency>
-    <dependency reexport="false">3bf16f17-7850-4b1d-804b-c60206298996(org.mpsqa.testing.build)</dependency>
+    <dependency reexport="false">422c2909-59d6-41a9-b318-40e6256b250f(jetbrains.mps.ide.build)</dependency>
   </dependencies>
   <languageVersions>
     <language slang="l:798100da-4f0a-421a-b991-71f8c50ce5d2:jetbrains.mps.build" version="0" />
@@ -24,7 +23,6 @@
   <dependencyVersions>
     <module reference="422c2909-59d6-41a9-b318-40e6256b250f(jetbrains.mps.ide.build)" version="0" />
     <module reference="5e8cea6b-997f-49b1-a8d8-dc2a7a6fa657(org.mpsqa.base.build)" version="0" />
-    <module reference="11d4368a-a7e8-4dd9-bfc6-c2de268d1994(org.mpsqa.build)" version="0" />
     <module reference="3bf16f17-7850-4b1d-804b-c60206298996(org.mpsqa.testing.build)" version="0" />
   </dependencyVersions>
 </solution>

--- a/code/languages/org.mpsqa.testing/solutions/org.mpsqa.testing.tests.build/models/org.mpsqa.testing.tests.build.mps
+++ b/code/languages/org.mpsqa.testing/solutions/org.mpsqa.testing.tests.build/models/org.mpsqa.testing.tests.build.mps
@@ -7,7 +7,7 @@
     <use id="3600cb0a-44dd-4a5b-9968-22924406419e" name="jetbrains.mps.build.mps.tests" version="1" />
   </languages>
   <imports>
-    <import index="hx16" ref="r:b207e9c3-ef31-40d7-92fc-7e446d92ce2a(org.mpsqa.build._020_testing_build)" />
+    <import index="hx16" ref="r:b207e9c3-ef31-40d7-92fc-7e446d92ce2a(org.mpsqa.testing.build)" />
     <import index="ffeo" ref="r:874d959d-e3b4-4d04-b931-ca849af130dd(jetbrains.mps.ide.build)" />
     <import index="2tou" ref="r:18bebd8f-6332-4ffd-b628-cc9dad4ef421(org.mpsqa.build._010_base_build)" />
   </imports>

--- a/code/languages/org.mpsqa.testing/solutions/org.mpsqa.testing.tests.build/org.mpsqa.testing.tests.build.msd
+++ b/code/languages/org.mpsqa.testing/solutions/org.mpsqa.testing.tests.build/org.mpsqa.testing.tests.build.msd
@@ -12,8 +12,9 @@
   </facets>
   <sourcePath />
   <dependencies>
-    <dependency reexport="false">11d4368a-a7e8-4dd9-bfc6-c2de268d1994(org.mpsqa.build)</dependency>
     <dependency reexport="false">422c2909-59d6-41a9-b318-40e6256b250f(jetbrains.mps.ide.build)</dependency>
+    <dependency reexport="false">3bf16f17-7850-4b1d-804b-c60206298996(org.mpsqa.testing.build)</dependency>
+    <dependency reexport="false">5e8cea6b-997f-49b1-a8d8-dc2a7a6fa657(org.mpsqa.base.build)</dependency>
   </dependencies>
   <languageVersions>
     <language slang="l:798100da-4f0a-421a-b991-71f8c50ce5d2:jetbrains.mps.build" version="0" />
@@ -23,7 +24,8 @@
   </languageVersions>
   <dependencyVersions>
     <module reference="422c2909-59d6-41a9-b318-40e6256b250f(jetbrains.mps.ide.build)" version="0" />
-    <module reference="11d4368a-a7e8-4dd9-bfc6-c2de268d1994(org.mpsqa.build)" version="0" />
+    <module reference="5e8cea6b-997f-49b1-a8d8-dc2a7a6fa657(org.mpsqa.base.build)" version="0" />
+    <module reference="3bf16f17-7850-4b1d-804b-c60206298996(org.mpsqa.testing.build)" version="0" />
     <module reference="e00d37eb-37fc-4a62-b803-95a116d28ecd(org.mpsqa.testing.tests.build)" version="0" />
   </dependencyVersions>
 </solution>


### PR DESCRIPTION
This is a prerequisite for adding a test for jacoco integration in the testing project.

This is a breaking change but should be easily fixed with Alt+Enter and adding dependencies on the new modules.