### PR TITLE
lint: re-write linter "models_in_same_project_with_same_IDs"

### DIFF
--- a/code/languages/org.mpsqa.lint/solutions/org.mpsqa.lint.generic.linters_library/models/org.mpsqa.lint.generic.linters_library.models.mps
+++ b/code/languages/org.mpsqa.lint/solutions/org.mpsqa.lint.generic.linters_library/models/org.mpsqa.lint.generic.linters_library.models.mps
@@ -1787,7 +1787,7 @@
                                       </node>
                                       <node concept="2OqwBi" id="3$9W3co6PWg" role="3uHU7B">
                                         <node concept="37vLTw" id="61xqYhG1SH4" role="2Oq$k0">
-                                          <ref role="3cqZAo" node="61xqYhG1SH0" resolve="toString" />
+                                          <ref role="3cqZAo" node="61xqYhG1SH0" resolve="fileName" />
                                         </node>
                                         <node concept="liA8E" id="3$9W3co6PWk" role="2OqNvi">
                                           <ref role="37wK5l" to="wyt6:~String.endsWith(java.lang.String)" resolve="endsWith" />

--- a/code/languages/org.mpsqa.lint/solutions/org.mpsqa.lint.generic.linters_library/models/org.mpsqa.lint.generic.linters_library.models.mps
+++ b/code/languages/org.mpsqa.lint/solutions/org.mpsqa.lint.generic.linters_library/models/org.mpsqa.lint.generic.linters_library.models.mps
@@ -35,6 +35,10 @@
     <import index="mhfm" ref="3f233e7f-b8a6-46d2-a57f-795d56775243/java:org.jetbrains.annotations(Annotations/)" />
     <import index="2gg1" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.errors(MPS.Core/)" />
     <import index="g3l6" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.extapi.model(MPS.Core/)" />
+    <import index="guwi" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.io(JDK/)" />
+    <import index="eoo2" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.nio.file(JDK/)" />
+    <import index="4qvk" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.nio.file.attribute(JDK/)" />
+    <import index="z1c4" ref="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61/java:jetbrains.mps.project(MPS.Platform/)" />
   </imports>
   <registry>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
@@ -48,6 +52,9 @@
       </concept>
       <concept id="4836112446988635817" name="jetbrains.mps.baseLanguage.structure.UndefinedType" flags="in" index="2jxLKc" />
       <concept id="1202948039474" name="jetbrains.mps.baseLanguage.structure.InstanceMethodCallOperation" flags="nn" index="liA8E" />
+      <concept id="8118189177080264853" name="jetbrains.mps.baseLanguage.structure.AlternativeType" flags="ig" index="nSUau">
+        <child id="8118189177080264854" name="alternative" index="nSUat" />
+      </concept>
       <concept id="1465982738277781862" name="jetbrains.mps.baseLanguage.structure.PlaceholderMember" flags="nn" index="2tJIrI" />
       <concept id="1188207840427" name="jetbrains.mps.baseLanguage.structure.AnnotationInstance" flags="nn" index="2AHcQZ">
         <reference id="1188208074048" name="annotation" index="2AI5Lk" />
@@ -78,6 +85,10 @@
       <concept id="1070475354124" name="jetbrains.mps.baseLanguage.structure.ThisExpression" flags="nn" index="Xjq3P" />
       <concept id="1070475926800" name="jetbrains.mps.baseLanguage.structure.StringLiteral" flags="nn" index="Xl_RD">
         <property id="1070475926801" name="value" index="Xl_RC" />
+      </concept>
+      <concept id="4952749571008284462" name="jetbrains.mps.baseLanguage.structure.CatchVariable" flags="ng" index="XOnhg" />
+      <concept id="1182160077978" name="jetbrains.mps.baseLanguage.structure.AnonymousClassCreator" flags="nn" index="YeOm9">
+        <child id="1182160096073" name="cls" index="YeSDq" />
       </concept>
       <concept id="1081236700937" name="jetbrains.mps.baseLanguage.structure.StaticMethodCall" flags="nn" index="2YIFZM">
         <reference id="1144433194310" name="classConcept" index="1Pybhc" />
@@ -115,6 +126,7 @@
         <child id="5680397130376446158" name="type" index="1tU5fm" />
       </concept>
       <concept id="1068580123132" name="jetbrains.mps.baseLanguage.structure.BaseMethodDeclaration" flags="ng" index="3clF44">
+        <child id="1164879685961" name="throwsItem" index="Sfmx6" />
         <child id="1068580123133" name="returnType" index="3clF45" />
         <child id="1068580123134" name="parameter" index="3clF46" />
         <child id="1068580123135" name="body" index="3clF47" />
@@ -160,10 +172,12 @@
         <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
         <child id="1068499141038" name="actualArgument" index="37wK5m" />
       </concept>
+      <concept id="1073063089578" name="jetbrains.mps.baseLanguage.structure.SuperMethodCall" flags="nn" index="3nyPlj" />
       <concept id="1212685548494" name="jetbrains.mps.baseLanguage.structure.ClassCreator" flags="nn" index="1pGfFk">
         <child id="1212687122400" name="typeParameter" index="1pMfVU" />
       </concept>
       <concept id="1107461130800" name="jetbrains.mps.baseLanguage.structure.Classifier" flags="ng" index="3pOWGL">
+        <property id="521412098689998745" name="nonStatic" index="2bfB8j" />
         <child id="5375687026011219971" name="member" index="jymVt" unordered="true" />
       </concept>
       <concept id="1171903607971" name="jetbrains.mps.baseLanguage.structure.WildCardType" flags="in" index="3qTvmN" />
@@ -175,13 +189,28 @@
         <child id="1081773367579" name="rightExpression" index="3uHU7w" />
         <child id="1081773367580" name="leftExpression" index="3uHU7B" />
       </concept>
+      <concept id="3093926081414150598" name="jetbrains.mps.baseLanguage.structure.MultipleCatchClause" flags="ng" index="3uVAMA">
+        <child id="8276990574895933173" name="catchBody" index="1zc67A" />
+        <child id="8276990574895933172" name="throwable" index="1zc67B" />
+      </concept>
       <concept id="1073239437375" name="jetbrains.mps.baseLanguage.structure.NotEqualsExpression" flags="nn" index="3y3z36" />
       <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ng" index="1B3ioH">
         <child id="1178549979242" name="visibility" index="1B3o_S" />
       </concept>
+      <concept id="5351203823916750322" name="jetbrains.mps.baseLanguage.structure.TryUniversalStatement" flags="nn" index="3J1_TO">
+        <child id="8276990574886367510" name="catchClause" index="1zxBo5" />
+        <child id="8276990574886367508" name="body" index="1zxBo7" />
+      </concept>
       <concept id="1082113931046" name="jetbrains.mps.baseLanguage.structure.ContinueStatement" flags="nn" index="3N13vt" />
+      <concept id="6329021646629104954" name="jetbrains.mps.baseLanguage.structure.SingleLineComment" flags="nn" index="3SKdUt">
+        <child id="8356039341262087992" name="line" index="1aUNEU" />
+      </concept>
       <concept id="1146644602865" name="jetbrains.mps.baseLanguage.structure.PublicVisibility" flags="nn" index="3Tm1VV" />
       <concept id="1080120340718" name="jetbrains.mps.baseLanguage.structure.AndExpression" flags="nn" index="1Wc70l" />
+      <concept id="1170345865475" name="jetbrains.mps.baseLanguage.structure.AnonymousClass" flags="ig" index="1Y3b0j">
+        <reference id="1170346070688" name="classifier" index="1Y3XeK" />
+        <child id="1201186121363" name="typeParameter" index="2Ghqu4" />
+      </concept>
     </language>
     <language id="40ab19e9-751a-4433-b645-0e65160e58a0" name="org.mpsqa.lint.generic">
       <concept id="7741759128795038157" name="org.mpsqa.lint.generic.structure.CheckableScriptParameter" flags="ng" index="2j1K4_">
@@ -214,9 +243,16 @@
       <concept id="2555875871751904530" name="org.mpsqa.lint.generic.structure.CheckingFunction" flags="ig" index="1MIXq2" />
     </language>
     <language id="fd392034-7849-419d-9071-12563d152375" name="jetbrains.mps.baseLanguage.closures">
+      <concept id="1199542442495" name="jetbrains.mps.baseLanguage.closures.structure.FunctionType" flags="in" index="1ajhzC">
+        <child id="1199542457201" name="resultType" index="1ajl9A" />
+        <child id="1199542501692" name="parameterType" index="1ajw0F" />
+      </concept>
       <concept id="1199569711397" name="jetbrains.mps.baseLanguage.closures.structure.ClosureLiteral" flags="nn" index="1bVj0M">
         <child id="1199569906740" name="parameter" index="1bW2Oz" />
         <child id="1199569916463" name="body" index="1bW5cS" />
+      </concept>
+      <concept id="1225797177491" name="jetbrains.mps.baseLanguage.closures.structure.InvokeFunctionOperation" flags="nn" index="1Bd96e">
+        <child id="1225797361612" name="parameter" index="1BdPVh" />
       </concept>
     </language>
     <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
@@ -252,7 +288,6 @@
       </concept>
     </language>
     <language id="1a8554c4-eb84-43ba-8c34-6f0d90c6e75a" name="jetbrains.mps.lang.smodel.query">
-      <concept id="6864030874028745314" name="jetbrains.mps.lang.smodel.query.structure.ModulesExpression" flags="ng" index="EzsRk" />
       <concept id="6864030874027862829" name="jetbrains.mps.lang.smodel.query.structure.ModelsExpression" flags="ng" index="EZOir" />
       <concept id="4234138103881610891" name="jetbrains.mps.lang.smodel.query.structure.WithStatement" flags="ng" index="L3pyB">
         <child id="4234138103881610935" name="scope" index="L3pyr" />
@@ -1611,98 +1646,411 @@
             </node>
           </node>
         </node>
+        <node concept="3cpWs8" id="3$9W3co3cMp" role="3cqZAp">
+          <node concept="3cpWsn" id="3$9W3co3cMq" role="3cpWs9">
+            <property role="TrG5h" value="projectDir" />
+            <node concept="3uibUv" id="3$9W3co3cAG" role="1tU5fm">
+              <ref role="3uigEE" to="guwi:~File" resolve="File" />
+            </node>
+            <node concept="2OqwBi" id="3$9W3co3cMr" role="33vP2m">
+              <node concept="1MG55F" id="3$9W3co3cMs" role="2Oq$k0" />
+              <node concept="liA8E" id="3$9W3co3cMt" role="2OqNvi">
+                <ref role="37wK5l" to="z1c4:~MPSProject.getProjectFile()" resolve="getProjectFile" />
+              </node>
+            </node>
+          </node>
+        </node>
         <node concept="3clFbH" id="3jiJ$OUDXtj" role="3cqZAp" />
-        <node concept="L3pyB" id="3jiJ$OUDXtk" role="3cqZAp">
-          <node concept="3clFbS" id="3jiJ$OUDXtl" role="L3pyw">
-            <node concept="3cpWs8" id="3jiJ$OUBO$C" role="3cqZAp">
-              <node concept="3cpWsn" id="3jiJ$OUBO$F" role="3cpWs9">
-                <property role="TrG5h" value="alreadyCollectedIDs2Models" />
-                <node concept="3rvAFt" id="3jiJ$OUEt3A" role="1tU5fm">
-                  <node concept="17QB3L" id="3jiJ$OUEtDi" role="3rvQeY" />
-                  <node concept="H_c77" id="3jiJ$OUEugE" role="3rvSg0" />
-                </node>
-                <node concept="2ShNRf" id="3jiJ$OUBQ1j" role="33vP2m">
-                  <node concept="3rGOSV" id="3jiJ$OUExc$" role="2ShVmc">
-                    <node concept="17QB3L" id="3jiJ$OUEy8l" role="3rHrn6" />
-                    <node concept="H_c77" id="3jiJ$OUEyBI" role="3rHtpV" />
-                  </node>
+        <node concept="3cpWs8" id="61xqYhFZGqu" role="3cqZAp">
+          <node concept="3cpWsn" id="61xqYhFZGqx" role="3cpWs9">
+            <property role="TrG5h" value="modelFiles" />
+            <property role="3TUv4t" value="true" />
+            <node concept="_YKpA" id="61xqYhFZGqq" role="1tU5fm">
+              <node concept="3uibUv" id="61xqYhFZTLC" role="_ZDj9">
+                <ref role="3uigEE" to="guwi:~File" resolve="File" />
+              </node>
+            </node>
+            <node concept="2ShNRf" id="61xqYhFZNCE" role="33vP2m">
+              <node concept="Tc6Ow" id="61xqYhFZQQE" role="2ShVmc">
+                <node concept="3uibUv" id="61xqYhFZUOi" role="HW$YZ">
+                  <ref role="3uigEE" to="guwi:~File" resolve="File" />
                 </node>
               </node>
             </node>
-            <node concept="2Gpval" id="3jiJ$OUDXtw" role="3cqZAp">
-              <node concept="2GrKxI" id="3jiJ$OUDXtx" role="2Gsz3X">
-                <property role="TrG5h" value="module" />
+          </node>
+        </node>
+        <node concept="3cpWs8" id="3$9W3co6PVS" role="3cqZAp">
+          <node concept="3cpWsn" id="3$9W3co6PVT" role="3cpWs9">
+            <property role="TrG5h" value="function" />
+            <node concept="1ajhzC" id="3$9W3co6PVO" role="1tU5fm">
+              <node concept="17QB3L" id="3$9W3co6PVP" role="1ajw0F" />
+              <node concept="3cqZAl" id="3$9W3co73sY" role="1ajl9A" />
+            </node>
+            <node concept="1bVj0M" id="3$9W3co6PVU" role="33vP2m">
+              <node concept="3clFbS" id="3$9W3co6PVV" role="1bW5cS">
+                <node concept="3J1_TO" id="3$9W3co6WGk" role="3cqZAp">
+                  <node concept="3uVAMA" id="3$9W3co6X7m" role="1zxBo5">
+                    <node concept="XOnhg" id="3$9W3co6X7n" role="1zc67B">
+                      <property role="TrG5h" value="ioe" />
+                      <node concept="nSUau" id="3$9W3co6X7o" role="1tU5fm">
+                        <node concept="3uibUv" id="3$9W3co6XxB" role="nSUat">
+                          <ref role="3uigEE" to="guwi:~IOException" resolve="IOException" />
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="3clFbS" id="3$9W3co6X7p" role="1zc67A">
+                      <node concept="3clFbF" id="3$9W3co42k7" role="3cqZAp">
+                        <node concept="2OqwBi" id="3$9W3co42KH" role="3clFbG">
+                          <node concept="37vLTw" id="3$9W3co42k6" role="2Oq$k0">
+                            <ref role="3cqZAo" node="3$9W3co6X7n" resolve="ioe" />
+                          </node>
+                          <node concept="liA8E" id="3$9W3co43gw" role="2OqNvi">
+                            <ref role="37wK5l" to="wyt6:~Throwable.printStackTrace()" resolve="printStackTrace" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3clFbS" id="3$9W3co6WGm" role="1zxBo7">
+                    <node concept="3clFbF" id="3$9W3co6PVW" role="3cqZAp">
+                      <node concept="2YIFZM" id="3$9W3co6PVX" role="3clFbG">
+                        <ref role="37wK5l" to="eoo2:~Files.walkFileTree(java.nio.file.Path,java.nio.file.FileVisitor)" resolve="walkFileTree" />
+                        <ref role="1Pybhc" to="eoo2:~Files" resolve="Files" />
+                        <node concept="2OqwBi" id="3$9W3co6PVY" role="37wK5m">
+                          <node concept="37vLTw" id="3$9W3co6PVZ" role="2Oq$k0">
+                            <ref role="3cqZAo" node="3$9W3co3cMq" resolve="projectDir" />
+                          </node>
+                          <node concept="liA8E" id="3$9W3co6PW0" role="2OqNvi">
+                            <ref role="37wK5l" to="guwi:~File.toPath()" resolve="toPath" />
+                          </node>
+                        </node>
+                        <node concept="2ShNRf" id="3$9W3co6PW1" role="37wK5m">
+                          <node concept="YeOm9" id="3$9W3co6PW2" role="2ShVmc">
+                            <node concept="1Y3b0j" id="3$9W3co6PW3" role="YeSDq">
+                              <property role="2bfB8j" value="true" />
+                              <ref role="37wK5l" to="eoo2:~SimpleFileVisitor.&lt;init&gt;()" resolve="SimpleFileVisitor" />
+                              <ref role="1Y3XeK" to="eoo2:~SimpleFileVisitor" resolve="SimpleFileVisitor" />
+                              <node concept="3Tm1VV" id="3$9W3co6PW4" role="1B3o_S" />
+                              <node concept="3uibUv" id="3$9W3co6PW5" role="2Ghqu4">
+                                <ref role="3uigEE" to="eoo2:~Path" resolve="Path" />
+                              </node>
+                              <node concept="3clFb_" id="3$9W3co6PW6" role="jymVt">
+                                <property role="TrG5h" value="visitFile" />
+                                <node concept="3Tm1VV" id="3$9W3co6PW7" role="1B3o_S" />
+                                <node concept="3uibUv" id="3$9W3co6PW8" role="3clF45">
+                                  <ref role="3uigEE" to="eoo2:~FileVisitResult" resolve="FileVisitResult" />
+                                </node>
+                                <node concept="37vLTG" id="3$9W3co6PW9" role="3clF46">
+                                  <property role="TrG5h" value="file" />
+                                  <node concept="3uibUv" id="3$9W3co6PWa" role="1tU5fm">
+                                    <ref role="3uigEE" to="eoo2:~Path" resolve="Path" />
+                                  </node>
+                                </node>
+                                <node concept="37vLTG" id="3$9W3co6PWb" role="3clF46">
+                                  <property role="TrG5h" value="attrs" />
+                                  <node concept="3uibUv" id="3$9W3co6PWc" role="1tU5fm">
+                                    <ref role="3uigEE" to="4qvk:~BasicFileAttributes" resolve="BasicFileAttributes" />
+                                  </node>
+                                </node>
+                                <node concept="3uibUv" id="3$9W3co6PWd" role="Sfmx6">
+                                  <ref role="3uigEE" to="guwi:~IOException" resolve="IOException" />
+                                </node>
+                                <node concept="3clFbS" id="3$9W3co6PWe" role="3clF47">
+                                  <node concept="3cpWs8" id="61xqYhG1SGZ" role="3cqZAp">
+                                    <node concept="3cpWsn" id="61xqYhG1SH0" role="3cpWs9">
+                                      <property role="TrG5h" value="fileName" />
+                                      <node concept="17QB3L" id="61xqYhG1Uut" role="1tU5fm" />
+                                      <node concept="2OqwBi" id="61xqYhG1SH1" role="33vP2m">
+                                        <node concept="37vLTw" id="61xqYhG1SH2" role="2Oq$k0">
+                                          <ref role="3cqZAo" node="3$9W3co6PW9" resolve="file" />
+                                        </node>
+                                        <node concept="liA8E" id="61xqYhG1SH3" role="2OqNvi">
+                                          <ref role="37wK5l" to="eoo2:~Path.toString()" resolve="toString" />
+                                        </node>
+                                      </node>
+                                    </node>
+                                  </node>
+                                  <node concept="3clFbJ" id="3$9W3co6PWf" role="3cqZAp">
+                                    <node concept="1Wc70l" id="61xqYhG1Q5i" role="3clFbw">
+                                      <node concept="3fqX7Q" id="61xqYhG1XDv" role="3uHU7w">
+                                        <node concept="2OqwBi" id="61xqYhG1XDx" role="3fr31v">
+                                          <node concept="37vLTw" id="61xqYhG1XDy" role="2Oq$k0">
+                                            <ref role="3cqZAo" node="61xqYhG1SH0" resolve="fileName" />
+                                          </node>
+                                          <node concept="liA8E" id="61xqYhG1XDz" role="2OqNvi">
+                                            <ref role="37wK5l" to="wyt6:~String.contains(java.lang.CharSequence)" resolve="contains" />
+                                            <node concept="Xl_RD" id="61xqYhG1XD$" role="37wK5m">
+                                              <property role="Xl_RC" value="descriptorclasses" />
+                                            </node>
+                                          </node>
+                                        </node>
+                                      </node>
+                                      <node concept="2OqwBi" id="3$9W3co6PWg" role="3uHU7B">
+                                        <node concept="37vLTw" id="61xqYhG1SH4" role="2Oq$k0">
+                                          <ref role="3cqZAo" node="61xqYhG1SH0" resolve="toString" />
+                                        </node>
+                                        <node concept="liA8E" id="3$9W3co6PWk" role="2OqNvi">
+                                          <ref role="37wK5l" to="wyt6:~String.endsWith(java.lang.String)" resolve="endsWith" />
+                                          <node concept="37vLTw" id="3$9W3co6PWl" role="37wK5m">
+                                            <ref role="3cqZAo" node="3$9W3co6PW_" resolve="extension" />
+                                          </node>
+                                        </node>
+                                      </node>
+                                    </node>
+                                    <node concept="3clFbS" id="3$9W3co6PWm" role="3clFbx">
+                                      <node concept="3clFbF" id="3$9W3co6PWn" role="3cqZAp">
+                                        <node concept="2OqwBi" id="3$9W3co6PWo" role="3clFbG">
+                                          <node concept="37vLTw" id="3$9W3co6PWp" role="2Oq$k0">
+                                            <ref role="3cqZAo" node="61xqYhFZGqx" resolve="modelFiles" />
+                                          </node>
+                                          <node concept="TSZUe" id="3$9W3co6PWq" role="2OqNvi">
+                                            <node concept="2OqwBi" id="3$9W3co6PWs" role="25WWJ7">
+                                              <node concept="37vLTw" id="3$9W3co6PWt" role="2Oq$k0">
+                                                <ref role="3cqZAo" node="3$9W3co6PW9" resolve="file" />
+                                              </node>
+                                              <node concept="liA8E" id="3$9W3co6PWu" role="2OqNvi">
+                                                <ref role="37wK5l" to="eoo2:~Path.toFile()" resolve="toFile" />
+                                              </node>
+                                            </node>
+                                          </node>
+                                        </node>
+                                      </node>
+                                    </node>
+                                  </node>
+                                  <node concept="3clFbF" id="3$9W3co6PWw" role="3cqZAp">
+                                    <node concept="3nyPlj" id="3$9W3co6PWx" role="3clFbG">
+                                      <ref role="37wK5l" to="eoo2:~SimpleFileVisitor.visitFile(java.lang.Object,java.nio.file.attribute.BasicFileAttributes)" resolve="visitFile" />
+                                      <node concept="37vLTw" id="3$9W3co6PWy" role="37wK5m">
+                                        <ref role="3cqZAo" node="3$9W3co6PW9" resolve="file" />
+                                      </node>
+                                      <node concept="37vLTw" id="3$9W3co6PWz" role="37wK5m">
+                                        <ref role="3cqZAo" node="3$9W3co6PWb" resolve="attrs" />
+                                      </node>
+                                    </node>
+                                  </node>
+                                </node>
+                                <node concept="2AHcQZ" id="3$9W3co6PW$" role="2AJF6D">
+                                  <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
               </node>
-              <node concept="EzsRk" id="3jiJ$OUDXty" role="2GsD0m" />
-              <node concept="3clFbS" id="3jiJ$OUDXtz" role="2LFqv$">
-                <node concept="2Gpval" id="3jiJ$OUE67l" role="3cqZAp">
-                  <node concept="2GrKxI" id="3jiJ$OUE67n" role="2Gsz3X">
-                    <property role="TrG5h" value="currentModel" />
-                  </node>
-                  <node concept="2OqwBi" id="3jiJ$OUE8mk" role="2GsD0m">
-                    <node concept="2GrUjf" id="3jiJ$OUE88P" role="2Oq$k0">
-                      <ref role="2Gs0qQ" node="3jiJ$OUDXtx" resolve="module" />
+              <node concept="37vLTG" id="3$9W3co6PW_" role="1bW2Oz">
+                <property role="TrG5h" value="extension" />
+                <property role="3TUv4t" value="true" />
+                <node concept="17QB3L" id="3$9W3co6PWA" role="1tU5fm" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="3$9W3co6S5b" role="3cqZAp">
+          <node concept="2OqwBi" id="3$9W3co6Suv" role="3clFbG">
+            <node concept="37vLTw" id="3$9W3co6S59" role="2Oq$k0">
+              <ref role="3cqZAo" node="3$9W3co6PVT" resolve="function" />
+            </node>
+            <node concept="1Bd96e" id="3$9W3co6SYp" role="2OqNvi">
+              <node concept="Xl_RD" id="3$9W3co6Tnp" role="1BdPVh">
+                <property role="Xl_RC" value=".mps" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="61xqYhFZYTS" role="3cqZAp">
+          <node concept="2OqwBi" id="61xqYhFZYTT" role="3clFbG">
+            <node concept="37vLTw" id="61xqYhFZYTU" role="2Oq$k0">
+              <ref role="3cqZAo" node="3$9W3co6PVT" resolve="function" />
+            </node>
+            <node concept="1Bd96e" id="61xqYhFZYTV" role="2OqNvi">
+              <node concept="Xl_RD" id="61xqYhFZYTW" role="1BdPVh">
+                <property role="Xl_RC" value=".model" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="61xqYhFZExS" role="3cqZAp" />
+        <node concept="3cpWs8" id="3jiJ$OUBO$C" role="3cqZAp">
+          <node concept="3cpWsn" id="3jiJ$OUBO$F" role="3cpWs9">
+            <property role="TrG5h" value="alreadyCollectedIDs2ModelFiles" />
+            <node concept="3rvAFt" id="3jiJ$OUEt3A" role="1tU5fm">
+              <node concept="17QB3L" id="3jiJ$OUEtDi" role="3rvQeY" />
+              <node concept="3uibUv" id="61xqYhG18te" role="3rvSg0">
+                <ref role="3uigEE" to="guwi:~File" resolve="File" />
+              </node>
+            </node>
+            <node concept="2ShNRf" id="3jiJ$OUBQ1j" role="33vP2m">
+              <node concept="3rGOSV" id="3jiJ$OUExc$" role="2ShVmc">
+                <node concept="17QB3L" id="3jiJ$OUEy8l" role="3rHrn6" />
+                <node concept="3uibUv" id="61xqYhG1cpc" role="3rHtpV">
+                  <ref role="3uigEE" to="guwi:~File" resolve="File" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="2Gpval" id="61xqYhG05up" role="3cqZAp">
+          <node concept="2GrKxI" id="61xqYhG05ur" role="2Gsz3X">
+            <property role="TrG5h" value="modelFile" />
+          </node>
+          <node concept="37vLTw" id="61xqYhG0aP7" role="2GsD0m">
+            <ref role="3cqZAo" node="61xqYhFZGqx" resolve="modelFiles" />
+          </node>
+          <node concept="3clFbS" id="61xqYhG05uv" role="2LFqv$">
+            <node concept="3J1_TO" id="61xqYhG0bqo" role="3cqZAp">
+              <node concept="3uVAMA" id="61xqYhG0bqp" role="1zxBo5">
+                <node concept="3clFbS" id="61xqYhG0bql" role="1zc67A">
+                  <node concept="3clFbF" id="61xqYhG0bqm" role="3cqZAp">
+                    <node concept="2OqwBi" id="61xqYhG0ew8" role="3clFbG">
+                      <node concept="37vLTw" id="61xqYhG0c2A" role="2Oq$k0">
+                        <ref role="3cqZAo" node="61xqYhG0bqh" resolve="e" />
+                      </node>
+                      <node concept="liA8E" id="61xqYhG0ew9" role="2OqNvi">
+                        <ref role="37wK5l" to="wyt6:~Throwable.printStackTrace()" resolve="printStackTrace" />
+                      </node>
                     </node>
-                    <node concept="liA8E" id="3jiJ$OUE92E" role="2OqNvi">
-                      <ref role="37wK5l" to="lui2:~SModule.getModels()" resolve="getModels" />
+                  </node>
+                </node>
+                <node concept="XOnhg" id="61xqYhG0bqh" role="1zc67B">
+                  <property role="TrG5h" value="e" />
+                  <node concept="nSUau" id="61xqYhG0bqj" role="1tU5fm">
+                    <node concept="3uibUv" id="61xqYhG0bqi" role="nSUat">
+                      <ref role="3uigEE" to="guwi:~IOException" resolve="IOException" />
                     </node>
                   </node>
-                  <node concept="3clFbS" id="3jiJ$OUE67r" role="2LFqv$">
+                </node>
+              </node>
+              <node concept="3clFbS" id="61xqYhG0bpM" role="1zxBo7">
+                <node concept="3cpWs8" id="61xqYhG0bpO" role="3cqZAp">
+                  <node concept="3cpWsn" id="61xqYhG0bpN" role="3cpWs9">
+                    <property role="TrG5h" value="reader" />
+                    <node concept="3uibUv" id="61xqYhG0bpP" role="1tU5fm">
+                      <ref role="3uigEE" to="guwi:~BufferedReader" resolve="BufferedReader" />
+                    </node>
+                    <node concept="2ShNRf" id="61xqYhG0cfm" role="33vP2m">
+                      <node concept="1pGfFk" id="61xqYhG0cgZ" role="2ShVmc">
+                        <ref role="37wK5l" to="guwi:~BufferedReader.&lt;init&gt;(java.io.Reader)" resolve="BufferedReader" />
+                        <node concept="2ShNRf" id="61xqYhG0ch0" role="37wK5m">
+                          <node concept="1pGfFk" id="61xqYhG0ch1" role="2ShVmc">
+                            <ref role="37wK5l" to="guwi:~FileReader.&lt;init&gt;(java.io.File)" resolve="FileReader" />
+                            <node concept="2GrUjf" id="61xqYhG0jhA" role="37wK5m">
+                              <ref role="2Gs0qQ" node="61xqYhG05ur" resolve="modelFile" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="3SKdUt" id="61xqYhG0bqq" role="3cqZAp">
+                  <node concept="1PaTwC" id="61xqYhG0bqr" role="1aUNEU">
+                    <node concept="3oM_SD" id="61xqYhG0bqs" role="1PaTwD">
+                      <property role="3oM_SC" value="Skip" />
+                    </node>
+                    <node concept="3oM_SD" id="61xqYhG0bqt" role="1PaTwD">
+                      <property role="3oM_SC" value="the" />
+                    </node>
+                    <node concept="3oM_SD" id="61xqYhG0bqu" role="1PaTwD">
+                      <property role="3oM_SC" value="first" />
+                    </node>
+                    <node concept="3oM_SD" id="61xqYhG0bqv" role="1PaTwD">
+                      <property role="3oM_SC" value="line" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="3clFbF" id="61xqYhG0bpT" role="3cqZAp">
+                  <node concept="2OqwBi" id="61xqYhG0e2y" role="3clFbG">
+                    <node concept="37vLTw" id="61xqYhG0cf3" role="2Oq$k0">
+                      <ref role="3cqZAo" node="61xqYhG0bpN" resolve="reader" />
+                    </node>
+                    <node concept="liA8E" id="61xqYhG0e2z" role="2OqNvi">
+                      <ref role="37wK5l" to="guwi:~BufferedReader.readLine()" resolve="readLine" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="3SKdUt" id="61xqYhG0bqw" role="3cqZAp">
+                  <node concept="1PaTwC" id="61xqYhG0bqx" role="1aUNEU">
+                    <node concept="3oM_SD" id="61xqYhG0bqy" role="1PaTwD">
+                      <property role="3oM_SC" value="Read" />
+                    </node>
+                    <node concept="3oM_SD" id="61xqYhG0bqz" role="1PaTwD">
+                      <property role="3oM_SC" value="the" />
+                    </node>
+                    <node concept="3oM_SD" id="61xqYhG0bq$" role="1PaTwD">
+                      <property role="3oM_SC" value="second" />
+                    </node>
+                    <node concept="3oM_SD" id="61xqYhG0bq_" role="1PaTwD">
+                      <property role="3oM_SC" value="line" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="3cpWs8" id="61xqYhG0bpW" role="3cqZAp">
+                  <node concept="3cpWsn" id="61xqYhG0bpV" role="3cpWs9">
+                    <property role="TrG5h" value="secondLine" />
+                    <node concept="17QB3L" id="61xqYhG0kSX" role="1tU5fm" />
+                    <node concept="2OqwBi" id="61xqYhG0d_c" role="33vP2m">
+                      <node concept="37vLTw" id="61xqYhG0ci1" role="2Oq$k0">
+                        <ref role="3cqZAo" node="61xqYhG0bpN" resolve="reader" />
+                      </node>
+                      <node concept="liA8E" id="61xqYhG0d_d" role="2OqNvi">
+                        <ref role="37wK5l" to="guwi:~BufferedReader.readLine()" resolve="readLine" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="3clFbJ" id="61xqYhG0olj" role="3cqZAp">
+                  <node concept="3clFbS" id="61xqYhG0oll" role="3clFbx">
                     <node concept="3cpWs8" id="3jiJ$OUEe4t" role="3cqZAp">
                       <node concept="3cpWsn" id="3jiJ$OUEe4u" role="3cpWs9">
                         <property role="TrG5h" value="currentModelId" />
                         <node concept="17QB3L" id="3jiJ$OUEfoi" role="1tU5fm" />
-                        <node concept="2OqwBi" id="3jiJ$OUEe4v" role="33vP2m">
-                          <node concept="2OqwBi" id="3jiJ$OUEe4w" role="2Oq$k0">
-                            <node concept="2GrUjf" id="3jiJ$OUEe4x" role="2Oq$k0">
-                              <ref role="2Gs0qQ" node="3jiJ$OUE67n" resolve="currentModel" />
-                            </node>
-                            <node concept="liA8E" id="3jiJ$OUEe4y" role="2OqNvi">
-                              <ref role="37wK5l" to="mhbf:~SModel.getModelId()" resolve="getModelId" />
-                            </node>
+                        <node concept="2OqwBi" id="61xqYhG0KsU" role="33vP2m">
+                          <node concept="37vLTw" id="61xqYhG0KsV" role="2Oq$k0">
+                            <ref role="3cqZAo" node="61xqYhG0bpV" resolve="secondLine" />
                           </node>
-                          <node concept="liA8E" id="3jiJ$OUEe4z" role="2OqNvi">
-                            <ref role="37wK5l" to="wyt6:~Object.toString()" resolve="toString" />
+                          <node concept="liA8E" id="61xqYhG0KsW" role="2OqNvi">
+                            <ref role="37wK5l" to="wyt6:~String.substring(int,int)" resolve="substring" />
+                            <node concept="2OqwBi" id="61xqYhG0KsX" role="37wK5m">
+                              <node concept="37vLTw" id="61xqYhG0KsY" role="2Oq$k0">
+                                <ref role="3cqZAo" node="61xqYhG0bpV" resolve="secondLine" />
+                              </node>
+                              <node concept="liA8E" id="61xqYhG0KsZ" role="2OqNvi">
+                                <ref role="37wK5l" to="wyt6:~String.indexOf(java.lang.String)" resolve="indexOf" />
+                                <node concept="Xl_RD" id="61xqYhG0Kt0" role="37wK5m">
+                                  <property role="Xl_RC" value="\&quot;" />
+                                </node>
+                              </node>
+                            </node>
+                            <node concept="2OqwBi" id="61xqYhG0Kt1" role="37wK5m">
+                              <node concept="37vLTw" id="61xqYhG0Kt2" role="2Oq$k0">
+                                <ref role="3cqZAo" node="61xqYhG0bpV" resolve="secondLine" />
+                              </node>
+                              <node concept="liA8E" id="61xqYhG0Kt3" role="2OqNvi">
+                                <ref role="37wK5l" to="wyt6:~String.indexOf(java.lang.String)" resolve="indexOf" />
+                                <node concept="Xl_RD" id="61xqYhG0Kt4" role="37wK5m">
+                                  <property role="Xl_RC" value="(" />
+                                </node>
+                              </node>
+                            </node>
                           </node>
                         </node>
                       </node>
                     </node>
                     <node concept="3clFbJ" id="3jiJ$OUE9Dr" role="3cqZAp">
-                      <node concept="1Wc70l" id="3jiJ$OUGjTX" role="3clFbw">
-                        <node concept="2OqwBi" id="3jiJ$OUEleT" role="3uHU7B">
-                          <node concept="2OqwBi" id="3jiJ$OUEzic" role="2Oq$k0">
-                            <node concept="37vLTw" id="3jiJ$OUEk_S" role="2Oq$k0">
-                              <ref role="3cqZAo" node="3jiJ$OUBO$F" resolve="alreadyCollectedIDs2Models" />
-                            </node>
-                            <node concept="3lbrtF" id="3jiJ$OUEzMb" role="2OqNvi" />
+                      <node concept="2OqwBi" id="3jiJ$OUEleT" role="3clFbw">
+                        <node concept="2OqwBi" id="3jiJ$OUEzic" role="2Oq$k0">
+                          <node concept="37vLTw" id="3jiJ$OUEk_S" role="2Oq$k0">
+                            <ref role="3cqZAo" node="3jiJ$OUBO$F" resolve="alreadyCollectedIDs2ModelFiles" />
                           </node>
-                          <node concept="3JPx81" id="3jiJ$OUElXh" role="2OqNvi">
-                            <node concept="37vLTw" id="3jiJ$OUEm3x" role="25WWJ7">
-                              <ref role="3cqZAo" node="3jiJ$OUEe4u" resolve="currentModelId" />
-                            </node>
-                          </node>
+                          <node concept="3lbrtF" id="3jiJ$OUEzMb" role="2OqNvi" />
                         </node>
-                        <node concept="3fqX7Q" id="3jiJ$OUGmU1" role="3uHU7w">
-                          <node concept="2OqwBi" id="3jiJ$OUGmU3" role="3fr31v">
-                            <node concept="2OqwBi" id="3jiJ$OUGmU4" role="2Oq$k0">
-                              <node concept="2OqwBi" id="3jiJ$OUGmU5" role="2Oq$k0">
-                                <node concept="2GrUjf" id="3jiJ$OUGmU6" role="2Oq$k0">
-                                  <ref role="2Gs0qQ" node="3jiJ$OUE67n" resolve="currentModel" />
-                                </node>
-                                <node concept="liA8E" id="3jiJ$OUGmU7" role="2OqNvi">
-                                  <ref role="37wK5l" to="mhbf:~SModel.getName()" resolve="getName" />
-                                </node>
-                              </node>
-                              <node concept="liA8E" id="3jiJ$OUGmU8" role="2OqNvi">
-                                <ref role="37wK5l" to="mhbf:~SModelName.getValue()" resolve="getValue" />
-                              </node>
-                            </node>
-                            <node concept="liA8E" id="3jiJ$OUGmU9" role="2OqNvi">
-                              <ref role="37wK5l" to="wyt6:~String.endsWith(java.lang.String)" resolve="endsWith" />
-                              <node concept="Xl_RD" id="3jiJ$OUGmUa" role="37wK5m">
-                                <property role="Xl_RC" value="@descriptor" />
-                              </node>
-                            </node>
+                        <node concept="3JPx81" id="3jiJ$OUElXh" role="2OqNvi">
+                          <node concept="37vLTw" id="3jiJ$OUEm3x" role="25WWJ7">
+                            <ref role="3cqZAo" node="3jiJ$OUEe4u" resolve="currentModelId" />
                           </node>
                         </node>
                       </node>
@@ -1717,96 +2065,41 @@
                                 <node concept="Xl_RD" id="3jiJ$OUEDkH" role="3uHU7w">
                                   <property role="Xl_RC" value="'" />
                                 </node>
-                                <node concept="3cpWs3" id="3jiJ$OUEC43" role="3uHU7B">
-                                  <node concept="3cpWs3" id="3jiJ$OUEAk6" role="3uHU7B">
-                                    <node concept="3cpWs3" id="3jiJ$OUDXw8" role="3uHU7B">
-                                      <node concept="3cpWs3" id="3jiJ$OUFm0E" role="3uHU7B">
-                                        <node concept="Xl_RD" id="3jiJ$OUFmsN" role="3uHU7w">
-                                          <property role="Xl_RC" value=" -- with model '" />
-                                        </node>
-                                        <node concept="3cpWs3" id="3jiJ$OUFliI" role="3uHU7B">
-                                          <node concept="3cpWs3" id="3jiJ$OUDXwa" role="3uHU7B">
-                                            <node concept="3cpWs3" id="3jiJ$OUEsmS" role="3uHU7B">
-                                              <node concept="2OqwBi" id="3jiJ$OUDXwd" role="3uHU7w">
-                                                <node concept="2GrUjf" id="3jiJ$OUDXwe" role="2Oq$k0">
-                                                  <ref role="2Gs0qQ" node="3jiJ$OUDXtx" resolve="module" />
-                                                </node>
-                                                <node concept="liA8E" id="3jiJ$OUDXwf" role="2OqNvi">
-                                                  <ref role="37wK5l" to="lui2:~SModule.getModuleName()" resolve="getModuleName" />
-                                                </node>
-                                              </node>
-                                              <node concept="3cpWs3" id="3jiJ$OUDXwb" role="3uHU7B">
-                                                <node concept="3cpWs3" id="3jiJ$OUFhg7" role="3uHU7B">
-                                                  <node concept="Xl_RD" id="3jiJ$OUDXwc" role="3uHU7B">
-                                                    <property role="Xl_RC" value="model '" />
-                                                  </node>
-                                                  <node concept="2OqwBi" id="3jiJ$OUFjo9" role="3uHU7w">
-                                                    <node concept="2OqwBi" id="3jiJ$OUFhHA" role="2Oq$k0">
-                                                      <node concept="2GrUjf" id="3jiJ$OUFh$Z" role="2Oq$k0">
-                                                        <ref role="2Gs0qQ" node="3jiJ$OUE67n" resolve="currentModel" />
-                                                      </node>
-                                                      <node concept="liA8E" id="3jiJ$OUFiso" role="2OqNvi">
-                                                        <ref role="37wK5l" to="mhbf:~SModel.getName()" resolve="getName" />
-                                                      </node>
-                                                    </node>
-                                                    <node concept="liA8E" id="3jiJ$OUFjZk" role="2OqNvi">
-                                                      <ref role="37wK5l" to="mhbf:~SModelName.getValue()" resolve="getValue" />
-                                                    </node>
-                                                  </node>
-                                                </node>
-                                                <node concept="Xl_RD" id="3jiJ$OUEsqT" role="3uHU7w">
-                                                  <property role="Xl_RC" value=" from module' " />
-                                                </node>
-                                              </node>
-                                            </node>
-                                            <node concept="Xl_RD" id="3jiJ$OUDXwg" role="3uHU7w">
-                                              <property role="Xl_RC" value="' has same model ID -- " />
-                                            </node>
-                                          </node>
-                                          <node concept="37vLTw" id="3jiJ$OUFlLh" role="3uHU7w">
-                                            <ref role="3cqZAo" node="3jiJ$OUEe4u" resolve="currentModelId" />
-                                          </node>
-                                        </node>
-                                      </node>
-                                      <node concept="2OqwBi" id="3jiJ$OUFZ_k" role="3uHU7w">
-                                        <node concept="2OqwBi" id="3jiJ$OUFZeC" role="2Oq$k0">
-                                          <node concept="2JrnkZ" id="3jiJ$OUFZ6P" role="2Oq$k0">
-                                            <node concept="3EllGN" id="3jiJ$OUE_R8" role="2JrQYb">
-                                              <node concept="37vLTw" id="3jiJ$OUEA1j" role="3ElVtu">
-                                                <ref role="3cqZAo" node="3jiJ$OUEe4u" resolve="currentModelId" />
-                                              </node>
-                                              <node concept="37vLTw" id="3jiJ$OUDXw9" role="3ElQJh">
-                                                <ref role="3cqZAo" node="3jiJ$OUBO$F" resolve="alreadyCollectedIDs2Models" />
-                                              </node>
-                                            </node>
-                                          </node>
-                                          <node concept="liA8E" id="3jiJ$OUFZti" role="2OqNvi">
-                                            <ref role="37wK5l" to="mhbf:~SModel.getName()" resolve="getName" />
-                                          </node>
-                                        </node>
-                                        <node concept="liA8E" id="3jiJ$OUFZTp" role="2OqNvi">
-                                          <ref role="37wK5l" to="mhbf:~SModelName.getValue()" resolve="getValue" />
-                                        </node>
-                                      </node>
+                                <node concept="3cpWs3" id="3jiJ$OUDXw8" role="3uHU7B">
+                                  <node concept="3cpWs3" id="3jiJ$OUFm0E" role="3uHU7B">
+                                    <node concept="Xl_RD" id="3jiJ$OUFmsN" role="3uHU7w">
+                                      <property role="Xl_RC" value=" -- with model from file '" />
                                     </node>
-                                    <node concept="Xl_RD" id="3jiJ$OUEASv" role="3uHU7w">
-                                      <property role="Xl_RC" value="' from module '" />
+                                    <node concept="3cpWs3" id="3jiJ$OUFliI" role="3uHU7B">
+                                      <node concept="3cpWs3" id="3jiJ$OUDXwa" role="3uHU7B">
+                                        <node concept="3cpWs3" id="3jiJ$OUFhg7" role="3uHU7B">
+                                          <node concept="Xl_RD" id="3jiJ$OUDXwc" role="3uHU7B">
+                                            <property role="Xl_RC" value="model from file '" />
+                                          </node>
+                                          <node concept="2GrUjf" id="61xqYhG0YAi" role="3uHU7w">
+                                            <ref role="2Gs0qQ" node="61xqYhG05ur" resolve="modelFile" />
+                                          </node>
+                                        </node>
+                                        <node concept="Xl_RD" id="3jiJ$OUDXwg" role="3uHU7w">
+                                          <property role="Xl_RC" value="' has same model ID -- " />
+                                        </node>
+                                      </node>
+                                      <node concept="37vLTw" id="3jiJ$OUFlLh" role="3uHU7w">
+                                        <ref role="3cqZAo" node="3jiJ$OUEe4u" resolve="currentModelId" />
+                                      </node>
                                     </node>
                                   </node>
-                                  <node concept="2OqwBi" id="3jiJ$OUEEFp" role="3uHU7w">
-                                    <node concept="2OqwBi" id="3jiJ$OUEDuP" role="2Oq$k0">
-                                      <node concept="3EllGN" id="3jiJ$OUECAh" role="2Oq$k0">
-                                        <node concept="37vLTw" id="3jiJ$OUECAi" role="3ElVtu">
-                                          <ref role="3cqZAo" node="3jiJ$OUEe4u" resolve="currentModelId" />
-                                        </node>
-                                        <node concept="37vLTw" id="3jiJ$OUECAj" role="3ElQJh">
-                                          <ref role="3cqZAo" node="3jiJ$OUBO$F" resolve="alreadyCollectedIDs2Models" />
-                                        </node>
+                                  <node concept="2OqwBi" id="3jiJ$OUFZeC" role="3uHU7w">
+                                    <node concept="3EllGN" id="3jiJ$OUE_R8" role="2Oq$k0">
+                                      <node concept="37vLTw" id="3jiJ$OUEA1j" role="3ElVtu">
+                                        <ref role="3cqZAo" node="3jiJ$OUEe4u" resolve="currentModelId" />
                                       </node>
-                                      <node concept="13u695" id="3jiJ$OUEDDz" role="2OqNvi" />
+                                      <node concept="37vLTw" id="3jiJ$OUDXw9" role="3ElQJh">
+                                        <ref role="3cqZAo" node="3jiJ$OUBO$F" resolve="alreadyCollectedIDs2ModelFiles" />
+                                      </node>
                                     </node>
-                                    <node concept="3TrcHB" id="3jiJ$OUEF0o" role="2OqNvi">
-                                      <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                                    <node concept="liA8E" id="61xqYhG1dpa" role="2OqNvi">
+                                      <ref role="37wK5l" to="guwi:~File.getAbsolutePath()" resolve="getAbsolutePath" />
                                     </node>
                                   </node>
                                 </node>
@@ -1820,14 +2113,14 @@
                           <node concept="3clFbF" id="3jiJ$OUEmgj" role="3cqZAp">
                             <node concept="37vLTI" id="3jiJ$OUEFhZ" role="3clFbG">
                               <node concept="2GrUjf" id="3jiJ$OUEFmg" role="37vLTx">
-                                <ref role="2Gs0qQ" node="3jiJ$OUE67n" resolve="currentModel" />
+                                <ref role="2Gs0qQ" node="61xqYhG05ur" resolve="modelFile" />
                               </node>
                               <node concept="3EllGN" id="3jiJ$OUEFbf" role="37vLTJ">
                                 <node concept="37vLTw" id="3jiJ$OUEFdP" role="3ElVtu">
                                   <ref role="3cqZAo" node="3jiJ$OUEe4u" resolve="currentModelId" />
                                 </node>
                                 <node concept="37vLTw" id="3jiJ$OUEmgi" role="3ElQJh">
-                                  <ref role="3cqZAo" node="3jiJ$OUBO$F" resolve="alreadyCollectedIDs2Models" />
+                                  <ref role="3cqZAo" node="3jiJ$OUBO$F" resolve="alreadyCollectedIDs2ModelFiles" />
                                 </node>
                               </node>
                             </node>
@@ -1836,12 +2129,33 @@
                       </node>
                     </node>
                   </node>
+                  <node concept="2OqwBi" id="61xqYhG0qcw" role="3clFbw">
+                    <node concept="37vLTw" id="61xqYhG0p5A" role="2Oq$k0">
+                      <ref role="3cqZAo" node="61xqYhG0bpV" resolve="secondLine" />
+                    </node>
+                    <node concept="liA8E" id="61xqYhG0rAh" role="2OqNvi">
+                      <ref role="37wK5l" to="wyt6:~String.startsWith(java.lang.String)" resolve="startsWith" />
+                      <node concept="Xl_RD" id="61xqYhG0slq" role="37wK5m">
+                        <property role="Xl_RC" value="&lt;model ref=" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="3clFbF" id="61xqYhG0bqf" role="3cqZAp">
+                  <node concept="2OqwBi" id="61xqYhG0fTO" role="3clFbG">
+                    <node concept="37vLTw" id="61xqYhG0chI" role="2Oq$k0">
+                      <ref role="3cqZAo" node="61xqYhG0bpN" resolve="reader" />
+                    </node>
+                    <node concept="liA8E" id="61xqYhG0fTP" role="2OqNvi">
+                      <ref role="37wK5l" to="guwi:~BufferedReader.close()" resolve="close" />
+                    </node>
+                  </node>
                 </node>
               </node>
             </node>
           </node>
-          <node concept="1MG55F" id="3jiJ$OUDXwk" role="L3pyr" />
         </node>
+        <node concept="3clFbH" id="61xqYhG03X9" role="3cqZAp" />
         <node concept="3cpWs6" id="3jiJ$OUDXwl" role="3cqZAp">
           <node concept="37vLTw" id="3jiJ$OUDXwm" role="3cqZAk">
             <ref role="3cqZAo" node="3jiJ$OUDXt7" resolve="res" />

--- a/code/languages/org.mpsqa.lint/solutions/org.mpsqa.lint.mps_lang.linters_library/models/org.mpsqa.lint.mps_lang.linters_library.performance_typesystem_rules.mps
+++ b/code/languages/org.mpsqa.lint/solutions/org.mpsqa.lint.mps_lang.linters_library/models/org.mpsqa.lint.mps_lang.linters_library.performance_typesystem_rules.mps
@@ -1053,6 +1053,45 @@
       <node concept="2DRihI" id="733wlN500I8" role="1PaQFQ">
         <property role="2RT3bR" value="0" />
         <node concept="3oM_SD" id="733wlN500KW" role="1PaTwD">
+          <property role="3oM_SC" value="modelsToCheckNamesRegex" />
+        </node>
+        <node concept="3oM_SD" id="1Yf9e2l4qtP" role="1PaTwD">
+          <property role="3oM_SC" value="-" />
+        </node>
+        <node concept="3oM_SD" id="1Yf9e2l4qw0" role="1PaTwD">
+          <property role="3oM_SC" value="the" />
+        </node>
+        <node concept="3oM_SD" id="1Yf9e2l4qw1" role="1PaTwD">
+          <property role="3oM_SC" value="regex" />
+        </node>
+        <node concept="3oM_SD" id="1Yf9e2l4qw2" role="1PaTwD">
+          <property role="3oM_SC" value="for" />
+        </node>
+        <node concept="3oM_SD" id="1Yf9e2l4qw3" role="1PaTwD">
+          <property role="3oM_SC" value="the" />
+        </node>
+        <node concept="3oM_SD" id="1Yf9e2l4qw4" role="1PaTwD">
+          <property role="3oM_SC" value="names" />
+        </node>
+        <node concept="3oM_SD" id="1Yf9e2l4qw5" role="1PaTwD">
+          <property role="3oM_SC" value="of" />
+        </node>
+        <node concept="3oM_SD" id="1Yf9e2l4qw6" role="1PaTwD">
+          <property role="3oM_SC" value="the" />
+        </node>
+        <node concept="3oM_SD" id="1Yf9e2l4qxs" role="1PaTwD">
+          <property role="3oM_SC" value="models" />
+        </node>
+        <node concept="3oM_SD" id="1Yf9e2l4qw9" role="1PaTwD">
+          <property role="3oM_SC" value="to" />
+        </node>
+        <node concept="3oM_SD" id="1Yf9e2l4qy5" role="1PaTwD">
+          <property role="3oM_SC" value="check" />
+        </node>
+      </node>
+      <node concept="2DRihI" id="1Yf9e2l4qqf" role="1PaQFQ">
+        <property role="2RT3bR" value="0" />
+        <node concept="3oM_SD" id="1Yf9e2l4qqe" role="1PaTwD">
           <property role="3oM_SC" value="timeBoundInMillis" />
         </node>
         <node concept="3oM_SD" id="733wlN500LY" role="1PaTwD">


### PR DESCRIPTION
models_in_same_project_with_same_IDs: re-wrote the linter "models_in_same_project_with_same_IDs" not to depend on MPS loading of models

Now we use low-level iteration through files and text reading API to get the model-id