### PR TITLE
mpsqa.lint: add back missing location information to saved results

### DIFF
--- a/code/languages/org.mpsqa.build/solutions/org.mpsqa.build/models/org.mpsqa.build._080_lint_build.mps
+++ b/code/languages/org.mpsqa.build/solutions/org.mpsqa.build/models/org.mpsqa.build._080_lint_build.mps
@@ -242,6 +242,9 @@
       <node concept="m$_yC" id="4Wm$DJ9mpUP" role="m$_yJ">
         <ref role="m$_y1" to="ffeo:4k71ibbLe59" resolve="com.intellij.modules.mps" />
       </node>
+      <node concept="m$_yC" id="4XPt_HaGDDW" role="m$_yJ">
+        <ref role="m$_y1" to="ffeo:ymnOULATpW" resolve="jetbrains.mps.testing" />
+      </node>
       <node concept="m$_yC" id="30a3800NyCh" role="m$_yJ">
         <ref role="m$_y1" to="ffeo:5lGJ4Taqfsl" resolve="jetbrains.mps.ide.modelchecker" />
       </node>

--- a/code/languages/org.mpsqa.lint/languages/org.mpsqa.lint.generic/models/org.mpsqa.lint.generic.behavior.mps
+++ b/code/languages/org.mpsqa.lint/languages/org.mpsqa.lint.generic/models/org.mpsqa.lint.generic.behavior.mps
@@ -2040,21 +2040,54 @@
                 </node>
               </node>
             </node>
+            <node concept="3cpWs8" id="7YedNyZKP5$" role="3cqZAp">
+              <node concept="3cpWsn" id="7YedNyZKP5_" role="3cpWs9">
+                <property role="TrG5h" value="model" />
+                <node concept="3uibUv" id="7YedNyZKK81" role="1tU5fm">
+                  <ref role="3uigEE" to="mhbf:~SModel" resolve="SModel" />
+                </node>
+                <node concept="2OqwBi" id="7YedNyZKP5A" role="33vP2m">
+                  <node concept="37vLTw" id="7YedNyZKP5B" role="2Oq$k0">
+                    <ref role="3cqZAo" node="4XPt_HaEId8" resolve="modelRef" />
+                  </node>
+                  <node concept="liA8E" id="7YedNyZKP5C" role="2OqNvi">
+                    <ref role="37wK5l" to="mhbf:~SModelReference.resolve(org.jetbrains.mps.openapi.module.SRepository)" resolve="resolve" />
+                    <node concept="37vLTw" id="7YedNyZKP5D" role="37wK5m">
+                      <ref role="3cqZAo" node="4XPt_HaxCna" resolve="repository" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbJ" id="7YedNyZKPBV" role="3cqZAp">
+              <node concept="3clFbS" id="7YedNyZKPBX" role="3clFbx">
+                <node concept="3cpWs6" id="7YedNyZKQok" role="3cqZAp">
+                  <node concept="1Ls8ON" id="7YedNyZKQol" role="3cqZAk">
+                    <node concept="2OqwBi" id="7YedNyZKQom" role="1Lso8e">
+                      <node concept="13iPFW" id="7YedNyZKQon" role="2Oq$k0" />
+                      <node concept="3TrcHB" id="7YedNyZKQoo" role="2OqNvi">
+                        <ref role="3TsBF5" to="a1af:2I_DQhwrOw" resolve="resultLocation" />
+                      </node>
+                    </node>
+                    <node concept="3clFbT" id="7YedNyZKQop" role="1Lso8e" />
+                  </node>
+                </node>
+              </node>
+              <node concept="3clFbC" id="7YedNyZKPWP" role="3clFbw">
+                <node concept="10Nm6u" id="7YedNyZKQ5N" role="3uHU7w" />
+                <node concept="37vLTw" id="7YedNyZKPI1" role="3uHU7B">
+                  <ref role="3cqZAo" node="7YedNyZKP5_" resolve="model" />
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbH" id="7YedNyZKQFT" role="3cqZAp" />
             <node concept="3cpWs6" id="4XPt_HauHqo" role="3cqZAp">
               <node concept="1Ls8ON" id="4XPt_HaCtaF" role="3cqZAk">
                 <node concept="3cpWs3" id="4XPt_HaxD5R" role="1Lso8e">
                   <node concept="2OqwBi" id="4XPt_HaxEfO" role="3uHU7w">
                     <node concept="2OqwBi" id="4XPt_HaxDTQ" role="2Oq$k0">
-                      <node concept="2OqwBi" id="4XPt_HaxDj3" role="2Oq$k0">
-                        <node concept="37vLTw" id="4XPt_HaxD94" role="2Oq$k0">
-                          <ref role="3cqZAo" node="4XPt_HaEId8" resolve="modelRef" />
-                        </node>
-                        <node concept="liA8E" id="4XPt_HaxD_D" role="2OqNvi">
-                          <ref role="37wK5l" to="mhbf:~SModelReference.resolve(org.jetbrains.mps.openapi.module.SRepository)" resolve="resolve" />
-                          <node concept="37vLTw" id="4XPt_HaxDK5" role="37wK5m">
-                            <ref role="3cqZAo" node="4XPt_HaxCna" resolve="repository" />
-                          </node>
-                        </node>
+                      <node concept="37vLTw" id="7YedNyZKP5E" role="2Oq$k0">
+                        <ref role="3cqZAo" node="7YedNyZKP5_" resolve="model" />
                       </node>
                       <node concept="liA8E" id="4XPt_HaxE78" role="2OqNvi">
                         <ref role="37wK5l" to="mhbf:~SModel.getModule()" resolve="getModule" />
@@ -2245,6 +2278,17 @@
                 </node>
               </node>
             </node>
+            <node concept="3clFbJ" id="7YedNyZKR1V" role="3cqZAp">
+              <node concept="3clFbS" id="7YedNyZKR1X" role="3clFbx">
+                <node concept="3cpWs6" id="7YedNyZKRB4" role="3cqZAp" />
+              </node>
+              <node concept="3clFbC" id="7YedNyZKRnA" role="3clFbw">
+                <node concept="10Nm6u" id="7YedNyZKRvn" role="3uHU7w" />
+                <node concept="37vLTw" id="7YedNyZKRai" role="3uHU7B">
+                  <ref role="3cqZAo" node="4XPt_HaF1fZ" resolve="model" />
+                </node>
+              </node>
+            </node>
             <node concept="3clFbF" id="4XPt_HaEOh0" role="3cqZAp">
               <node concept="37vLTI" id="4XPt_HaEPEX" role="3clFbG">
                 <node concept="2OqwBi" id="4XPt_HaF4bq" role="37vLTx">
@@ -2328,6 +2372,17 @@
                         <ref role="3cqZAo" node="4XPt_HaEA7b" resolve="repository" />
                       </node>
                     </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3clFbJ" id="7YedNyZKRRC" role="3cqZAp">
+                <node concept="3clFbS" id="7YedNyZKRRE" role="3clFbx">
+                  <node concept="3cpWs6" id="7YedNyZKSK5" role="3cqZAp" />
+                </node>
+                <node concept="3clFbC" id="7YedNyZKStx" role="3clFbw">
+                  <node concept="10Nm6u" id="7YedNyZKSCb" role="3uHU7w" />
+                  <node concept="37vLTw" id="7YedNyZKS0C" role="3uHU7B">
+                    <ref role="3cqZAo" node="4XPt_HaFgpK" resolve="module" />
                   </node>
                 </node>
               </node>
@@ -2448,17 +2503,27 @@
                 </node>
               </node>
             </node>
-            <node concept="3clFbF" id="4XPt_HaCGgF" role="3cqZAp">
-              <node concept="2OqwBi" id="4XPt_HaCGoE" role="3clFbG">
-                <node concept="2YIFZM" id="4XPt_HaCGhd" role="2Oq$k0">
-                  <ref role="37wK5l" to="z60i:~Desktop.getDesktop()" resolve="getDesktop" />
-                  <ref role="1Pybhc" to="z60i:~Desktop" resolve="Desktop" />
-                </node>
-                <node concept="liA8E" id="4XPt_HaCGwI" role="2OqNvi">
-                  <ref role="37wK5l" to="z60i:~Desktop.open(java.io.File)" resolve="open" />
-                  <node concept="37vLTw" id="4XPt_HaDmUU" role="37wK5m">
-                    <ref role="3cqZAo" node="4XPt_HaDmUO" resolve="file" />
+            <node concept="3clFbJ" id="5MlhRObXPtR" role="3cqZAp">
+              <node concept="3clFbS" id="5MlhRObXPtT" role="3clFbx">
+                <node concept="3clFbF" id="4XPt_HaCGgF" role="3cqZAp">
+                  <node concept="2OqwBi" id="4XPt_HaCGoE" role="3clFbG">
+                    <node concept="2YIFZM" id="4XPt_HaCGhd" role="2Oq$k0">
+                      <ref role="37wK5l" to="z60i:~Desktop.getDesktop()" resolve="getDesktop" />
+                      <ref role="1Pybhc" to="z60i:~Desktop" resolve="Desktop" />
+                    </node>
+                    <node concept="liA8E" id="4XPt_HaCGwI" role="2OqNvi">
+                      <ref role="37wK5l" to="z60i:~Desktop.open(java.io.File)" resolve="open" />
+                      <node concept="37vLTw" id="4XPt_HaDmUU" role="37wK5m">
+                        <ref role="3cqZAo" node="4XPt_HaDmUO" resolve="file" />
+                      </node>
+                    </node>
                   </node>
+                </node>
+              </node>
+              <node concept="3y3z36" id="5MlhRObXQhY" role="3clFbw">
+                <node concept="10Nm6u" id="5MlhRObXQwE" role="3uHU7w" />
+                <node concept="37vLTw" id="5MlhRObXP_E" role="3uHU7B">
+                  <ref role="3cqZAo" node="4XPt_HaDmUO" resolve="file" />
                 </node>
               </node>
             </node>

--- a/code/languages/org.mpsqa.lint/languages/org.mpsqa.lint.generic/models/org.mpsqa.lint.generic.behavior.mps
+++ b/code/languages/org.mpsqa.lint/languages/org.mpsqa.lint.generic/models/org.mpsqa.lint.generic.behavior.mps
@@ -28,6 +28,9 @@
     <import index="alof" ref="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61/java:jetbrains.mps.ide.project(MPS.Platform/)" />
     <import index="dush" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.persistence(MPS.OpenAPI/)" />
     <import index="guwi" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.io(JDK/)" />
+    <import index="z60i" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.awt(JDK/)" />
+    <import index="ends" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.extapi.persistence(MPS.Core/)" />
+    <import index="3ju5" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.vfs(MPS.Core/)" implicit="true" />
     <import index="vdrq" ref="r:85354f47-14fd-40e6-a7cc-2d1aa842c4cd(jetbrains.mps.lang.text.behavior)" implicit="true" />
     <import index="tpcu" ref="r:00000000-0000-4000-0000-011c89590282(jetbrains.mps.lang.core.behavior)" implicit="true" />
   </imports>
@@ -44,6 +47,7 @@
       </concept>
     </language>
     <language id="af65afd8-f0dd-4942-87d9-63a55f2a9db1" name="jetbrains.mps.lang.behavior">
+      <concept id="6496299201655527393" name="jetbrains.mps.lang.behavior.structure.LocalBehaviorMethodCall" flags="nn" index="BsUDl" />
       <concept id="1225194240794" name="jetbrains.mps.lang.behavior.structure.ConceptBehavior" flags="ng" index="13h7C7">
         <reference id="1225194240799" name="concept" index="13h7C2" />
         <child id="1225194240805" name="method" index="13h7CS" />
@@ -58,6 +62,10 @@
       <concept id="1225194691553" name="jetbrains.mps.lang.behavior.structure.ThisNodeExpression" flags="nn" index="13iPFW" />
     </language>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1224071154655" name="jetbrains.mps.baseLanguage.structure.AsExpression" flags="nn" index="0kSF2">
+        <child id="1224071154657" name="classifierType" index="0kSFW" />
+        <child id="1224071154656" name="expression" index="0kSFX" />
+      </concept>
       <concept id="1082485599095" name="jetbrains.mps.baseLanguage.structure.BlockStatement" flags="nn" index="9aQIb">
         <child id="1082485599096" name="statements" index="9aQI4" />
       </concept>
@@ -92,8 +100,16 @@
       <concept id="1081236700937" name="jetbrains.mps.baseLanguage.structure.StaticMethodCall" flags="nn" index="2YIFZM">
         <reference id="1144433194310" name="classConcept" index="1Pybhc" />
       </concept>
+      <concept id="1081256982272" name="jetbrains.mps.baseLanguage.structure.InstanceOfExpression" flags="nn" index="2ZW3vV">
+        <child id="1081256993305" name="classType" index="2ZW6by" />
+        <child id="1081256993304" name="leftExpression" index="2ZW6bz" />
+      </concept>
       <concept id="1070534058343" name="jetbrains.mps.baseLanguage.structure.NullLiteral" flags="nn" index="10Nm6u" />
       <concept id="1070534644030" name="jetbrains.mps.baseLanguage.structure.BooleanType" flags="in" index="10P_77" />
+      <concept id="1070534934090" name="jetbrains.mps.baseLanguage.structure.CastExpression" flags="nn" index="10QFUN">
+        <child id="1070534934091" name="type" index="10QFUM" />
+        <child id="1070534934092" name="expression" index="10QFUP" />
+      </concept>
       <concept id="1068390468198" name="jetbrains.mps.baseLanguage.structure.ClassConcept" flags="ig" index="312cEu" />
       <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
         <child id="1068431790190" name="initializer" index="33vP2m" />
@@ -125,6 +141,7 @@
         <child id="1082485599094" name="ifFalseStatement" index="9aQIa" />
         <child id="1068580123160" name="condition" index="3clFbw" />
         <child id="1068580123161" name="ifTrue" index="3clFbx" />
+        <child id="1206060520071" name="elsifClauses" index="3eNLev" />
       </concept>
       <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
         <child id="1068581517665" name="statement" index="3cqZAp" />
@@ -141,6 +158,13 @@
       </concept>
       <concept id="1068581242863" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclaration" flags="nr" index="3cpWsn" />
       <concept id="1068581517677" name="jetbrains.mps.baseLanguage.structure.VoidType" flags="in" index="3cqZAl" />
+      <concept id="1206060495898" name="jetbrains.mps.baseLanguage.structure.ElsifClause" flags="ng" index="3eNFk2">
+        <child id="1206060619838" name="condition" index="3eO9$A" />
+        <child id="1206060644605" name="statementList" index="3eOfB_" />
+      </concept>
+      <concept id="1079359253375" name="jetbrains.mps.baseLanguage.structure.ParenthesizedExpression" flags="nn" index="1eOMI4">
+        <child id="1079359253376" name="expression" index="1eOMHV" />
+      </concept>
       <concept id="1081516740877" name="jetbrains.mps.baseLanguage.structure.NotExpression" flags="nn" index="3fqX7Q">
         <child id="1081516765348" name="expression" index="3fr31v" />
       </concept>
@@ -220,6 +244,12 @@
       </concept>
       <concept id="8182547171709614739" name="jetbrains.mps.lang.quotation.structure.NodeBuilderRef" flags="nn" index="36bGnv">
         <reference id="8182547171709614741" name="target" index="36bGnp" />
+      </concept>
+    </language>
+    <language id="760a0a8c-eabb-4521-8bfd-65db761a9ba3" name="jetbrains.mps.baseLanguage.logging">
+      <concept id="2034914114981261497" name="jetbrains.mps.baseLanguage.logging.structure.LogLowLevelStatement" flags="ng" index="RRSsy">
+        <property id="2034914114981261751" name="severity" index="RRSoG" />
+        <child id="2034914114981261753" name="message" index="RRSoy" />
       </concept>
     </language>
     <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
@@ -1907,52 +1937,129 @@
         </node>
       </node>
     </node>
-    <node concept="13i0hz" id="4XPt_HauH1N" role="13h7CS">
-      <property role="TrG5h" value="formatLocation" />
-      <node concept="3Tm1VV" id="4XPt_HauH1O" role="1B3o_S" />
-      <node concept="3clFbS" id="4XPt_HauH1Q" role="3clF47">
-        <node concept="3cpWs8" id="4XPt_HauIId" role="3cqZAp">
-          <node concept="3cpWsn" id="4XPt_HauIIe" role="3cpWs9">
+    <node concept="13i0hz" id="4XPt_HaECXY" role="13h7CS">
+      <property role="TrG5h" value="convertLocationToObject" />
+      <node concept="3Tm1VV" id="4XPt_HaECXZ" role="1B3o_S" />
+      <node concept="3uibUv" id="4XPt_HaEDeB" role="3clF45">
+        <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
+      </node>
+      <node concept="3clFbS" id="4XPt_HaECY1" role="3clF47">
+        <node concept="3cpWs8" id="4XPt_HaEDga" role="3cqZAp">
+          <node concept="3cpWsn" id="4XPt_HaEDgb" role="3cpWs9">
             <property role="TrG5h" value="persistenceFacade" />
-            <node concept="3uibUv" id="4XPt_HauIH$" role="1tU5fm">
+            <node concept="3uibUv" id="4XPt_HaEDgc" role="1tU5fm">
               <ref role="3uigEE" to="dush:~PersistenceFacade" resolve="PersistenceFacade" />
             </node>
-            <node concept="2YIFZM" id="4XPt_HauIIf" role="33vP2m">
+            <node concept="2YIFZM" id="4XPt_HaEDgd" role="33vP2m">
               <ref role="37wK5l" to="dush:~PersistenceFacade.getInstance()" resolve="getInstance" />
               <ref role="1Pybhc" to="dush:~PersistenceFacade" resolve="PersistenceFacade" />
             </node>
           </node>
         </node>
-        <node concept="3J1_TO" id="4XPt_HauHn6" role="3cqZAp">
-          <node concept="3uVAMA" id="4XPt_HauHnV" role="1zxBo5">
-            <node concept="XOnhg" id="4XPt_HauHnW" role="1zc67B">
+        <node concept="3J1_TO" id="4XPt_HaEDge" role="3cqZAp">
+          <node concept="3uVAMA" id="4XPt_HaEDgf" role="1zxBo5">
+            <node concept="XOnhg" id="4XPt_HaEDgg" role="1zc67B">
               <property role="TrG5h" value="e" />
-              <node concept="nSUau" id="4XPt_HauHnX" role="1tU5fm">
-                <node concept="3uibUv" id="4XPt_HauHoC" role="nSUat">
+              <node concept="nSUau" id="4XPt_HaEDgh" role="1tU5fm">
+                <node concept="3uibUv" id="4XPt_HaEDgi" role="nSUat">
                   <ref role="3uigEE" to="wyt6:~Exception" resolve="Exception" />
                 </node>
               </node>
             </node>
-            <node concept="3clFbS" id="4XPt_HauHnY" role="1zc67A" />
+            <node concept="3clFbS" id="4XPt_HaEDgj" role="1zc67A" />
           </node>
-          <node concept="3clFbS" id="4XPt_HauHn8" role="1zxBo7">
-            <node concept="3cpWs8" id="4XPt_HaxnmX" role="3cqZAp">
-              <node concept="3cpWsn" id="4XPt_HaxnmY" role="3cpWs9">
+          <node concept="3clFbS" id="4XPt_HaEDgk" role="1zxBo7">
+            <node concept="3cpWs6" id="4XPt_HaEErf" role="3cqZAp">
+              <node concept="2OqwBi" id="4XPt_HaEDgo" role="3cqZAk">
+                <node concept="37vLTw" id="4XPt_HaEDgp" role="2Oq$k0">
+                  <ref role="3cqZAo" node="4XPt_HaEDgb" resolve="persistenceFacade" />
+                </node>
+                <node concept="liA8E" id="4XPt_HaEDgq" role="2OqNvi">
+                  <ref role="37wK5l" to="dush:~PersistenceFacade.createModelReference(java.lang.String)" resolve="createModelReference" />
+                  <node concept="2OqwBi" id="4XPt_HaEDgr" role="37wK5m">
+                    <node concept="13iPFW" id="4XPt_HaEDgs" role="2Oq$k0" />
+                    <node concept="3TrcHB" id="4XPt_HaEDgt" role="2OqNvi">
+                      <ref role="3TsBF5" to="a1af:2I_DQhwrOw" resolve="resultLocation" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="4XPt_HaEDgN" role="3cqZAp" />
+        <node concept="3J1_TO" id="4XPt_HaEDgO" role="3cqZAp">
+          <node concept="3uVAMA" id="4XPt_HaEDgP" role="1zxBo5">
+            <node concept="XOnhg" id="4XPt_HaEDgQ" role="1zc67B">
+              <property role="TrG5h" value="e" />
+              <node concept="nSUau" id="4XPt_HaEDgR" role="1tU5fm">
+                <node concept="3uibUv" id="4XPt_HaEDgS" role="nSUat">
+                  <ref role="3uigEE" to="wyt6:~Exception" resolve="Exception" />
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbS" id="4XPt_HaEDgT" role="1zc67A" />
+          </node>
+          <node concept="3clFbS" id="4XPt_HaEDgU" role="1zxBo7">
+            <node concept="3cpWs6" id="4XPt_HaEEFb" role="3cqZAp">
+              <node concept="2OqwBi" id="4XPt_HaEDh0" role="3cqZAk">
+                <node concept="37vLTw" id="4XPt_HaEDh1" role="2Oq$k0">
+                  <ref role="3cqZAo" node="4XPt_HaEDgb" resolve="persistenceFacade" />
+                </node>
+                <node concept="liA8E" id="4XPt_HaEDh2" role="2OqNvi">
+                  <ref role="37wK5l" to="dush:~PersistenceFacade.createModuleReference(java.lang.String)" resolve="createModuleReference" />
+                  <node concept="2OqwBi" id="4XPt_HaEDh3" role="37wK5m">
+                    <node concept="13iPFW" id="4XPt_HaEDh4" role="2Oq$k0" />
+                    <node concept="3TrcHB" id="4XPt_HaEDh5" role="2OqNvi">
+                      <ref role="3TsBF5" to="a1af:2I_DQhwrOw" resolve="resultLocation" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="4XPt_HaEDh8" role="3cqZAp" />
+        <node concept="3cpWs6" id="4XPt_HaEDh9" role="3cqZAp">
+          <node concept="2OqwBi" id="4XPt_HaEDhb" role="3cqZAk">
+            <node concept="13iPFW" id="4XPt_HaEDhc" role="2Oq$k0" />
+            <node concept="3TrcHB" id="4XPt_HaEDhd" role="2OqNvi">
+              <ref role="3TsBF5" to="a1af:2I_DQhwrOw" resolve="resultLocation" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="13i0hz" id="4XPt_HauH1N" role="13h7CS">
+      <property role="TrG5h" value="formatLocation" />
+      <node concept="3Tm1VV" id="4XPt_HauH1O" role="1B3o_S" />
+      <node concept="3clFbS" id="4XPt_HauH1Q" role="3clF47">
+        <node concept="3cpWs8" id="4XPt_HaEFop" role="3cqZAp">
+          <node concept="3cpWsn" id="4XPt_HaEFoq" role="3cpWs9">
+            <property role="TrG5h" value="obj" />
+            <node concept="3uibUv" id="4XPt_HaEFor" role="1tU5fm">
+              <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
+            </node>
+            <node concept="BsUDl" id="4XPt_HaEFDj" role="33vP2m">
+              <ref role="37wK5l" node="4XPt_HaECXY" resolve="convertLocationToObject" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbJ" id="4XPt_HaEGrb" role="3cqZAp">
+          <node concept="3clFbS" id="4XPt_HaEGrd" role="3clFbx">
+            <node concept="3cpWs8" id="4XPt_HaEId7" role="3cqZAp">
+              <node concept="3cpWsn" id="4XPt_HaEId8" role="3cpWs9">
                 <property role="TrG5h" value="modelRef" />
-                <node concept="3uibUv" id="4XPt_Haxnkx" role="1tU5fm">
+                <node concept="3uibUv" id="4XPt_HaEId9" role="1tU5fm">
                   <ref role="3uigEE" to="mhbf:~SModelReference" resolve="SModelReference" />
                 </node>
-                <node concept="2OqwBi" id="4XPt_HaxnmZ" role="33vP2m">
-                  <node concept="37vLTw" id="4XPt_Haxnn0" role="2Oq$k0">
-                    <ref role="3cqZAo" node="4XPt_HauIIe" resolve="persistenceFacade" />
-                  </node>
-                  <node concept="liA8E" id="4XPt_Haxnn1" role="2OqNvi">
-                    <ref role="37wK5l" to="dush:~PersistenceFacade.createModelReference(java.lang.String)" resolve="createModelReference" />
-                    <node concept="2OqwBi" id="4XPt_Haxnn2" role="37wK5m">
-                      <node concept="13iPFW" id="4XPt_Haxnn3" role="2Oq$k0" />
-                      <node concept="3TrcHB" id="4XPt_Haxnn4" role="2OqNvi">
-                        <ref role="3TsBF5" to="a1af:2I_DQhwrOw" resolve="resultLocation" />
-                      </node>
+                <node concept="1eOMI4" id="4XPt_HaEICK" role="33vP2m">
+                  <node concept="10QFUN" id="4XPt_HaEICH" role="1eOMHV">
+                    <node concept="3uibUv" id="4XPt_HaEICM" role="10QFUM">
+                      <ref role="3uigEE" to="mhbf:~SModelReference" resolve="SModelReference" />
+                    </node>
+                    <node concept="37vLTw" id="4XPt_HaEICN" role="10QFUP">
+                      <ref role="3cqZAo" node="4XPt_HaEFoq" resolve="obj" />
                     </node>
                   </node>
                 </node>
@@ -1965,7 +2072,7 @@
                     <node concept="2OqwBi" id="4XPt_HaxDTQ" role="2Oq$k0">
                       <node concept="2OqwBi" id="4XPt_HaxDj3" role="2Oq$k0">
                         <node concept="37vLTw" id="4XPt_HaxD94" role="2Oq$k0">
-                          <ref role="3cqZAo" node="4XPt_HaxnmY" resolve="modelRef" />
+                          <ref role="3cqZAo" node="4XPt_HaEId8" resolve="modelRef" />
                         </node>
                         <node concept="liA8E" id="4XPt_HaxD_D" role="2OqNvi">
                           <ref role="37wK5l" to="mhbf:~SModelReference.resolve(org.jetbrains.mps.openapi.module.SRepository)" resolve="resolve" />
@@ -1990,7 +2097,7 @@
                       <node concept="2OqwBi" id="4XPt_HauJO2" role="3uHU7w">
                         <node concept="2OqwBi" id="4XPt_HauJwl" role="2Oq$k0">
                           <node concept="37vLTw" id="4XPt_Haxnn5" role="2Oq$k0">
-                            <ref role="3cqZAo" node="4XPt_HaxnmY" resolve="modelRef" />
+                            <ref role="3cqZAo" node="4XPt_HaEId8" resolve="modelRef" />
                           </node>
                           <node concept="liA8E" id="4XPt_HauJE1" role="2OqNvi">
                             <ref role="37wK5l" to="mhbf:~SModelReference.getName()" resolve="getName" />
@@ -2012,55 +2119,66 @@
               </node>
             </node>
           </node>
-        </node>
-        <node concept="3clFbH" id="4XPt_HauHUV" role="3cqZAp" />
-        <node concept="3J1_TO" id="4XPt_HauHOA" role="3cqZAp">
-          <node concept="3uVAMA" id="4XPt_HauHOB" role="1zxBo5">
-            <node concept="XOnhg" id="4XPt_HauHOC" role="1zc67B">
-              <property role="TrG5h" value="e" />
-              <node concept="nSUau" id="4XPt_HauHOD" role="1tU5fm">
-                <node concept="3uibUv" id="4XPt_HauHOE" role="nSUat">
-                  <ref role="3uigEE" to="wyt6:~Exception" resolve="Exception" />
-                </node>
+          <node concept="2ZW3vV" id="4XPt_HaEH27" role="3clFbw">
+            <node concept="3uibUv" id="4XPt_HaEH9u" role="2ZW6by">
+              <ref role="3uigEE" to="mhbf:~SModelReference" resolve="SModelReference" />
+            </node>
+            <node concept="37vLTw" id="4XPt_HaEG_$" role="2ZW6bz">
+              <ref role="3cqZAo" node="4XPt_HaEFoq" resolve="obj" />
+            </node>
+          </node>
+          <node concept="3eNFk2" id="4XPt_HaEJ5g" role="3eNLev">
+            <node concept="2ZW3vV" id="4XPt_HaEJqP" role="3eO9$A">
+              <node concept="3uibUv" id="4XPt_HaEJyf" role="2ZW6by">
+                <ref role="3uigEE" to="lui2:~SModuleReference" resolve="SModuleReference" />
+              </node>
+              <node concept="37vLTw" id="4XPt_HaEJdi" role="2ZW6bz">
+                <ref role="3cqZAo" node="4XPt_HaEFoq" resolve="obj" />
               </node>
             </node>
-            <node concept="3clFbS" id="4XPt_HauHOF" role="1zc67A" />
-          </node>
-          <node concept="3clFbS" id="4XPt_HauHOG" role="1zxBo7">
-            <node concept="3cpWs6" id="4XPt_HauHOH" role="3cqZAp">
-              <node concept="1Ls8ON" id="4XPt_HaCtVC" role="3cqZAk">
-                <node concept="3cpWs3" id="4XPt_HayD7j" role="1Lso8e">
-                  <node concept="Xl_RD" id="4XPt_HayDbO" role="3uHU7B">
-                    <property role="Xl_RC" value="module: " />
+            <node concept="3clFbS" id="4XPt_HaEJ5i" role="3eOfB_">
+              <node concept="3cpWs8" id="4XPt_HaEJQ4" role="3cqZAp">
+                <node concept="3cpWsn" id="4XPt_HaEJQ5" role="3cpWs9">
+                  <property role="TrG5h" value="moduleRef" />
+                  <node concept="3uibUv" id="4XPt_HaEJQ6" role="1tU5fm">
+                    <ref role="3uigEE" to="lui2:~SModuleReference" resolve="SModuleReference" />
                   </node>
-                  <node concept="2OqwBi" id="4XPt_HauK8Z" role="3uHU7w">
-                    <node concept="2OqwBi" id="4XPt_HauHOI" role="2Oq$k0">
-                      <node concept="37vLTw" id="4XPt_HauIIh" role="2Oq$k0">
-                        <ref role="3cqZAo" node="4XPt_HauIIe" resolve="persistenceFacade" />
+                  <node concept="1eOMI4" id="4XPt_HaEKdU" role="33vP2m">
+                    <node concept="10QFUN" id="4XPt_HaEKdR" role="1eOMHV">
+                      <node concept="3uibUv" id="4XPt_HaEKdW" role="10QFUM">
+                        <ref role="3uigEE" to="lui2:~SModuleReference" resolve="SModuleReference" />
                       </node>
-                      <node concept="liA8E" id="4XPt_HauHOK" role="2OqNvi">
-                        <ref role="37wK5l" to="dush:~PersistenceFacade.createModuleReference(java.lang.String)" resolve="createModuleReference" />
-                        <node concept="2OqwBi" id="4XPt_HauHOL" role="37wK5m">
-                          <node concept="13iPFW" id="4XPt_HauHOM" role="2Oq$k0" />
-                          <node concept="3TrcHB" id="4XPt_HauHON" role="2OqNvi">
-                            <ref role="3TsBF5" to="a1af:2I_DQhwrOw" resolve="resultLocation" />
-                          </node>
-                        </node>
+                      <node concept="37vLTw" id="4XPt_HaEKdX" role="10QFUP">
+                        <ref role="3cqZAo" node="4XPt_HaEFoq" resolve="obj" />
                       </node>
-                    </node>
-                    <node concept="liA8E" id="4XPt_HauKj1" role="2OqNvi">
-                      <ref role="37wK5l" to="lui2:~SModuleReference.getModuleName()" resolve="getModuleName" />
                     </node>
                   </node>
                 </node>
-                <node concept="3clFbT" id="4XPt_HaCuZf" role="1Lso8e">
-                  <property role="3clFbU" value="true" />
+              </node>
+              <node concept="3cpWs6" id="4XPt_HauHOH" role="3cqZAp">
+                <node concept="1Ls8ON" id="4XPt_HaCtVC" role="3cqZAk">
+                  <node concept="3cpWs3" id="4XPt_HayD7j" role="1Lso8e">
+                    <node concept="Xl_RD" id="4XPt_HayDbO" role="3uHU7B">
+                      <property role="Xl_RC" value="module: " />
+                    </node>
+                    <node concept="2OqwBi" id="4XPt_HauK8Z" role="3uHU7w">
+                      <node concept="liA8E" id="4XPt_HauKj1" role="2OqNvi">
+                        <ref role="37wK5l" to="lui2:~SModuleReference.getModuleName()" resolve="getModuleName" />
+                      </node>
+                      <node concept="37vLTw" id="4XPt_HaELF7" role="2Oq$k0">
+                        <ref role="3cqZAo" node="4XPt_HaEJQ5" resolve="moduleRef" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3clFbT" id="4XPt_HaCuZf" role="1Lso8e">
+                    <property role="3clFbU" value="true" />
+                  </node>
                 </node>
               </node>
             </node>
           </node>
         </node>
-        <node concept="3clFbH" id="4XPt_HauI1d" role="3cqZAp" />
+        <node concept="3clFbH" id="4XPt_HaEGgV" role="3cqZAp" />
         <node concept="3cpWs6" id="4XPt_HauIlq" role="3cqZAp">
           <node concept="1Ls8ON" id="4XPt_HaCvhk" role="3cqZAk">
             <node concept="2OqwBi" id="4XPt_HauIyE" role="1Lso8e">
@@ -2082,6 +2200,301 @@
       <node concept="1LlUBW" id="4XPt_HaCsnk" role="3clF45">
         <node concept="17QB3L" id="4XPt_HaCsJL" role="1Lm7xW" />
         <node concept="10P_77" id="4XPt_HaCsUt" role="1Lm7xW" />
+      </node>
+    </node>
+    <node concept="13i0hz" id="4XPt_HaE_RC" role="13h7CS">
+      <property role="TrG5h" value="openLocation" />
+      <node concept="3Tm1VV" id="4XPt_HaE_RD" role="1B3o_S" />
+      <node concept="3cqZAl" id="4XPt_HaEA6C" role="3clF45" />
+      <node concept="3clFbS" id="4XPt_HaE_RF" role="3clF47">
+        <node concept="3clFbH" id="4XPt_HaEMnL" role="3cqZAp" />
+        <node concept="3cpWs8" id="4XPt_HaEMys" role="3cqZAp">
+          <node concept="3cpWsn" id="4XPt_HaEMyv" role="3cpWs9">
+            <property role="TrG5h" value="localFile" />
+            <node concept="17QB3L" id="4XPt_HaEMyq" role="1tU5fm" />
+            <node concept="2OqwBi" id="4XPt_HaENkw" role="33vP2m">
+              <node concept="13iPFW" id="4XPt_HaEN39" role="2Oq$k0" />
+              <node concept="3TrcHB" id="4XPt_HaENDk" role="2OqNvi">
+                <ref role="3TsBF5" to="a1af:2I_DQhwrOw" resolve="resultLocation" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="4XPt_HaENKr" role="3cqZAp">
+          <node concept="3cpWsn" id="4XPt_HaENKs" role="3cpWs9">
+            <property role="TrG5h" value="obj" />
+            <node concept="3uibUv" id="4XPt_HaENKt" role="1tU5fm">
+              <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
+            </node>
+            <node concept="BsUDl" id="4XPt_HaENKu" role="33vP2m">
+              <ref role="37wK5l" node="4XPt_HaECXY" resolve="convertLocationToObject" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbJ" id="4XPt_HaENTr" role="3cqZAp">
+          <node concept="3clFbS" id="4XPt_HaENTs" role="3clFbx">
+            <node concept="3cpWs8" id="4XPt_HaENTt" role="3cqZAp">
+              <node concept="3cpWsn" id="4XPt_HaENTu" role="3cpWs9">
+                <property role="TrG5h" value="modelRef" />
+                <node concept="3uibUv" id="4XPt_HaENTv" role="1tU5fm">
+                  <ref role="3uigEE" to="mhbf:~SModelReference" resolve="SModelReference" />
+                </node>
+                <node concept="1eOMI4" id="4XPt_HaENTw" role="33vP2m">
+                  <node concept="10QFUN" id="4XPt_HaENTx" role="1eOMHV">
+                    <node concept="3uibUv" id="4XPt_HaENTy" role="10QFUM">
+                      <ref role="3uigEE" to="mhbf:~SModelReference" resolve="SModelReference" />
+                    </node>
+                    <node concept="37vLTw" id="4XPt_HaENTz" role="10QFUP">
+                      <ref role="3cqZAo" node="4XPt_HaENKs" resolve="obj" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3cpWs8" id="4XPt_HaF1fY" role="3cqZAp">
+              <node concept="3cpWsn" id="4XPt_HaF1fZ" role="3cpWs9">
+                <property role="TrG5h" value="model" />
+                <node concept="3uibUv" id="4XPt_HaF1du" role="1tU5fm">
+                  <ref role="3uigEE" to="mhbf:~SModel" resolve="SModel" />
+                </node>
+                <node concept="2OqwBi" id="4XPt_HaF1g0" role="33vP2m">
+                  <node concept="37vLTw" id="4XPt_HaF1g1" role="2Oq$k0">
+                    <ref role="3cqZAo" node="4XPt_HaENTu" resolve="modelRef" />
+                  </node>
+                  <node concept="liA8E" id="4XPt_HaF1g2" role="2OqNvi">
+                    <ref role="37wK5l" to="mhbf:~SModelReference.resolve(org.jetbrains.mps.openapi.module.SRepository)" resolve="resolve" />
+                    <node concept="37vLTw" id="4XPt_HaF1g3" role="37wK5m">
+                      <ref role="3cqZAo" node="4XPt_HaEA7b" resolve="repository" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbF" id="4XPt_HaEOh0" role="3cqZAp">
+              <node concept="37vLTI" id="4XPt_HaEPEX" role="3clFbG">
+                <node concept="2OqwBi" id="4XPt_HaF4bq" role="37vLTx">
+                  <node concept="2OqwBi" id="4XPt_HaF3mi" role="2Oq$k0">
+                    <node concept="0kSF2" id="4XPt_HaF2sX" role="2Oq$k0">
+                      <node concept="3uibUv" id="4XPt_HaF2sZ" role="0kSFW">
+                        <ref role="3uigEE" to="ends:~FileBasedModelRoot" resolve="FileBasedModelRoot" />
+                      </node>
+                      <node concept="2OqwBi" id="4XPt_HaF1H$" role="0kSFX">
+                        <node concept="37vLTw" id="4XPt_HaF1g4" role="2Oq$k0">
+                          <ref role="3cqZAo" node="4XPt_HaF1fZ" resolve="model" />
+                        </node>
+                        <node concept="liA8E" id="4XPt_HaF1Tc" role="2OqNvi">
+                          <ref role="37wK5l" to="mhbf:~SModel.getModelRoot()" resolve="getModelRoot" />
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="liA8E" id="4XPt_HaF3ED" role="2OqNvi">
+                      <ref role="37wK5l" to="ends:~FileBasedModelRoot.getContentDirectory()" resolve="getContentDirectory" />
+                    </node>
+                  </node>
+                  <node concept="liA8E" id="4XPt_HaF4oa" role="2OqNvi">
+                    <ref role="37wK5l" to="3ju5:~IFile.toRealPath()" resolve="toRealPath" />
+                  </node>
+                </node>
+                <node concept="37vLTw" id="4XPt_HaEOgY" role="37vLTJ">
+                  <ref role="3cqZAo" node="4XPt_HaEMyv" resolve="file" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="2ZW3vV" id="4XPt_HaENTT" role="3clFbw">
+            <node concept="3uibUv" id="4XPt_HaENTU" role="2ZW6by">
+              <ref role="3uigEE" to="mhbf:~SModelReference" resolve="SModelReference" />
+            </node>
+            <node concept="37vLTw" id="4XPt_HaENTV" role="2ZW6bz">
+              <ref role="3cqZAo" node="4XPt_HaENKs" resolve="obj" />
+            </node>
+          </node>
+          <node concept="3eNFk2" id="4XPt_HaENTW" role="3eNLev">
+            <node concept="2ZW3vV" id="4XPt_HaENTX" role="3eO9$A">
+              <node concept="3uibUv" id="4XPt_HaENTY" role="2ZW6by">
+                <ref role="3uigEE" to="lui2:~SModuleReference" resolve="SModuleReference" />
+              </node>
+              <node concept="37vLTw" id="4XPt_HaENTZ" role="2ZW6bz">
+                <ref role="3cqZAo" node="4XPt_HaENKs" resolve="obj" />
+              </node>
+            </node>
+            <node concept="3clFbS" id="4XPt_HaENU0" role="3eOfB_">
+              <node concept="3cpWs8" id="4XPt_HaENU1" role="3cqZAp">
+                <node concept="3cpWsn" id="4XPt_HaENU2" role="3cpWs9">
+                  <property role="TrG5h" value="moduleRef" />
+                  <node concept="3uibUv" id="4XPt_HaENU3" role="1tU5fm">
+                    <ref role="3uigEE" to="lui2:~SModuleReference" resolve="SModuleReference" />
+                  </node>
+                  <node concept="1eOMI4" id="4XPt_HaENU4" role="33vP2m">
+                    <node concept="10QFUN" id="4XPt_HaENU5" role="1eOMHV">
+                      <node concept="3uibUv" id="4XPt_HaENU6" role="10QFUM">
+                        <ref role="3uigEE" to="lui2:~SModuleReference" resolve="SModuleReference" />
+                      </node>
+                      <node concept="37vLTw" id="4XPt_HaENU7" role="10QFUP">
+                        <ref role="3cqZAo" node="4XPt_HaENKs" resolve="obj" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3cpWs8" id="4XPt_HaFgpJ" role="3cqZAp">
+                <node concept="3cpWsn" id="4XPt_HaFgpK" role="3cpWs9">
+                  <property role="TrG5h" value="module" />
+                  <node concept="3uibUv" id="4XPt_HaFg82" role="1tU5fm">
+                    <ref role="3uigEE" to="lui2:~SModule" resolve="SModule" />
+                  </node>
+                  <node concept="2OqwBi" id="4XPt_HaFgpL" role="33vP2m">
+                    <node concept="37vLTw" id="4XPt_HaFgpM" role="2Oq$k0">
+                      <ref role="3cqZAo" node="4XPt_HaENU2" resolve="moduleRef" />
+                    </node>
+                    <node concept="liA8E" id="4XPt_HaFgpN" role="2OqNvi">
+                      <ref role="37wK5l" to="lui2:~SModuleReference.resolve(org.jetbrains.mps.openapi.module.SRepository)" resolve="resolve" />
+                      <node concept="37vLTw" id="4XPt_HaFgpO" role="37wK5m">
+                        <ref role="3cqZAo" node="4XPt_HaEA7b" resolve="repository" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3clFbF" id="4XPt_HaFh31" role="3cqZAp">
+                <node concept="37vLTI" id="4XPt_HaFigF" role="3clFbG">
+                  <node concept="2OqwBi" id="4XPt_HaFk5L" role="37vLTx">
+                    <node concept="2OqwBi" id="4XPt_HaFjwF" role="2Oq$k0">
+                      <node concept="1eOMI4" id="4XPt_HaFiu7" role="2Oq$k0">
+                        <node concept="10QFUN" id="4XPt_HaFiu4" role="1eOMHV">
+                          <node concept="37vLTw" id="4XPt_HaFj3l" role="10QFUP">
+                            <ref role="3cqZAo" node="4XPt_HaFgpK" resolve="module" />
+                          </node>
+                          <node concept="3uibUv" id="4XPt_HaFiST" role="10QFUM">
+                            <ref role="3uigEE" to="z1c4:~AbstractModule" resolve="AbstractModule" />
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="liA8E" id="4XPt_HaFjRX" role="2OqNvi">
+                        <ref role="37wK5l" to="z1c4:~AbstractModule.getModuleSourceDir()" resolve="getModuleSourceDir" />
+                      </node>
+                    </node>
+                    <node concept="liA8E" id="4XPt_HaFkl4" role="2OqNvi">
+                      <ref role="37wK5l" to="3ju5:~IFile.toRealPath()" resolve="toRealPath" />
+                    </node>
+                  </node>
+                  <node concept="37vLTw" id="4XPt_HaFh2Z" role="37vLTJ">
+                    <ref role="3cqZAo" node="4XPt_HaEMyv" resolve="localFile" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="4XPt_HaEMuR" role="3cqZAp" />
+        <node concept="3clFbJ" id="4XPt_HaFlKV" role="3cqZAp">
+          <node concept="3clFbS" id="4XPt_HaFlKX" role="3clFbx">
+            <node concept="3cpWs6" id="4XPt_HaFmMW" role="3cqZAp" />
+          </node>
+          <node concept="3clFbC" id="4XPt_HaFmtB" role="3clFbw">
+            <node concept="10Nm6u" id="4XPt_HaFmtE" role="3uHU7w" />
+            <node concept="37vLTw" id="4XPt_HaFlQu" role="3uHU7B">
+              <ref role="3cqZAo" node="4XPt_HaEMyv" resolve="localFile" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="4XPt_HaFlBK" role="3cqZAp" />
+        <node concept="3J1_TO" id="4XPt_HaCr2T" role="3cqZAp">
+          <node concept="3uVAMA" id="4XPt_HaCr3c" role="1zxBo5">
+            <node concept="XOnhg" id="4XPt_HaCr3d" role="1zc67B">
+              <property role="TrG5h" value="io" />
+              <node concept="nSUau" id="4XPt_HaCr3e" role="1tU5fm">
+                <node concept="3uibUv" id="4XPt_HaCr3M" role="nSUat">
+                  <ref role="3uigEE" to="guwi:~IOException" resolve="IOException" />
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbS" id="4XPt_HaCr3f" role="1zc67A">
+              <node concept="RRSsy" id="4XPt_HaCr5H" role="3cqZAp">
+                <property role="RRSoG" value="gZ5fh_4/error" />
+                <node concept="3cpWs3" id="4XPt_HaCruz" role="RRSoy">
+                  <node concept="2OqwBi" id="4XPt_HaCFZ2" role="3uHU7w">
+                    <node concept="13iPFW" id="4XPt_HaECM3" role="2Oq$k0" />
+                    <node concept="3TrcHB" id="4XPt_HaCG9X" role="2OqNvi">
+                      <ref role="3TsBF5" to="a1af:2I_DQhwrOw" resolve="resultLocation" />
+                    </node>
+                  </node>
+                  <node concept="Xl_RD" id="4XPt_HaCr5J" role="3uHU7B">
+                    <property role="Xl_RC" value="Couldn't open " />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbS" id="4XPt_HaCr2U" role="1zxBo7">
+            <node concept="3cpWs8" id="4XPt_HaDmUN" role="3cqZAp">
+              <node concept="3cpWsn" id="4XPt_HaDmUO" role="3cpWs9">
+                <property role="TrG5h" value="file" />
+                <node concept="3uibUv" id="4XPt_HaDlNx" role="1tU5fm">
+                  <ref role="3uigEE" to="guwi:~File" resolve="File" />
+                </node>
+                <node concept="2ShNRf" id="4XPt_HaDmUP" role="33vP2m">
+                  <node concept="1pGfFk" id="4XPt_HaDmUQ" role="2ShVmc">
+                    <property role="373rjd" value="true" />
+                    <ref role="37wK5l" to="guwi:~File.&lt;init&gt;(java.lang.String)" resolve="File" />
+                    <node concept="37vLTw" id="4XPt_HaFkFL" role="37wK5m">
+                      <ref role="3cqZAo" node="4XPt_HaEMyv" resolve="localFile" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbJ" id="4XPt_HaDn5x" role="3cqZAp">
+              <node concept="3clFbS" id="4XPt_HaDn5z" role="3clFbx">
+                <node concept="3clFbF" id="4XPt_HaDnKW" role="3cqZAp">
+                  <node concept="37vLTI" id="4XPt_HaDo4s" role="3clFbG">
+                    <node concept="2OqwBi" id="4XPt_HaDo59" role="37vLTx">
+                      <node concept="37vLTw" id="4XPt_HaDo4I" role="2Oq$k0">
+                        <ref role="3cqZAo" node="4XPt_HaDmUO" resolve="file" />
+                      </node>
+                      <node concept="liA8E" id="4XPt_HaDoql" role="2OqNvi">
+                        <ref role="37wK5l" to="guwi:~File.getParentFile()" resolve="getParentFile" />
+                      </node>
+                    </node>
+                    <node concept="37vLTw" id="4XPt_HaDnKU" role="37vLTJ">
+                      <ref role="3cqZAo" node="4XPt_HaDmUO" resolve="file" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3fqX7Q" id="4XPt_HaDnJa" role="3clFbw">
+                <node concept="2OqwBi" id="4XPt_HaDnJc" role="3fr31v">
+                  <node concept="37vLTw" id="4XPt_HaDnJd" role="2Oq$k0">
+                    <ref role="3cqZAo" node="4XPt_HaDmUO" resolve="file" />
+                  </node>
+                  <node concept="liA8E" id="4XPt_HaDnJe" role="2OqNvi">
+                    <ref role="37wK5l" to="guwi:~File.isDirectory()" resolve="isDirectory" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbF" id="4XPt_HaCGgF" role="3cqZAp">
+              <node concept="2OqwBi" id="4XPt_HaCGoE" role="3clFbG">
+                <node concept="2YIFZM" id="4XPt_HaCGhd" role="2Oq$k0">
+                  <ref role="37wK5l" to="z60i:~Desktop.getDesktop()" resolve="getDesktop" />
+                  <ref role="1Pybhc" to="z60i:~Desktop" resolve="Desktop" />
+                </node>
+                <node concept="liA8E" id="4XPt_HaCGwI" role="2OqNvi">
+                  <ref role="37wK5l" to="z60i:~Desktop.open(java.io.File)" resolve="open" />
+                  <node concept="37vLTw" id="4XPt_HaDmUU" role="37wK5m">
+                    <ref role="3cqZAo" node="4XPt_HaDmUO" resolve="file" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="4XPt_HaEA7b" role="3clF46">
+        <property role="TrG5h" value="repository" />
+        <node concept="3uibUv" id="4XPt_HaEA7a" role="1tU5fm">
+          <ref role="3uigEE" to="lui2:~SRepository" resolve="SRepository" />
+        </node>
       </node>
     </node>
     <node concept="13hLZK" id="4Wm$DJ9cjhM" role="13h7CW">

--- a/code/languages/org.mpsqa.lint/languages/org.mpsqa.lint.generic/models/org.mpsqa.lint.generic.behavior.mps
+++ b/code/languages/org.mpsqa.lint/languages/org.mpsqa.lint.generic/models/org.mpsqa.lint.generic.behavior.mps
@@ -24,6 +24,9 @@
     <import index="lui2" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.module(MPS.OpenAPI/)" />
     <import index="qqy" ref="r:baac1a2f-1e52-45fa-95c5-02a3dfae441c(org.mpsqa.lint.generic.util)" />
     <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" />
+    <import index="w1kc" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.smodel(MPS.Core/)" />
+    <import index="alof" ref="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61/java:jetbrains.mps.ide.project(MPS.Platform/)" />
+    <import index="dush" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.persistence(MPS.OpenAPI/)" />
     <import index="vdrq" ref="r:85354f47-14fd-40e6-a7cc-2d1aa842c4cd(jetbrains.mps.lang.text.behavior)" implicit="true" />
     <import index="tpcu" ref="r:00000000-0000-4000-0000-011c89590282(jetbrains.mps.lang.core.behavior)" implicit="true" />
   </imports>
@@ -57,6 +60,9 @@
       </concept>
       <concept id="4836112446988635817" name="jetbrains.mps.baseLanguage.structure.UndefinedType" flags="in" index="2jxLKc" />
       <concept id="1202948039474" name="jetbrains.mps.baseLanguage.structure.InstanceMethodCallOperation" flags="nn" index="liA8E" />
+      <concept id="8118189177080264853" name="jetbrains.mps.baseLanguage.structure.AlternativeType" flags="ig" index="nSUau">
+        <child id="8118189177080264854" name="alternative" index="nSUat" />
+      </concept>
       <concept id="1465982738277781862" name="jetbrains.mps.baseLanguage.structure.PlaceholderMember" flags="nn" index="2tJIrI" />
       <concept id="1154032098014" name="jetbrains.mps.baseLanguage.structure.AbstractLoopStatement" flags="nn" index="2LF5Ji">
         <child id="1154032183016" name="body" index="2LFqv$" />
@@ -74,6 +80,7 @@
       <concept id="1070475926800" name="jetbrains.mps.baseLanguage.structure.StringLiteral" flags="nn" index="Xl_RD">
         <property id="1070475926801" name="value" index="Xl_RC" />
       </concept>
+      <concept id="4952749571008284462" name="jetbrains.mps.baseLanguage.structure.CatchVariable" flags="ng" index="XOnhg" />
       <concept id="1081236700938" name="jetbrains.mps.baseLanguage.structure.StaticMethodDeclaration" flags="ig" index="2YIFZL" />
       <concept id="1081236700937" name="jetbrains.mps.baseLanguage.structure.StaticMethodCall" flags="nn" index="2YIFZM">
         <reference id="1144433194310" name="classConcept" index="1Pybhc" />
@@ -83,6 +90,9 @@
       <concept id="1068390468198" name="jetbrains.mps.baseLanguage.structure.ClassConcept" flags="ig" index="312cEu" />
       <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
         <child id="1068431790190" name="initializer" index="33vP2m" />
+      </concept>
+      <concept id="1513279640923991009" name="jetbrains.mps.baseLanguage.structure.IGenericClassCreator" flags="ng" index="366HgL">
+        <property id="1513279640906337053" name="inferTypeParams" index="373rjd" />
       </concept>
       <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
         <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
@@ -131,6 +141,7 @@
         <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
         <child id="1068499141038" name="actualArgument" index="37wK5m" />
       </concept>
+      <concept id="1212685548494" name="jetbrains.mps.baseLanguage.structure.ClassCreator" flags="nn" index="1pGfFk" />
       <concept id="1107461130800" name="jetbrains.mps.baseLanguage.structure.Classifier" flags="ng" index="3pOWGL">
         <child id="5375687026011219971" name="member" index="jymVt" unordered="true" />
       </concept>
@@ -142,8 +153,17 @@
         <child id="1081773367579" name="rightExpression" index="3uHU7w" />
         <child id="1081773367580" name="leftExpression" index="3uHU7B" />
       </concept>
+      <concept id="3093926081414150598" name="jetbrains.mps.baseLanguage.structure.MultipleCatchClause" flags="ng" index="3uVAMA">
+        <child id="8276990574895933173" name="catchBody" index="1zc67A" />
+        <child id="8276990574895933172" name="throwable" index="1zc67B" />
+      </concept>
+      <concept id="1073239437375" name="jetbrains.mps.baseLanguage.structure.NotEqualsExpression" flags="nn" index="3y3z36" />
       <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ng" index="1B3ioH">
         <child id="1178549979242" name="visibility" index="1B3o_S" />
+      </concept>
+      <concept id="5351203823916750322" name="jetbrains.mps.baseLanguage.structure.TryUniversalStatement" flags="nn" index="3J1_TO">
+        <child id="8276990574886367510" name="catchClause" index="1zxBo5" />
+        <child id="8276990574886367508" name="body" index="1zxBo7" />
       </concept>
       <concept id="1163668896201" name="jetbrains.mps.baseLanguage.structure.TernaryOperatorExpression" flags="nn" index="3K4zz7">
         <child id="1163668914799" name="condition" index="3K4Cdx" />
@@ -716,7 +736,7 @@
                     <node concept="2pJxcG" id="78RogMCHrs6" role="2pJxcM">
                       <ref role="2pJxcJ" to="a1af:78RogMCGEW7" resolve="resultNodeModelId" />
                       <node concept="WxPPo" id="78RogMCHrs7" role="28ntcv">
-                        <node concept="2OqwBi" id="78RogMCHrs8" role="WxPPp">
+                        <node concept="2OqwBi" id="2I_DQhFbTJ" role="WxPPp">
                           <node concept="2OqwBi" id="78RogMCHrs9" role="2Oq$k0">
                             <node concept="2JrnkZ" id="78RogMCHrsa" role="2Oq$k0">
                               <node concept="2OqwBi" id="78RogMCHwou" role="2JrQYb">
@@ -731,12 +751,42 @@
                                 <node concept="I4A8Y" id="78RogMCHyZN" role="2OqNvi" />
                               </node>
                             </node>
-                            <node concept="liA8E" id="78RogMCHrse" role="2OqNvi">
-                              <ref role="37wK5l" to="mhbf:~SModel.getModelId()" resolve="getModelId" />
+                            <node concept="liA8E" id="2I_DQhF3TU" role="2OqNvi">
+                              <ref role="37wK5l" to="mhbf:~SModel.getReference()" resolve="getReference" />
                             </node>
                           </node>
-                          <node concept="liA8E" id="78RogMCHrsf" role="2OqNvi">
+                          <node concept="liA8E" id="2I_DQhFhAn" role="2OqNvi">
                             <ref role="37wK5l" to="wyt6:~Object.toString()" resolve="toString" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="2pJxcG" id="2I_DQhwFnn" role="2pJxcM">
+                      <ref role="2pJxcJ" to="a1af:2I_DQhwrOw" resolve="resultLocation" />
+                      <node concept="3K4zz7" id="2I_DQhAlv6" role="28ntcv">
+                        <node concept="2OqwBi" id="2I_DQhAJB$" role="3K4E3e">
+                          <node concept="2OqwBi" id="2I_DQhAzue" role="2Oq$k0">
+                            <node concept="2GrUjf" id="2I_DQhAry5" role="2Oq$k0">
+                              <ref role="2Gs0qQ" node="6gY6GEDwgRS" resolve="r" />
+                            </node>
+                            <node concept="2sxana" id="2I_DQhADyx" role="2OqNvi">
+                              <ref role="2sxfKC" to="qqy:3ghOW5H_ihW" resolve="location" />
+                            </node>
+                          </node>
+                          <node concept="liA8E" id="2I_DQhANOC" role="2OqNvi">
+                            <ref role="37wK5l" to="wyt6:~Object.toString()" resolve="toString" />
+                          </node>
+                        </node>
+                        <node concept="10Nm6u" id="2I_DQhAT24" role="3K4GZi" />
+                        <node concept="3y3z36" id="2I_DQhA8DW" role="3K4Cdx">
+                          <node concept="10Nm6u" id="2I_DQhAdkH" role="3uHU7w" />
+                          <node concept="2OqwBi" id="2I_DQhwRI_" role="3uHU7B">
+                            <node concept="2GrUjf" id="2I_DQhwKmO" role="2Oq$k0">
+                              <ref role="2Gs0qQ" node="6gY6GEDwgRS" resolve="r" />
+                            </node>
+                            <node concept="2sxana" id="2I_DQhwVEl" role="2OqNvi">
+                              <ref role="2sxfKC" to="qqy:3ghOW5H_ihW" resolve="location" />
+                            </node>
                           </node>
                         </node>
                       </node>
@@ -1340,108 +1390,174 @@
     <node concept="2YIFZL" id="78RogMCHOPn" role="jymVt">
       <property role="TrG5h" value="findNodeById" />
       <node concept="3clFbS" id="78RogMCHLgO" role="3clF47">
-        <node concept="2Gpval" id="78RogMCGGKJ" role="3cqZAp">
-          <node concept="2GrKxI" id="78RogMCGGKO" role="2Gsz3X">
-            <property role="TrG5h" value="m" />
-          </node>
-          <node concept="3clFbS" id="78RogMCGGKY" role="2LFqv$">
-            <node concept="3clFbJ" id="78RogMCGGRh" role="3cqZAp">
-              <node concept="2OqwBi" id="78RogMCGIsc" role="3clFbw">
-                <node concept="2OqwBi" id="78RogMCGHBN" role="2Oq$k0">
-                  <node concept="2OqwBi" id="78RogMCGH6f" role="2Oq$k0">
-                    <node concept="2GrUjf" id="78RogMCGGVs" role="2Oq$k0">
-                      <ref role="2Gs0qQ" node="78RogMCGGKO" resolve="m" />
-                    </node>
-                    <node concept="liA8E" id="78RogMCGHsX" role="2OqNvi">
-                      <ref role="37wK5l" to="mhbf:~SModel.getModelId()" resolve="getModelId" />
-                    </node>
-                  </node>
-                  <node concept="liA8E" id="78RogMCGI29" role="2OqNvi">
-                    <ref role="37wK5l" to="wyt6:~Object.toString()" resolve="toString" />
-                  </node>
+        <node concept="3J1_TO" id="4XPt_HarTg3" role="3cqZAp">
+          <node concept="3uVAMA" id="4XPt_HarToM" role="1zxBo5">
+            <node concept="XOnhg" id="4XPt_HarToN" role="1zc67B">
+              <property role="TrG5h" value="e" />
+              <node concept="nSUau" id="4XPt_HarToO" role="1tU5fm">
+                <node concept="3uibUv" id="4XPt_HarTqI" role="nSUat">
+                  <ref role="3uigEE" to="wyt6:~Exception" resolve="Exception" />
                 </node>
-                <node concept="liA8E" id="78RogMCGJpO" role="2OqNvi">
-                  <ref role="37wK5l" to="wyt6:~String.equals(java.lang.Object)" resolve="equals" />
-                  <node concept="37vLTw" id="78RogMCHMIi" role="37wK5m">
-                    <ref role="3cqZAo" node="78RogMCHLXq" resolve="resultNodeModelId" />
+              </node>
+            </node>
+            <node concept="3clFbS" id="4XPt_HarToP" role="1zc67A">
+              <node concept="3cpWs8" id="4XPt_Hasg_9" role="3cqZAp">
+                <node concept="3cpWsn" id="4XPt_Hasg_a" role="3cpWs9">
+                  <property role="TrG5h" value="project" />
+                  <node concept="3uibUv" id="4XPt_Has81y" role="1tU5fm">
+                    <ref role="3uigEE" to="z1c4:~Project" resolve="Project" />
+                  </node>
+                  <node concept="2YIFZM" id="4XPt_Hasg_b" role="33vP2m">
+                    <ref role="37wK5l" to="alof:~ProjectHelper.getProject(org.jetbrains.mps.openapi.module.SRepository)" resolve="getProject" />
+                    <ref role="1Pybhc" to="alof:~ProjectHelper" resolve="ProjectHelper" />
+                    <node concept="37vLTw" id="4XPt_Hasg_c" role="37wK5m">
+                      <ref role="3cqZAo" node="2I_DQhG0jj" resolve="repository" />
+                    </node>
                   </node>
                 </node>
               </node>
-              <node concept="3clFbS" id="78RogMCGGRj" role="3clFbx">
-                <node concept="3cpWs8" id="78RogMCGLi0" role="3cqZAp">
-                  <node concept="3cpWsn" id="78RogMCGLi3" role="3cpWs9">
-                    <property role="TrG5h" value="model" />
-                    <node concept="H_c77" id="78RogMCGLhZ" role="1tU5fm" />
-                    <node concept="2GrUjf" id="78RogMCGLwW" role="33vP2m">
-                      <ref role="2Gs0qQ" node="78RogMCGGKO" resolve="m" />
-                    </node>
+              <node concept="3clFbJ" id="4XPt_HasjbG" role="3cqZAp">
+                <node concept="3clFbS" id="4XPt_HasjbI" role="3clFbx">
+                  <node concept="3cpWs6" id="4XPt_HasltE" role="3cqZAp">
+                    <node concept="10Nm6u" id="4XPt_HaslLV" role="3cqZAk" />
                   </node>
                 </node>
-                <node concept="3cpWs6" id="78RogMCGLAJ" role="3cqZAp">
-                  <node concept="2OqwBi" id="78RogMCGOsz" role="3cqZAk">
-                    <node concept="2OqwBi" id="78RogMCGM8h" role="2Oq$k0">
-                      <node concept="37vLTw" id="78RogMCGLL5" role="2Oq$k0">
-                        <ref role="3cqZAo" node="78RogMCGLi3" resolve="model" />
+                <node concept="3clFbC" id="4XPt_HaskBc" role="3clFbw">
+                  <node concept="10Nm6u" id="4XPt_Hasl8I" role="3uHU7w" />
+                  <node concept="37vLTw" id="4XPt_HasjMr" role="3uHU7B">
+                    <ref role="3cqZAo" node="4XPt_Hasg_a" resolve="project" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2Gpval" id="78RogMCGGKJ" role="3cqZAp">
+                <node concept="2GrKxI" id="78RogMCGGKO" role="2Gsz3X">
+                  <property role="TrG5h" value="m" />
+                </node>
+                <node concept="3clFbS" id="78RogMCGGKY" role="2LFqv$">
+                  <node concept="3clFbJ" id="78RogMCGGRh" role="3cqZAp">
+                    <node concept="2OqwBi" id="78RogMCGIsc" role="3clFbw">
+                      <node concept="2OqwBi" id="78RogMCGHBN" role="2Oq$k0">
+                        <node concept="2OqwBi" id="78RogMCGH6f" role="2Oq$k0">
+                          <node concept="2GrUjf" id="78RogMCGGVs" role="2Oq$k0">
+                            <ref role="2Gs0qQ" node="78RogMCGGKO" resolve="m" />
+                          </node>
+                          <node concept="liA8E" id="78RogMCGHsX" role="2OqNvi">
+                            <ref role="37wK5l" to="mhbf:~SModel.getModelId()" resolve="getModelId" />
+                          </node>
+                        </node>
+                        <node concept="liA8E" id="78RogMCGI29" role="2OqNvi">
+                          <ref role="37wK5l" to="wyt6:~Object.toString()" resolve="toString" />
+                        </node>
                       </node>
-                      <node concept="2SmgA7" id="78RogMCGMef" role="2OqNvi" />
+                      <node concept="liA8E" id="78RogMCGJpO" role="2OqNvi">
+                        <ref role="37wK5l" to="wyt6:~String.equals(java.lang.Object)" resolve="equals" />
+                        <node concept="37vLTw" id="78RogMCHMIi" role="37wK5m">
+                          <ref role="3cqZAo" node="78RogMCHLXq" resolve="resultNodeModelId" />
+                        </node>
+                      </node>
                     </node>
-                    <node concept="1z4cxt" id="78RogMCGPYW" role="2OqNvi">
-                      <node concept="1bVj0M" id="78RogMCGPYY" role="23t8la">
-                        <node concept="3clFbS" id="78RogMCGPYZ" role="1bW5cS">
-                          <node concept="3clFbF" id="78RogMCGQiD" role="3cqZAp">
-                            <node concept="2OqwBi" id="78RogMCGSsL" role="3clFbG">
-                              <node concept="2OqwBi" id="78RogMCGRG9" role="2Oq$k0">
-                                <node concept="2OqwBi" id="78RogMCGR7M" role="2Oq$k0">
-                                  <node concept="2JrnkZ" id="78RogMCGQJZ" role="2Oq$k0">
-                                    <node concept="37vLTw" id="78RogMCGQiC" role="2JrQYb">
-                                      <ref role="3cqZAo" node="78RogMCGPZ0" resolve="it" />
+                    <node concept="3clFbS" id="78RogMCGGRj" role="3clFbx">
+                      <node concept="3cpWs8" id="78RogMCGLi0" role="3cqZAp">
+                        <node concept="3cpWsn" id="78RogMCGLi3" role="3cpWs9">
+                          <property role="TrG5h" value="model" />
+                          <node concept="H_c77" id="78RogMCGLhZ" role="1tU5fm" />
+                          <node concept="2GrUjf" id="78RogMCGLwW" role="33vP2m">
+                            <ref role="2Gs0qQ" node="78RogMCGGKO" resolve="m" />
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="3cpWs6" id="78RogMCGLAJ" role="3cqZAp">
+                        <node concept="2OqwBi" id="78RogMCGOsz" role="3cqZAk">
+                          <node concept="2OqwBi" id="78RogMCGM8h" role="2Oq$k0">
+                            <node concept="37vLTw" id="78RogMCGLL5" role="2Oq$k0">
+                              <ref role="3cqZAo" node="78RogMCGLi3" resolve="model" />
+                            </node>
+                            <node concept="2SmgA7" id="78RogMCGMef" role="2OqNvi" />
+                          </node>
+                          <node concept="1z4cxt" id="78RogMCGPYW" role="2OqNvi">
+                            <node concept="1bVj0M" id="78RogMCGPYY" role="23t8la">
+                              <node concept="3clFbS" id="78RogMCGPYZ" role="1bW5cS">
+                                <node concept="3clFbF" id="78RogMCGQiD" role="3cqZAp">
+                                  <node concept="2OqwBi" id="78RogMCGSsL" role="3clFbG">
+                                    <node concept="2OqwBi" id="78RogMCGRG9" role="2Oq$k0">
+                                      <node concept="2OqwBi" id="78RogMCGR7M" role="2Oq$k0">
+                                        <node concept="2JrnkZ" id="78RogMCGQJZ" role="2Oq$k0">
+                                          <node concept="37vLTw" id="78RogMCGQiC" role="2JrQYb">
+                                            <ref role="3cqZAo" node="78RogMCGPZ0" resolve="it" />
+                                          </node>
+                                        </node>
+                                        <node concept="liA8E" id="78RogMCGRq_" role="2OqNvi">
+                                          <ref role="37wK5l" to="mhbf:~SNode.getNodeId()" resolve="getNodeId" />
+                                        </node>
+                                      </node>
+                                      <node concept="liA8E" id="78RogMCGRZr" role="2OqNvi">
+                                        <ref role="37wK5l" to="wyt6:~Object.toString()" resolve="toString" />
+                                      </node>
+                                    </node>
+                                    <node concept="liA8E" id="78RogMCGT6K" role="2OqNvi">
+                                      <ref role="37wK5l" to="wyt6:~String.equals(java.lang.Object)" resolve="equals" />
+                                      <node concept="37vLTw" id="78RogMCHN5i" role="37wK5m">
+                                        <ref role="3cqZAo" node="78RogMCHM7D" resolve="resultNodeId" />
+                                      </node>
                                     </node>
                                   </node>
-                                  <node concept="liA8E" id="78RogMCGRq_" role="2OqNvi">
-                                    <ref role="37wK5l" to="mhbf:~SNode.getNodeId()" resolve="getNodeId" />
-                                  </node>
-                                </node>
-                                <node concept="liA8E" id="78RogMCGRZr" role="2OqNvi">
-                                  <ref role="37wK5l" to="wyt6:~Object.toString()" resolve="toString" />
                                 </node>
                               </node>
-                              <node concept="liA8E" id="78RogMCGT6K" role="2OqNvi">
-                                <ref role="37wK5l" to="wyt6:~String.equals(java.lang.Object)" resolve="equals" />
-                                <node concept="37vLTw" id="78RogMCHN5i" role="37wK5m">
-                                  <ref role="3cqZAo" node="78RogMCHM7D" resolve="resultNodeId" />
-                                </node>
+                              <node concept="Rh6nW" id="78RogMCGPZ0" role="1bW2Oz">
+                                <property role="TrG5h" value="it" />
+                                <node concept="2jxLKc" id="78RogMCGPZ1" role="1tU5fm" />
                               </node>
                             </node>
                           </node>
                         </node>
-                        <node concept="Rh6nW" id="78RogMCGPZ0" role="1bW2Oz">
-                          <property role="TrG5h" value="it" />
-                          <node concept="2jxLKc" id="78RogMCGPZ1" role="1tU5fm" />
-                        </node>
                       </node>
                     </node>
+                  </node>
+                </node>
+                <node concept="2OqwBi" id="4XPt_Has6i8" role="2GsD0m">
+                  <node concept="37vLTw" id="4XPt_Hasg_d" role="2Oq$k0">
+                    <ref role="3cqZAo" node="4XPt_Hasg_a" resolve="project" />
+                  </node>
+                  <node concept="liA8E" id="4XPt_Has7GX" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c4:~Project.getProjectModels()" resolve="getProjectModels" />
                   </node>
                 </node>
               </node>
             </node>
           </node>
-          <node concept="2OqwBi" id="78RogMCGGqQ" role="2GsD0m">
-            <node concept="37vLTw" id="78RogMCGG78" role="2Oq$k0">
-              <ref role="3cqZAo" node="78RogMCHLOw" resolve="proj" />
-            </node>
-            <node concept="liA8E" id="78RogMCGGHU" role="2OqNvi">
-              <ref role="37wK5l" to="z1c4:~Project.getProjectModels()" resolve="getProjectModels" />
+          <node concept="3clFbS" id="4XPt_HarTg5" role="1zxBo7">
+            <node concept="3cpWs6" id="4XPt_HarTDJ" role="3cqZAp">
+              <node concept="2OqwBi" id="2I_DQhCwgY" role="3cqZAk">
+                <node concept="2ShNRf" id="2I_DQhCtFU" role="2Oq$k0">
+                  <node concept="1pGfFk" id="2I_DQhCvfd" role="2ShVmc">
+                    <property role="373rjd" value="true" />
+                    <ref role="37wK5l" to="w1kc:~SNodePointer.&lt;init&gt;(java.lang.String,java.lang.String)" resolve="SNodePointer" />
+                    <node concept="37vLTw" id="2I_DQhCvqF" role="37wK5m">
+                      <ref role="3cqZAo" node="78RogMCHLXq" resolve="resultNodeModelId" />
+                    </node>
+                    <node concept="37vLTw" id="2I_DQhCvWI" role="37wK5m">
+                      <ref role="3cqZAo" node="78RogMCHM7D" resolve="resultNodeId" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="liA8E" id="2I_DQhCwAL" role="2OqNvi">
+                  <ref role="37wK5l" to="w1kc:~SNodePointer.resolve(org.jetbrains.mps.openapi.module.SRepository)" resolve="resolve" />
+                  <node concept="37vLTw" id="2I_DQhG0vM" role="37wK5m">
+                    <ref role="3cqZAo" node="2I_DQhG0jj" resolve="repository" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>
-        <node concept="3cpWs6" id="78RogMCHNmQ" role="3cqZAp">
-          <node concept="10Nm6u" id="78RogMCHNxJ" role="3cqZAk" />
+        <node concept="3cpWs6" id="4XPt_HasnCa" role="3cqZAp">
+          <node concept="10Nm6u" id="4XPt_HasnEp" role="3cqZAk" />
         </node>
       </node>
-      <node concept="37vLTG" id="78RogMCHLOw" role="3clF46">
-        <property role="TrG5h" value="proj" />
-        <node concept="3uibUv" id="78RogMCHLOv" role="1tU5fm">
-          <ref role="3uigEE" to="z1c4:~Project" resolve="Project" />
+      <node concept="37vLTG" id="2I_DQhG0jj" role="3clF46">
+        <property role="TrG5h" value="repository" />
+        <node concept="3uibUv" id="2I_DQhG0rg" role="1tU5fm">
+          <ref role="3uigEE" to="lui2:~SRepository" resolve="SRepository" />
         </node>
       </node>
       <node concept="37vLTG" id="78RogMCHLXq" role="3clF46">
@@ -1669,38 +1785,246 @@
       <node concept="17QB3L" id="4Wm$DJ9cjic" role="3clF45" />
       <node concept="3clFbS" id="4Wm$DJ9cjhZ" role="3clF47">
         <node concept="3clFbF" id="4Wm$DJ9cjiS" role="3cqZAp">
-          <node concept="3cpWs3" id="4Wm$DJ9cklg" role="3clFbG">
-            <node concept="2OqwBi" id="4Wm$DJ9cknD" role="3uHU7w">
-              <node concept="13iPFW" id="4Wm$DJ9ckmD" role="2Oq$k0" />
-              <node concept="3TrcHB" id="4Wm$DJ9ckpU" role="2OqNvi">
-                <ref role="3TsBF5" to="a1af:78RogMCGEUf" resolve="resultNodeId" />
+          <node concept="3cpWs3" id="4XPt_HavKTq" role="3clFbG">
+            <node concept="2OqwBi" id="4XPt_HavLei" role="3uHU7w">
+              <node concept="13iPFW" id="4XPt_HavKTt" role="2Oq$k0" />
+              <node concept="3TrcHB" id="4XPt_HavLBl" role="2OqNvi">
+                <ref role="3TsBF5" to="a1af:2I_DQhwrOw" resolve="resultLocation" />
               </node>
             </node>
-            <node concept="3cpWs3" id="4Wm$DJ9ckdW" role="3uHU7B">
-              <node concept="3cpWs3" id="4Wm$DJ9ck0J" role="3uHU7B">
-                <node concept="3cpWs3" id="4Wm$DJ9cjQ8" role="3uHU7B">
-                  <node concept="2OqwBi" id="4Wm$DJ9cjqa" role="3uHU7B">
-                    <node concept="13iPFW" id="4Wm$DJ9cjiR" role="2Oq$k0" />
-                    <node concept="3TrcHB" id="4Wm$DJ9cjxP" role="2OqNvi">
-                      <ref role="3TsBF5" to="a1af:6gY6GEDvQYT" resolve="result" />
+            <node concept="3cpWs3" id="4XPt_HavKP6" role="3uHU7B">
+              <node concept="3cpWs3" id="4Wm$DJ9cklg" role="3uHU7B">
+                <node concept="3cpWs3" id="4Wm$DJ9ckdW" role="3uHU7B">
+                  <node concept="3cpWs3" id="4Wm$DJ9ck0J" role="3uHU7B">
+                    <node concept="3cpWs3" id="4Wm$DJ9cjQ8" role="3uHU7B">
+                      <node concept="2OqwBi" id="4Wm$DJ9cjqa" role="3uHU7B">
+                        <node concept="13iPFW" id="4Wm$DJ9cjiR" role="2Oq$k0" />
+                        <node concept="3TrcHB" id="4Wm$DJ9cjxP" role="2OqNvi">
+                          <ref role="3TsBF5" to="a1af:6gY6GEDvQYT" resolve="result" />
+                        </node>
+                      </node>
+                      <node concept="Xl_RD" id="4Wm$DJ9cjQD" role="3uHU7w">
+                        <property role="Xl_RC" value=" / " />
+                      </node>
+                    </node>
+                    <node concept="2OqwBi" id="4Wm$DJ9ck6o" role="3uHU7w">
+                      <node concept="13iPFW" id="4Wm$DJ9ck1x" role="2Oq$k0" />
+                      <node concept="3TrcHB" id="4Wm$DJ9ck8h" role="2OqNvi">
+                        <ref role="3TsBF5" to="a1af:78RogMCGEW7" resolve="resultNodeModelId" />
+                      </node>
                     </node>
                   </node>
-                  <node concept="Xl_RD" id="4Wm$DJ9cjQD" role="3uHU7w">
-                    <property role="Xl_RC" value=" / " />
+                  <node concept="Xl_RD" id="4Wm$DJ9ckf7" role="3uHU7w">
+                    <property role="Xl_RC" value=":" />
                   </node>
                 </node>
-                <node concept="2OqwBi" id="4Wm$DJ9ck6o" role="3uHU7w">
-                  <node concept="13iPFW" id="4Wm$DJ9ck1x" role="2Oq$k0" />
-                  <node concept="3TrcHB" id="4Wm$DJ9ck8h" role="2OqNvi">
-                    <ref role="3TsBF5" to="a1af:78RogMCGEW7" resolve="resultNodeModelId" />
+                <node concept="2OqwBi" id="4Wm$DJ9cknD" role="3uHU7w">
+                  <node concept="13iPFW" id="4Wm$DJ9ckmD" role="2Oq$k0" />
+                  <node concept="3TrcHB" id="4Wm$DJ9ckpU" role="2OqNvi">
+                    <ref role="3TsBF5" to="a1af:78RogMCGEUf" resolve="resultNodeId" />
                   </node>
                 </node>
               </node>
-              <node concept="Xl_RD" id="4Wm$DJ9ckf7" role="3uHU7w">
+              <node concept="Xl_RD" id="4XPt_HavKP9" role="3uHU7w">
                 <property role="Xl_RC" value=":" />
               </node>
             </node>
           </node>
+        </node>
+      </node>
+    </node>
+    <node concept="13i0hz" id="2I_DQhGejd" role="13h7CS">
+      <property role="TrG5h" value="getNode" />
+      <node concept="3Tm1VV" id="2I_DQhGeje" role="1B3o_S" />
+      <node concept="3Tqbb2" id="2I_DQhGekN" role="3clF45" />
+      <node concept="3clFbS" id="2I_DQhGejg" role="3clF47">
+        <node concept="3clFbF" id="2I_DQhGell" role="3cqZAp">
+          <node concept="2YIFZM" id="78RogMCHPlD" role="3clFbG">
+            <ref role="37wK5l" node="78RogMCHOPn" resolve="findNodeById" />
+            <ref role="1Pybhc" node="78RogMCHKPV" resolve="Node2ID" />
+            <node concept="37vLTw" id="2I_DQhGezh" role="37wK5m">
+              <ref role="3cqZAo" node="2I_DQhGenF" resolve="repository" />
+            </node>
+            <node concept="2OqwBi" id="78RogMCHQ00" role="37wK5m">
+              <node concept="13iPFW" id="2I_DQhGe$A" role="2Oq$k0" />
+              <node concept="3TrcHB" id="78RogMCHQhE" role="2OqNvi">
+                <ref role="3TsBF5" to="a1af:78RogMCGEW7" resolve="resultNodeModelId" />
+              </node>
+            </node>
+            <node concept="2OqwBi" id="78RogMCHQEb" role="37wK5m">
+              <node concept="13iPFW" id="2I_DQhGeB$" role="2Oq$k0" />
+              <node concept="3TrcHB" id="78RogMCHQP$" role="2OqNvi">
+                <ref role="3TsBF5" to="a1af:78RogMCGEUf" resolve="resultNodeId" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="2I_DQhGenF" role="3clF46">
+        <property role="TrG5h" value="repository" />
+        <node concept="3uibUv" id="2I_DQhGenE" role="1tU5fm">
+          <ref role="3uigEE" to="lui2:~SRepository" resolve="SRepository" />
+        </node>
+      </node>
+    </node>
+    <node concept="13i0hz" id="4XPt_HauH1N" role="13h7CS">
+      <property role="TrG5h" value="formatLocation" />
+      <node concept="3Tm1VV" id="4XPt_HauH1O" role="1B3o_S" />
+      <node concept="17QB3L" id="4XPt_HauH4u" role="3clF45" />
+      <node concept="3clFbS" id="4XPt_HauH1Q" role="3clF47">
+        <node concept="3cpWs8" id="4XPt_HauIId" role="3cqZAp">
+          <node concept="3cpWsn" id="4XPt_HauIIe" role="3cpWs9">
+            <property role="TrG5h" value="persistenceFacade" />
+            <node concept="3uibUv" id="4XPt_HauIH$" role="1tU5fm">
+              <ref role="3uigEE" to="dush:~PersistenceFacade" resolve="PersistenceFacade" />
+            </node>
+            <node concept="2YIFZM" id="4XPt_HauIIf" role="33vP2m">
+              <ref role="37wK5l" to="dush:~PersistenceFacade.getInstance()" resolve="getInstance" />
+              <ref role="1Pybhc" to="dush:~PersistenceFacade" resolve="PersistenceFacade" />
+            </node>
+          </node>
+        </node>
+        <node concept="3J1_TO" id="4XPt_HauHn6" role="3cqZAp">
+          <node concept="3uVAMA" id="4XPt_HauHnV" role="1zxBo5">
+            <node concept="XOnhg" id="4XPt_HauHnW" role="1zc67B">
+              <property role="TrG5h" value="e" />
+              <node concept="nSUau" id="4XPt_HauHnX" role="1tU5fm">
+                <node concept="3uibUv" id="4XPt_HauHoC" role="nSUat">
+                  <ref role="3uigEE" to="wyt6:~Exception" resolve="Exception" />
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbS" id="4XPt_HauHnY" role="1zc67A" />
+          </node>
+          <node concept="3clFbS" id="4XPt_HauHn8" role="1zxBo7">
+            <node concept="3cpWs8" id="4XPt_HaxnmX" role="3cqZAp">
+              <node concept="3cpWsn" id="4XPt_HaxnmY" role="3cpWs9">
+                <property role="TrG5h" value="modelRef" />
+                <node concept="3uibUv" id="4XPt_Haxnkx" role="1tU5fm">
+                  <ref role="3uigEE" to="mhbf:~SModelReference" resolve="SModelReference" />
+                </node>
+                <node concept="2OqwBi" id="4XPt_HaxnmZ" role="33vP2m">
+                  <node concept="37vLTw" id="4XPt_Haxnn0" role="2Oq$k0">
+                    <ref role="3cqZAo" node="4XPt_HauIIe" resolve="persistenceFacade" />
+                  </node>
+                  <node concept="liA8E" id="4XPt_Haxnn1" role="2OqNvi">
+                    <ref role="37wK5l" to="dush:~PersistenceFacade.createModelReference(java.lang.String)" resolve="createModelReference" />
+                    <node concept="2OqwBi" id="4XPt_Haxnn2" role="37wK5m">
+                      <node concept="13iPFW" id="4XPt_Haxnn3" role="2Oq$k0" />
+                      <node concept="3TrcHB" id="4XPt_Haxnn4" role="2OqNvi">
+                        <ref role="3TsBF5" to="a1af:2I_DQhwrOw" resolve="resultLocation" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3cpWs6" id="4XPt_HauHqo" role="3cqZAp">
+              <node concept="3cpWs3" id="4XPt_HaxD5R" role="3cqZAk">
+                <node concept="2OqwBi" id="4XPt_HaxEfO" role="3uHU7w">
+                  <node concept="2OqwBi" id="4XPt_HaxDTQ" role="2Oq$k0">
+                    <node concept="2OqwBi" id="4XPt_HaxDj3" role="2Oq$k0">
+                      <node concept="37vLTw" id="4XPt_HaxD94" role="2Oq$k0">
+                        <ref role="3cqZAo" node="4XPt_HaxnmY" resolve="modelRef" />
+                      </node>
+                      <node concept="liA8E" id="4XPt_HaxD_D" role="2OqNvi">
+                        <ref role="37wK5l" to="mhbf:~SModelReference.resolve(org.jetbrains.mps.openapi.module.SRepository)" resolve="resolve" />
+                        <node concept="37vLTw" id="4XPt_HaxDK5" role="37wK5m">
+                          <ref role="3cqZAo" node="4XPt_HaxCna" resolve="repository" />
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="liA8E" id="4XPt_HaxE78" role="2OqNvi">
+                      <ref role="37wK5l" to="mhbf:~SModel.getModule()" resolve="getModule" />
+                    </node>
+                  </node>
+                  <node concept="liA8E" id="4XPt_HaxEuD" role="2OqNvi">
+                    <ref role="37wK5l" to="lui2:~SModule.getModuleName()" resolve="getModuleName" />
+                  </node>
+                </node>
+                <node concept="3cpWs3" id="4XPt_HaxCcN" role="3uHU7B">
+                  <node concept="3cpWs3" id="4XPt_HayC$o" role="3uHU7B">
+                    <node concept="Xl_RD" id="4XPt_HayC$r" role="3uHU7B">
+                      <property role="Xl_RC" value="model: " />
+                    </node>
+                    <node concept="2OqwBi" id="4XPt_HauJO2" role="3uHU7w">
+                      <node concept="2OqwBi" id="4XPt_HauJwl" role="2Oq$k0">
+                        <node concept="37vLTw" id="4XPt_Haxnn5" role="2Oq$k0">
+                          <ref role="3cqZAo" node="4XPt_HaxnmY" resolve="modelRef" />
+                        </node>
+                        <node concept="liA8E" id="4XPt_HauJE1" role="2OqNvi">
+                          <ref role="37wK5l" to="mhbf:~SModelReference.getName()" resolve="getName" />
+                        </node>
+                      </node>
+                      <node concept="liA8E" id="4XPt_HauJYN" role="2OqNvi">
+                        <ref role="37wK5l" to="mhbf:~SModelName.toString()" resolve="toString" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="Xl_RD" id="4XPt_HaxCcQ" role="3uHU7w">
+                    <property role="Xl_RC" value=" module:" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="4XPt_HauHUV" role="3cqZAp" />
+        <node concept="3J1_TO" id="4XPt_HauHOA" role="3cqZAp">
+          <node concept="3uVAMA" id="4XPt_HauHOB" role="1zxBo5">
+            <node concept="XOnhg" id="4XPt_HauHOC" role="1zc67B">
+              <property role="TrG5h" value="e" />
+              <node concept="nSUau" id="4XPt_HauHOD" role="1tU5fm">
+                <node concept="3uibUv" id="4XPt_HauHOE" role="nSUat">
+                  <ref role="3uigEE" to="wyt6:~Exception" resolve="Exception" />
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbS" id="4XPt_HauHOF" role="1zc67A" />
+          </node>
+          <node concept="3clFbS" id="4XPt_HauHOG" role="1zxBo7">
+            <node concept="3cpWs6" id="4XPt_HauHOH" role="3cqZAp">
+              <node concept="3cpWs3" id="4XPt_HayD7j" role="3cqZAk">
+                <node concept="Xl_RD" id="4XPt_HayDbO" role="3uHU7B">
+                  <property role="Xl_RC" value="module: " />
+                </node>
+                <node concept="2OqwBi" id="4XPt_HauK8Z" role="3uHU7w">
+                  <node concept="2OqwBi" id="4XPt_HauHOI" role="2Oq$k0">
+                    <node concept="37vLTw" id="4XPt_HauIIh" role="2Oq$k0">
+                      <ref role="3cqZAo" node="4XPt_HauIIe" resolve="persistenceFacade" />
+                    </node>
+                    <node concept="liA8E" id="4XPt_HauHOK" role="2OqNvi">
+                      <ref role="37wK5l" to="dush:~PersistenceFacade.createModuleReference(java.lang.String)" resolve="createModuleReference" />
+                      <node concept="2OqwBi" id="4XPt_HauHOL" role="37wK5m">
+                        <node concept="13iPFW" id="4XPt_HauHOM" role="2Oq$k0" />
+                        <node concept="3TrcHB" id="4XPt_HauHON" role="2OqNvi">
+                          <ref role="3TsBF5" to="a1af:2I_DQhwrOw" resolve="resultLocation" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="liA8E" id="4XPt_HauKj1" role="2OqNvi">
+                    <ref role="37wK5l" to="lui2:~SModuleReference.getModuleName()" resolve="getModuleName" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="4XPt_HauI1d" role="3cqZAp" />
+        <node concept="3cpWs6" id="4XPt_HauIlq" role="3cqZAp">
+          <node concept="2OqwBi" id="4XPt_HauIyE" role="3cqZAk">
+            <node concept="13iPFW" id="4XPt_HauInp" role="2Oq$k0" />
+            <node concept="3TrcHB" id="4XPt_HauIGq" role="2OqNvi">
+              <ref role="3TsBF5" to="a1af:2I_DQhwrOw" resolve="resultLocation" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="4XPt_HaxCna" role="3clF46">
+        <property role="TrG5h" value="repository" />
+        <node concept="3uibUv" id="4XPt_HaxCn9" role="1tU5fm">
+          <ref role="3uigEE" to="lui2:~SRepository" resolve="SRepository" />
         </node>
       </node>
     </node>

--- a/code/languages/org.mpsqa.lint/languages/org.mpsqa.lint.generic/models/org.mpsqa.lint.generic.behavior.mps
+++ b/code/languages/org.mpsqa.lint/languages/org.mpsqa.lint.generic/models/org.mpsqa.lint.generic.behavior.mps
@@ -1214,42 +1214,15 @@
                     <node concept="3zZkjj" id="5vskli_kHn2" role="2OqNvi">
                       <node concept="1bVj0M" id="5vskli_kHn3" role="23t8la">
                         <node concept="3clFbS" id="5vskli_kHn4" role="1bW5cS">
-                          <node concept="3clFbF" id="5vskli_kHn5" role="3cqZAp">
-                            <node concept="1Wc70l" id="5vskli_kHn6" role="3clFbG">
-                              <node concept="2YIFZM" id="5vskli_kHn7" role="3uHU7w">
-                                <ref role="37wK5l" node="78RogMCIawZ" resolve="sameNode" />
-                                <ref role="1Pybhc" node="78RogMCHKPV" resolve="Node2ID" />
-                                <node concept="2OqwBi" id="5vskli_kHn8" role="37wK5m">
-                                  <node concept="37vLTw" id="5vskli_kHn9" role="2Oq$k0">
-                                    <ref role="3cqZAo" node="5vskli_kHnk" resolve="it" />
-                                  </node>
-                                  <node concept="2sxana" id="3ghOW5HSeom" role="2OqNvi">
-                                    <ref role="2sxfKC" to="qqy:3ghOW5HS78o" resolve="node" />
-                                  </node>
-                                </node>
-                                <node concept="2GrUjf" id="5vskli_kHnb" role="37wK5m">
-                                  <ref role="2Gs0qQ" node="6gY6GEDxCpt" resolve="v" />
-                                </node>
+                          <node concept="3clFbF" id="106MO2l5APC" role="3cqZAp">
+                            <node concept="2OqwBi" id="106MO2l5BKQ" role="3clFbG">
+                              <node concept="2GrUjf" id="106MO2l5APA" role="2Oq$k0">
+                                <ref role="2Gs0qQ" node="6gY6GEDxCpt" resolve="v" />
                               </node>
-                              <node concept="2OqwBi" id="5vskli_kHnc" role="3uHU7B">
-                                <node concept="2OqwBi" id="5vskli_kHnd" role="2Oq$k0">
-                                  <node concept="37vLTw" id="5vskli_kHne" role="2Oq$k0">
-                                    <ref role="3cqZAo" node="5vskli_kHnk" resolve="it" />
-                                  </node>
-                                  <node concept="2sxana" id="19GnlsUlTxc" role="2OqNvi">
-                                    <ref role="2sxfKC" to="qqy:19GnlsUkKsI" resolve="message" />
-                                  </node>
-                                </node>
-                                <node concept="liA8E" id="5vskli_kHng" role="2OqNvi">
-                                  <ref role="37wK5l" to="wyt6:~String.equals(java.lang.Object)" resolve="equals" />
-                                  <node concept="2OqwBi" id="5vskli_kHnh" role="37wK5m">
-                                    <node concept="2GrUjf" id="5vskli_kHni" role="2Oq$k0">
-                                      <ref role="2Gs0qQ" node="6gY6GEDxCpt" resolve="v" />
-                                    </node>
-                                    <node concept="3TrcHB" id="5vskli_kHnj" role="2OqNvi">
-                                      <ref role="3TsBF5" to="a1af:6gY6GEDvQYT" resolve="result" />
-                                    </node>
-                                  </node>
+                              <node concept="2qgKlT" id="106MO2l5G9w" role="2OqNvi">
+                                <ref role="37wK5l" node="106MO2l56WG" resolve="equals" />
+                                <node concept="37vLTw" id="106MO2l5GyZ" role="37wK5m">
+                                  <ref role="3cqZAo" node="5vskli_kHnk" resolve="it" />
                                 </node>
                               </node>
                             </node>
@@ -2496,6 +2469,90 @@
         <property role="TrG5h" value="repository" />
         <node concept="3uibUv" id="4XPt_HaEA7a" role="1tU5fm">
           <ref role="3uigEE" to="lui2:~SRepository" resolve="SRepository" />
+        </node>
+      </node>
+    </node>
+    <node concept="13i0hz" id="106MO2l56WG" role="13h7CS">
+      <property role="TrG5h" value="equals" />
+      <node concept="3Tm1VV" id="106MO2l56WH" role="1B3o_S" />
+      <node concept="10P_77" id="106MO2l57js" role="3clF45" />
+      <node concept="3clFbS" id="106MO2l56WJ" role="3clF47">
+        <node concept="3clFbF" id="106MO2l59$6" role="3cqZAp">
+          <node concept="1Wc70l" id="106MO2l5hf1" role="3clFbG">
+            <node concept="17R0WA" id="106MO2l5m9l" role="3uHU7w">
+              <node concept="2OqwBi" id="106MO2l5nJK" role="3uHU7w">
+                <node concept="2OqwBi" id="106MO2l5n4F" role="2Oq$k0">
+                  <node concept="37vLTw" id="106MO2l5mgN" role="2Oq$k0">
+                    <ref role="3cqZAo" node="106MO2l57jJ" resolve="result" />
+                  </node>
+                  <node concept="2sxana" id="106MO2l5nC8" role="2OqNvi">
+                    <ref role="2sxfKC" to="qqy:3ghOW5H_ihW" resolve="location" />
+                  </node>
+                </node>
+                <node concept="liA8E" id="106MO2l5nP_" role="2OqNvi">
+                  <ref role="37wK5l" to="wyt6:~Object.toString()" resolve="toString" />
+                </node>
+              </node>
+              <node concept="2OqwBi" id="106MO2l5lAt" role="3uHU7B">
+                <node concept="13iPFW" id="106MO2l5l$w" role="2Oq$k0" />
+                <node concept="3TrcHB" id="106MO2l5lE1" role="2OqNvi">
+                  <ref role="3TsBF5" to="a1af:2I_DQhwrOw" resolve="resultLocation" />
+                </node>
+              </node>
+            </node>
+            <node concept="1Wc70l" id="106MO2l5cSW" role="3uHU7B">
+              <node concept="17R0WA" id="106MO2l5bok" role="3uHU7B">
+                <node concept="2OqwBi" id="106MO2l59JH" role="3uHU7B">
+                  <node concept="13iPFW" id="106MO2l59$5" role="2Oq$k0" />
+                  <node concept="3TrcHB" id="106MO2l59Sx" role="2OqNvi">
+                    <ref role="3TsBF5" to="a1af:6gY6GEDvQYT" resolve="result" />
+                  </node>
+                </node>
+                <node concept="2OqwBi" id="106MO2l5clb" role="3uHU7w">
+                  <node concept="37vLTw" id="106MO2l5btm" role="2Oq$k0">
+                    <ref role="3cqZAo" node="106MO2l57jJ" resolve="result" />
+                  </node>
+                  <node concept="2sxana" id="106MO2l5cR5" role="2OqNvi">
+                    <ref role="2sxfKC" to="qqy:19GnlsUkKsI" resolve="message" />
+                  </node>
+                </node>
+              </node>
+              <node concept="17R0WA" id="106MO2l5e5K" role="3uHU7w">
+                <node concept="2OqwBi" id="106MO2l5d1B" role="3uHU7B">
+                  <node concept="13iPFW" id="106MO2l5cSZ" role="2Oq$k0" />
+                  <node concept="3TrcHB" id="106MO2l5db6" role="2OqNvi">
+                    <ref role="3TsBF5" to="a1af:78RogMCGEUf" resolve="resultNodeId" />
+                  </node>
+                </node>
+                <node concept="2OqwBi" id="106MO2l5gJR" role="3uHU7w">
+                  <node concept="2OqwBi" id="106MO2l5gi2" role="2Oq$k0">
+                    <node concept="2JrnkZ" id="106MO2l5fRV" role="2Oq$k0">
+                      <node concept="2OqwBi" id="106MO2l5eTA" role="2JrQYb">
+                        <node concept="37vLTw" id="106MO2l5ebs" role="2Oq$k0">
+                          <ref role="3cqZAo" node="106MO2l57jJ" resolve="result" />
+                        </node>
+                        <node concept="2sxana" id="106MO2l5frX" role="2OqNvi">
+                          <ref role="2sxfKC" to="qqy:3ghOW5HS78o" resolve="node" />
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="liA8E" id="106MO2l6XGr" role="2OqNvi">
+                      <ref role="37wK5l" to="mhbf:~SNode.getNodeId()" resolve="getNodeId" />
+                    </node>
+                  </node>
+                  <node concept="liA8E" id="106MO2l5gSP" role="2OqNvi">
+                    <ref role="37wK5l" to="wyt6:~Object.toString()" resolve="toString" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="106MO2l57jJ" role="3clF46">
+        <property role="TrG5h" value="result" />
+        <node concept="3uibUv" id="106MO2l57jI" role="1tU5fm">
+          <ref role="3uigEE" to="qqy:19GnlsUkKsu" resolve="Result" />
         </node>
       </node>
     </node>

--- a/code/languages/org.mpsqa.lint/languages/org.mpsqa.lint.generic/models/org.mpsqa.lint.generic.behavior.mps
+++ b/code/languages/org.mpsqa.lint/languages/org.mpsqa.lint.generic/models/org.mpsqa.lint.generic.behavior.mps
@@ -27,6 +27,7 @@
     <import index="w1kc" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.smodel(MPS.Core/)" />
     <import index="alof" ref="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61/java:jetbrains.mps.ide.project(MPS.Platform/)" />
     <import index="dush" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.persistence(MPS.OpenAPI/)" />
+    <import index="guwi" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.io(JDK/)" />
     <import index="vdrq" ref="r:85354f47-14fd-40e6-a7cc-2d1aa842c4cd(jetbrains.mps.lang.text.behavior)" implicit="true" />
     <import index="tpcu" ref="r:00000000-0000-4000-0000-011c89590282(jetbrains.mps.lang.core.behavior)" implicit="true" />
   </imports>
@@ -34,6 +35,12 @@
     <language id="a247e09e-2435-45ba-b8d2-07e93feba96a" name="jetbrains.mps.baseLanguage.tuples">
       <concept id="1239576519914" name="jetbrains.mps.baseLanguage.tuples.structure.NamedTupleComponentAccessOperation" flags="nn" index="2sxana">
         <reference id="1239576542472" name="component" index="2sxfKC" />
+      </concept>
+      <concept id="1238852151516" name="jetbrains.mps.baseLanguage.tuples.structure.IndexedTupleType" flags="in" index="1LlUBW">
+        <child id="1238852204892" name="componentType" index="1Lm7xW" />
+      </concept>
+      <concept id="1238853782547" name="jetbrains.mps.baseLanguage.tuples.structure.IndexedTupleLiteral" flags="nn" index="1Ls8ON">
+        <child id="1238853845806" name="component" index="1Lso8e" />
       </concept>
     </language>
     <language id="af65afd8-f0dd-4942-87d9-63a55f2a9db1" name="jetbrains.mps.lang.behavior">
@@ -458,6 +465,39 @@
                               <ref role="2pIpSl" to="tpee:g7uigIF" resolve="classifier" />
                               <node concept="36bGnv" id="3ghOW5HAf7f" role="28nt2d">
                                 <ref role="36bGnp" to="lui2:~SModule" resolve="SModule" />
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="2pJPED" id="4XPt_HaAdId" role="36be1Z">
+                    <ref role="2pJxaS" to="tp2q:gK_YKtE" resolve="ListType" />
+                    <node concept="2pIpSj" id="4XPt_HaAdIe" role="2pJxcM">
+                      <ref role="2pIpSl" to="tp2q:gK_ZDn5" resolve="elementType" />
+                      <node concept="2pJPED" id="4XPt_HaAdIf" role="28nt2d">
+                        <ref role="2pJxaS" to="tpee:g7uibYu" resolve="ClassifierType" />
+                        <node concept="2pIpSj" id="4XPt_HaAdIg" role="2pJxcM">
+                          <ref role="2pIpSl" to="tpee:g7uigIF" resolve="classifier" />
+                          <node concept="36bGnv" id="4XPt_HaAdIh" role="28nt2d">
+                            <ref role="36bGnp" to="zn9m:~Pair" resolve="Pair" />
+                          </node>
+                        </node>
+                        <node concept="2pIpSj" id="4XPt_HaAdIi" role="2pJxcM">
+                          <ref role="2pIpSl" to="tpee:g91_B6F" resolve="parameter" />
+                          <node concept="2pJPED" id="4XPt_HaAdIj" role="28nt2d">
+                            <ref role="2pJxaS" to="tpee:hP7QB7G" resolve="StringType" />
+                          </node>
+                        </node>
+                        <node concept="2pIpSj" id="4XPt_HaAdIk" role="2pJxcM">
+                          <ref role="2pIpSl" to="tpee:g91_B6F" resolve="parameter" />
+                          <node concept="2pJPED" id="4XPt_HaAdIl" role="28nt2d">
+                            <ref role="2pJxaS" to="tpee:g7uibYu" resolve="ClassifierType" />
+                            <node concept="2pIpSj" id="4XPt_HaAdIm" role="2pJxcM">
+                              <ref role="2pIpSl" to="tpee:g7uigIF" resolve="classifier" />
+                              <node concept="36bGnv" id="4XPt_HaAqAE" role="28nt2d">
+                                <ref role="36bGnp" to="guwi:~File" resolve="File" />
                               </node>
                             </node>
                           </node>
@@ -1870,7 +1910,6 @@
     <node concept="13i0hz" id="4XPt_HauH1N" role="13h7CS">
       <property role="TrG5h" value="formatLocation" />
       <node concept="3Tm1VV" id="4XPt_HauH1O" role="1B3o_S" />
-      <node concept="17QB3L" id="4XPt_HauH4u" role="3clF45" />
       <node concept="3clFbS" id="4XPt_HauH1Q" role="3clF47">
         <node concept="3cpWs8" id="4XPt_HauIId" role="3cqZAp">
           <node concept="3cpWsn" id="4XPt_HauIIe" role="3cpWs9">
@@ -1920,50 +1959,55 @@
               </node>
             </node>
             <node concept="3cpWs6" id="4XPt_HauHqo" role="3cqZAp">
-              <node concept="3cpWs3" id="4XPt_HaxD5R" role="3cqZAk">
-                <node concept="2OqwBi" id="4XPt_HaxEfO" role="3uHU7w">
-                  <node concept="2OqwBi" id="4XPt_HaxDTQ" role="2Oq$k0">
-                    <node concept="2OqwBi" id="4XPt_HaxDj3" role="2Oq$k0">
-                      <node concept="37vLTw" id="4XPt_HaxD94" role="2Oq$k0">
-                        <ref role="3cqZAo" node="4XPt_HaxnmY" resolve="modelRef" />
-                      </node>
-                      <node concept="liA8E" id="4XPt_HaxD_D" role="2OqNvi">
-                        <ref role="37wK5l" to="mhbf:~SModelReference.resolve(org.jetbrains.mps.openapi.module.SRepository)" resolve="resolve" />
-                        <node concept="37vLTw" id="4XPt_HaxDK5" role="37wK5m">
-                          <ref role="3cqZAo" node="4XPt_HaxCna" resolve="repository" />
-                        </node>
-                      </node>
-                    </node>
-                    <node concept="liA8E" id="4XPt_HaxE78" role="2OqNvi">
-                      <ref role="37wK5l" to="mhbf:~SModel.getModule()" resolve="getModule" />
-                    </node>
-                  </node>
-                  <node concept="liA8E" id="4XPt_HaxEuD" role="2OqNvi">
-                    <ref role="37wK5l" to="lui2:~SModule.getModuleName()" resolve="getModuleName" />
-                  </node>
-                </node>
-                <node concept="3cpWs3" id="4XPt_HaxCcN" role="3uHU7B">
-                  <node concept="3cpWs3" id="4XPt_HayC$o" role="3uHU7B">
-                    <node concept="Xl_RD" id="4XPt_HayC$r" role="3uHU7B">
-                      <property role="Xl_RC" value="model: " />
-                    </node>
-                    <node concept="2OqwBi" id="4XPt_HauJO2" role="3uHU7w">
-                      <node concept="2OqwBi" id="4XPt_HauJwl" role="2Oq$k0">
-                        <node concept="37vLTw" id="4XPt_Haxnn5" role="2Oq$k0">
+              <node concept="1Ls8ON" id="4XPt_HaCtaF" role="3cqZAk">
+                <node concept="3cpWs3" id="4XPt_HaxD5R" role="1Lso8e">
+                  <node concept="2OqwBi" id="4XPt_HaxEfO" role="3uHU7w">
+                    <node concept="2OqwBi" id="4XPt_HaxDTQ" role="2Oq$k0">
+                      <node concept="2OqwBi" id="4XPt_HaxDj3" role="2Oq$k0">
+                        <node concept="37vLTw" id="4XPt_HaxD94" role="2Oq$k0">
                           <ref role="3cqZAo" node="4XPt_HaxnmY" resolve="modelRef" />
                         </node>
-                        <node concept="liA8E" id="4XPt_HauJE1" role="2OqNvi">
-                          <ref role="37wK5l" to="mhbf:~SModelReference.getName()" resolve="getName" />
+                        <node concept="liA8E" id="4XPt_HaxD_D" role="2OqNvi">
+                          <ref role="37wK5l" to="mhbf:~SModelReference.resolve(org.jetbrains.mps.openapi.module.SRepository)" resolve="resolve" />
+                          <node concept="37vLTw" id="4XPt_HaxDK5" role="37wK5m">
+                            <ref role="3cqZAo" node="4XPt_HaxCna" resolve="repository" />
+                          </node>
                         </node>
                       </node>
-                      <node concept="liA8E" id="4XPt_HauJYN" role="2OqNvi">
-                        <ref role="37wK5l" to="mhbf:~SModelName.toString()" resolve="toString" />
+                      <node concept="liA8E" id="4XPt_HaxE78" role="2OqNvi">
+                        <ref role="37wK5l" to="mhbf:~SModel.getModule()" resolve="getModule" />
                       </node>
                     </node>
+                    <node concept="liA8E" id="4XPt_HaxEuD" role="2OqNvi">
+                      <ref role="37wK5l" to="lui2:~SModule.getModuleName()" resolve="getModuleName" />
+                    </node>
                   </node>
-                  <node concept="Xl_RD" id="4XPt_HaxCcQ" role="3uHU7w">
-                    <property role="Xl_RC" value=" module:" />
+                  <node concept="3cpWs3" id="4XPt_HaxCcN" role="3uHU7B">
+                    <node concept="3cpWs3" id="4XPt_HayC$o" role="3uHU7B">
+                      <node concept="Xl_RD" id="4XPt_HayC$r" role="3uHU7B">
+                        <property role="Xl_RC" value="model: " />
+                      </node>
+                      <node concept="2OqwBi" id="4XPt_HauJO2" role="3uHU7w">
+                        <node concept="2OqwBi" id="4XPt_HauJwl" role="2Oq$k0">
+                          <node concept="37vLTw" id="4XPt_Haxnn5" role="2Oq$k0">
+                            <ref role="3cqZAo" node="4XPt_HaxnmY" resolve="modelRef" />
+                          </node>
+                          <node concept="liA8E" id="4XPt_HauJE1" role="2OqNvi">
+                            <ref role="37wK5l" to="mhbf:~SModelReference.getName()" resolve="getName" />
+                          </node>
+                        </node>
+                        <node concept="liA8E" id="4XPt_HauJYN" role="2OqNvi">
+                          <ref role="37wK5l" to="mhbf:~SModelName.toString()" resolve="toString" />
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="Xl_RD" id="4XPt_HaxCcQ" role="3uHU7w">
+                      <property role="Xl_RC" value=" module:" />
+                    </node>
                   </node>
+                </node>
+                <node concept="3clFbT" id="4XPt_HaCtEG" role="1Lso8e">
+                  <property role="3clFbU" value="true" />
                 </node>
               </node>
             </node>
@@ -1984,28 +2028,33 @@
           </node>
           <node concept="3clFbS" id="4XPt_HauHOG" role="1zxBo7">
             <node concept="3cpWs6" id="4XPt_HauHOH" role="3cqZAp">
-              <node concept="3cpWs3" id="4XPt_HayD7j" role="3cqZAk">
-                <node concept="Xl_RD" id="4XPt_HayDbO" role="3uHU7B">
-                  <property role="Xl_RC" value="module: " />
-                </node>
-                <node concept="2OqwBi" id="4XPt_HauK8Z" role="3uHU7w">
-                  <node concept="2OqwBi" id="4XPt_HauHOI" role="2Oq$k0">
-                    <node concept="37vLTw" id="4XPt_HauIIh" role="2Oq$k0">
-                      <ref role="3cqZAo" node="4XPt_HauIIe" resolve="persistenceFacade" />
-                    </node>
-                    <node concept="liA8E" id="4XPt_HauHOK" role="2OqNvi">
-                      <ref role="37wK5l" to="dush:~PersistenceFacade.createModuleReference(java.lang.String)" resolve="createModuleReference" />
-                      <node concept="2OqwBi" id="4XPt_HauHOL" role="37wK5m">
-                        <node concept="13iPFW" id="4XPt_HauHOM" role="2Oq$k0" />
-                        <node concept="3TrcHB" id="4XPt_HauHON" role="2OqNvi">
-                          <ref role="3TsBF5" to="a1af:2I_DQhwrOw" resolve="resultLocation" />
+              <node concept="1Ls8ON" id="4XPt_HaCtVC" role="3cqZAk">
+                <node concept="3cpWs3" id="4XPt_HayD7j" role="1Lso8e">
+                  <node concept="Xl_RD" id="4XPt_HayDbO" role="3uHU7B">
+                    <property role="Xl_RC" value="module: " />
+                  </node>
+                  <node concept="2OqwBi" id="4XPt_HauK8Z" role="3uHU7w">
+                    <node concept="2OqwBi" id="4XPt_HauHOI" role="2Oq$k0">
+                      <node concept="37vLTw" id="4XPt_HauIIh" role="2Oq$k0">
+                        <ref role="3cqZAo" node="4XPt_HauIIe" resolve="persistenceFacade" />
+                      </node>
+                      <node concept="liA8E" id="4XPt_HauHOK" role="2OqNvi">
+                        <ref role="37wK5l" to="dush:~PersistenceFacade.createModuleReference(java.lang.String)" resolve="createModuleReference" />
+                        <node concept="2OqwBi" id="4XPt_HauHOL" role="37wK5m">
+                          <node concept="13iPFW" id="4XPt_HauHOM" role="2Oq$k0" />
+                          <node concept="3TrcHB" id="4XPt_HauHON" role="2OqNvi">
+                            <ref role="3TsBF5" to="a1af:2I_DQhwrOw" resolve="resultLocation" />
+                          </node>
                         </node>
                       </node>
                     </node>
+                    <node concept="liA8E" id="4XPt_HauKj1" role="2OqNvi">
+                      <ref role="37wK5l" to="lui2:~SModuleReference.getModuleName()" resolve="getModuleName" />
+                    </node>
                   </node>
-                  <node concept="liA8E" id="4XPt_HauKj1" role="2OqNvi">
-                    <ref role="37wK5l" to="lui2:~SModuleReference.getModuleName()" resolve="getModuleName" />
-                  </node>
+                </node>
+                <node concept="3clFbT" id="4XPt_HaCuZf" role="1Lso8e">
+                  <property role="3clFbU" value="true" />
                 </node>
               </node>
             </node>
@@ -2013,11 +2062,14 @@
         </node>
         <node concept="3clFbH" id="4XPt_HauI1d" role="3cqZAp" />
         <node concept="3cpWs6" id="4XPt_HauIlq" role="3cqZAp">
-          <node concept="2OqwBi" id="4XPt_HauIyE" role="3cqZAk">
-            <node concept="13iPFW" id="4XPt_HauInp" role="2Oq$k0" />
-            <node concept="3TrcHB" id="4XPt_HauIGq" role="2OqNvi">
-              <ref role="3TsBF5" to="a1af:2I_DQhwrOw" resolve="resultLocation" />
+          <node concept="1Ls8ON" id="4XPt_HaCvhk" role="3cqZAk">
+            <node concept="2OqwBi" id="4XPt_HauIyE" role="1Lso8e">
+              <node concept="13iPFW" id="4XPt_HauInp" role="2Oq$k0" />
+              <node concept="3TrcHB" id="4XPt_HauIGq" role="2OqNvi">
+                <ref role="3TsBF5" to="a1af:2I_DQhwrOw" resolve="resultLocation" />
+              </node>
             </node>
+            <node concept="3clFbT" id="4XPt_HaCvD3" role="1Lso8e" />
           </node>
         </node>
       </node>
@@ -2026,6 +2078,10 @@
         <node concept="3uibUv" id="4XPt_HaxCn9" role="1tU5fm">
           <ref role="3uigEE" to="lui2:~SRepository" resolve="SRepository" />
         </node>
+      </node>
+      <node concept="1LlUBW" id="4XPt_HaCsnk" role="3clF45">
+        <node concept="17QB3L" id="4XPt_HaCsJL" role="1Lm7xW" />
+        <node concept="10P_77" id="4XPt_HaCsUt" role="1Lm7xW" />
       </node>
     </node>
     <node concept="13hLZK" id="4Wm$DJ9cjhM" role="13h7CW">

--- a/code/languages/org.mpsqa.lint/languages/org.mpsqa.lint.generic/models/org.mpsqa.lint.generic.behavior.mps
+++ b/code/languages/org.mpsqa.lint/languages/org.mpsqa.lint.generic/models/org.mpsqa.lint.generic.behavior.mps
@@ -833,29 +833,31 @@
                     </node>
                     <node concept="2pJxcG" id="2I_DQhwFnn" role="2pJxcM">
                       <ref role="2pJxcJ" to="a1af:2I_DQhwrOw" resolve="resultLocation" />
-                      <node concept="3K4zz7" id="2I_DQhAlv6" role="28ntcv">
-                        <node concept="2OqwBi" id="2I_DQhAJB$" role="3K4E3e">
-                          <node concept="2OqwBi" id="2I_DQhAzue" role="2Oq$k0">
-                            <node concept="2GrUjf" id="2I_DQhAry5" role="2Oq$k0">
-                              <ref role="2Gs0qQ" node="6gY6GEDwgRS" resolve="r" />
+                      <node concept="WxPPo" id="2czVPH2a5Cu" role="28ntcv">
+                        <node concept="3K4zz7" id="2I_DQhAlv6" role="WxPPp">
+                          <node concept="2OqwBi" id="2I_DQhAJB$" role="3K4E3e">
+                            <node concept="2OqwBi" id="2I_DQhAzue" role="2Oq$k0">
+                              <node concept="2GrUjf" id="2I_DQhAry5" role="2Oq$k0">
+                                <ref role="2Gs0qQ" node="6gY6GEDwgRS" resolve="r" />
+                              </node>
+                              <node concept="2sxana" id="2I_DQhADyx" role="2OqNvi">
+                                <ref role="2sxfKC" to="qqy:3ghOW5H_ihW" resolve="location" />
+                              </node>
                             </node>
-                            <node concept="2sxana" id="2I_DQhADyx" role="2OqNvi">
-                              <ref role="2sxfKC" to="qqy:3ghOW5H_ihW" resolve="location" />
+                            <node concept="liA8E" id="2I_DQhANOC" role="2OqNvi">
+                              <ref role="37wK5l" to="wyt6:~Object.toString()" resolve="toString" />
                             </node>
                           </node>
-                          <node concept="liA8E" id="2I_DQhANOC" role="2OqNvi">
-                            <ref role="37wK5l" to="wyt6:~Object.toString()" resolve="toString" />
-                          </node>
-                        </node>
-                        <node concept="10Nm6u" id="2I_DQhAT24" role="3K4GZi" />
-                        <node concept="3y3z36" id="2I_DQhA8DW" role="3K4Cdx">
-                          <node concept="10Nm6u" id="2I_DQhAdkH" role="3uHU7w" />
-                          <node concept="2OqwBi" id="2I_DQhwRI_" role="3uHU7B">
-                            <node concept="2GrUjf" id="2I_DQhwKmO" role="2Oq$k0">
-                              <ref role="2Gs0qQ" node="6gY6GEDwgRS" resolve="r" />
-                            </node>
-                            <node concept="2sxana" id="2I_DQhwVEl" role="2OqNvi">
-                              <ref role="2sxfKC" to="qqy:3ghOW5H_ihW" resolve="location" />
+                          <node concept="10Nm6u" id="2I_DQhAT24" role="3K4GZi" />
+                          <node concept="3y3z36" id="2I_DQhA8DW" role="3K4Cdx">
+                            <node concept="10Nm6u" id="2I_DQhAdkH" role="3uHU7w" />
+                            <node concept="2OqwBi" id="2I_DQhwRI_" role="3uHU7B">
+                              <node concept="2GrUjf" id="2I_DQhwKmO" role="2Oq$k0">
+                                <ref role="2Gs0qQ" node="6gY6GEDwgRS" resolve="r" />
+                              </node>
+                              <node concept="2sxana" id="2I_DQhwVEl" role="2OqNvi">
+                                <ref role="2sxfKC" to="qqy:3ghOW5H_ihW" resolve="location" />
+                              </node>
                             </node>
                           </node>
                         </node>
@@ -2296,7 +2298,7 @@
                   </node>
                 </node>
                 <node concept="37vLTw" id="4XPt_HaEOgY" role="37vLTJ">
-                  <ref role="3cqZAo" node="4XPt_HaEMyv" resolve="file" />
+                  <ref role="3cqZAo" node="4XPt_HaEMyv" resolve="localFile" />
                 </node>
               </node>
             </node>

--- a/code/languages/org.mpsqa.lint/languages/org.mpsqa.lint.generic/models/org.mpsqa.lint.generic.behavior.mps
+++ b/code/languages/org.mpsqa.lint/languages/org.mpsqa.lint.generic/models/org.mpsqa.lint.generic.behavior.mps
@@ -2479,27 +2479,6 @@
       <node concept="3clFbS" id="106MO2l56WJ" role="3clF47">
         <node concept="3clFbF" id="106MO2l59$6" role="3cqZAp">
           <node concept="1Wc70l" id="106MO2l5hf1" role="3clFbG">
-            <node concept="17R0WA" id="106MO2l5m9l" role="3uHU7w">
-              <node concept="2OqwBi" id="106MO2l5nJK" role="3uHU7w">
-                <node concept="2OqwBi" id="106MO2l5n4F" role="2Oq$k0">
-                  <node concept="37vLTw" id="106MO2l5mgN" role="2Oq$k0">
-                    <ref role="3cqZAo" node="106MO2l57jJ" resolve="result" />
-                  </node>
-                  <node concept="2sxana" id="106MO2l5nC8" role="2OqNvi">
-                    <ref role="2sxfKC" to="qqy:3ghOW5H_ihW" resolve="location" />
-                  </node>
-                </node>
-                <node concept="liA8E" id="106MO2l5nP_" role="2OqNvi">
-                  <ref role="37wK5l" to="wyt6:~Object.toString()" resolve="toString" />
-                </node>
-              </node>
-              <node concept="2OqwBi" id="106MO2l5lAt" role="3uHU7B">
-                <node concept="13iPFW" id="106MO2l5l$w" role="2Oq$k0" />
-                <node concept="3TrcHB" id="106MO2l5lE1" role="2OqNvi">
-                  <ref role="3TsBF5" to="a1af:2I_DQhwrOw" resolve="resultLocation" />
-                </node>
-              </node>
-            </node>
             <node concept="1Wc70l" id="106MO2l5cSW" role="3uHU7B">
               <node concept="17R0WA" id="106MO2l5bok" role="3uHU7B">
                 <node concept="2OqwBi" id="106MO2l59JH" role="3uHU7B">
@@ -2542,6 +2521,43 @@
                   </node>
                   <node concept="liA8E" id="106MO2l5gSP" role="2OqNvi">
                     <ref role="37wK5l" to="wyt6:~Object.toString()" resolve="toString" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="17R0WA" id="106MO2l5m9l" role="3uHU7w">
+              <node concept="2OqwBi" id="106MO2l5lAt" role="3uHU7B">
+                <node concept="13iPFW" id="106MO2l5l$w" role="2Oq$k0" />
+                <node concept="3TrcHB" id="106MO2l5lE1" role="2OqNvi">
+                  <ref role="3TsBF5" to="a1af:2I_DQhwrOw" resolve="resultLocation" />
+                </node>
+              </node>
+              <node concept="1eOMI4" id="1xUl7871GBE" role="3uHU7w">
+                <node concept="3K4zz7" id="1xUl7871E0X" role="1eOMHV">
+                  <node concept="2OqwBi" id="106MO2l5nJK" role="3K4E3e">
+                    <node concept="2OqwBi" id="106MO2l5n4F" role="2Oq$k0">
+                      <node concept="37vLTw" id="106MO2l5mgN" role="2Oq$k0">
+                        <ref role="3cqZAo" node="106MO2l57jJ" resolve="result" />
+                      </node>
+                      <node concept="2sxana" id="106MO2l5nC8" role="2OqNvi">
+                        <ref role="2sxfKC" to="qqy:3ghOW5H_ihW" resolve="location" />
+                      </node>
+                    </node>
+                    <node concept="liA8E" id="106MO2l5nP_" role="2OqNvi">
+                      <ref role="37wK5l" to="wyt6:~Object.toString()" resolve="toString" />
+                    </node>
+                  </node>
+                  <node concept="10Nm6u" id="1xUl7871Gcx" role="3K4GZi" />
+                  <node concept="3y3z36" id="1xUl7871FZR" role="3K4Cdx">
+                    <node concept="10Nm6u" id="1xUl7871G3K" role="3uHU7w" />
+                    <node concept="2OqwBi" id="1xUl7871FgX" role="3uHU7B">
+                      <node concept="37vLTw" id="1xUl7871EmW" role="2Oq$k0">
+                        <ref role="3cqZAo" node="106MO2l57jJ" resolve="result" />
+                      </node>
+                      <node concept="2sxana" id="1xUl7871FOs" role="2OqNvi">
+                        <ref role="2sxfKC" to="qqy:3ghOW5H_ihW" resolve="location" />
+                      </node>
+                    </node>
                   </node>
                 </node>
               </node>

--- a/code/languages/org.mpsqa.lint/languages/org.mpsqa.lint.generic/models/org.mpsqa.lint.generic.editor.mps
+++ b/code/languages/org.mpsqa.lint/languages/org.mpsqa.lint.generic/models/org.mpsqa.lint.generic.editor.mps
@@ -192,9 +192,6 @@
       </concept>
       <concept id="4836112446988635817" name="jetbrains.mps.baseLanguage.structure.UndefinedType" flags="in" index="2jxLKc" />
       <concept id="1202948039474" name="jetbrains.mps.baseLanguage.structure.InstanceMethodCallOperation" flags="nn" index="liA8E" />
-      <concept id="8118189177080264853" name="jetbrains.mps.baseLanguage.structure.AlternativeType" flags="ig" index="nSUau">
-        <child id="8118189177080264854" name="alternative" index="nSUat" />
-      </concept>
       <concept id="1465982738277781862" name="jetbrains.mps.baseLanguage.structure.PlaceholderMember" flags="nn" index="2tJIrI" />
       <concept id="1188207840427" name="jetbrains.mps.baseLanguage.structure.AnnotationInstance" flags="nn" index="2AHcQZ">
         <reference id="1188208074048" name="annotation" index="2AI5Lk" />
@@ -216,7 +213,6 @@
       <concept id="1070475926800" name="jetbrains.mps.baseLanguage.structure.StringLiteral" flags="nn" index="Xl_RD">
         <property id="1070475926801" name="value" index="Xl_RC" />
       </concept>
-      <concept id="4952749571008284462" name="jetbrains.mps.baseLanguage.structure.CatchVariable" flags="ng" index="XOnhg" />
       <concept id="1182160077978" name="jetbrains.mps.baseLanguage.structure.AnonymousClassCreator" flags="nn" index="YeOm9">
         <child id="1182160096073" name="cls" index="YeSDq" />
       </concept>
@@ -302,17 +298,9 @@
         <child id="1081773367579" name="rightExpression" index="3uHU7w" />
         <child id="1081773367580" name="leftExpression" index="3uHU7B" />
       </concept>
-      <concept id="3093926081414150598" name="jetbrains.mps.baseLanguage.structure.MultipleCatchClause" flags="ng" index="3uVAMA">
-        <child id="8276990574895933173" name="catchBody" index="1zc67A" />
-        <child id="8276990574895933172" name="throwable" index="1zc67B" />
-      </concept>
       <concept id="1073239437375" name="jetbrains.mps.baseLanguage.structure.NotEqualsExpression" flags="nn" index="3y3z36" />
       <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ng" index="1B3ioH">
         <child id="1178549979242" name="visibility" index="1B3o_S" />
-      </concept>
-      <concept id="5351203823916750322" name="jetbrains.mps.baseLanguage.structure.TryUniversalStatement" flags="nn" index="3J1_TO">
-        <child id="8276990574886367510" name="catchClause" index="1zxBo5" />
-        <child id="8276990574886367508" name="body" index="1zxBo7" />
       </concept>
       <concept id="1163668896201" name="jetbrains.mps.baseLanguage.structure.TernaryOperatorExpression" flags="nn" index="3K4zz7">
         <child id="1163668914799" name="condition" index="3K4Cdx" />
@@ -339,12 +327,6 @@
     <language id="fd392034-7849-419d-9071-12563d152375" name="jetbrains.mps.baseLanguage.closures">
       <concept id="1199569711397" name="jetbrains.mps.baseLanguage.closures.structure.ClosureLiteral" flags="nn" index="1bVj0M">
         <child id="1199569916463" name="body" index="1bW5cS" />
-      </concept>
-    </language>
-    <language id="760a0a8c-eabb-4521-8bfd-65db761a9ba3" name="jetbrains.mps.baseLanguage.logging">
-      <concept id="2034914114981261497" name="jetbrains.mps.baseLanguage.logging.structure.LogLowLevelStatement" flags="ng" index="RRSsy">
-        <property id="2034914114981261751" name="severity" index="RRSoG" />
-        <child id="2034914114981261753" name="message" index="RRSoy" />
       </concept>
     </language>
     <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
@@ -1831,94 +1813,15 @@
       <property role="1hAc7j" value="1FSxSwWqMNJ/click_action_id" />
       <node concept="1hAIg9" id="4XPt_HaCr2b" role="1hA7z_">
         <node concept="3clFbS" id="4XPt_HaCr2c" role="2VODD2">
-          <node concept="3J1_TO" id="4XPt_HaCr2T" role="3cqZAp">
-            <node concept="3uVAMA" id="4XPt_HaCr3c" role="1zxBo5">
-              <node concept="XOnhg" id="4XPt_HaCr3d" role="1zc67B">
-                <property role="TrG5h" value="io" />
-                <node concept="nSUau" id="4XPt_HaCr3e" role="1tU5fm">
-                  <node concept="3uibUv" id="4XPt_HaCr3M" role="nSUat">
-                    <ref role="3uigEE" to="guwi:~IOException" resolve="IOException" />
-                  </node>
-                </node>
-              </node>
-              <node concept="3clFbS" id="4XPt_HaCr3f" role="1zc67A">
-                <node concept="RRSsy" id="4XPt_HaCr5H" role="3cqZAp">
-                  <property role="RRSoG" value="gZ5fh_4/error" />
-                  <node concept="3cpWs3" id="4XPt_HaCruz" role="RRSoy">
-                    <node concept="2OqwBi" id="4XPt_HaCFZ2" role="3uHU7w">
-                      <node concept="0IXxy" id="4XPt_HaCFLf" role="2Oq$k0" />
-                      <node concept="3TrcHB" id="4XPt_HaCG9X" role="2OqNvi">
-                        <ref role="3TsBF5" to="a1af:2I_DQhwrOw" resolve="resultLocation" />
-                      </node>
-                    </node>
-                    <node concept="Xl_RD" id="4XPt_HaCr5J" role="3uHU7B">
-                      <property role="Xl_RC" value="Couldn't open " />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3clFbS" id="4XPt_HaCr2U" role="1zxBo7">
-              <node concept="3cpWs8" id="4XPt_HaDmUN" role="3cqZAp">
-                <node concept="3cpWsn" id="4XPt_HaDmUO" role="3cpWs9">
-                  <property role="TrG5h" value="file" />
-                  <node concept="3uibUv" id="4XPt_HaDlNx" role="1tU5fm">
-                    <ref role="3uigEE" to="guwi:~File" resolve="File" />
-                  </node>
-                  <node concept="2ShNRf" id="4XPt_HaDmUP" role="33vP2m">
-                    <node concept="1pGfFk" id="4XPt_HaDmUQ" role="2ShVmc">
-                      <property role="373rjd" value="true" />
-                      <ref role="37wK5l" to="guwi:~File.&lt;init&gt;(java.lang.String)" resolve="File" />
-                      <node concept="2OqwBi" id="4XPt_HaDmUR" role="37wK5m">
-                        <node concept="0IXxy" id="4XPt_HaDmUS" role="2Oq$k0" />
-                        <node concept="3TrcHB" id="4XPt_HaDmUT" role="2OqNvi">
-                          <ref role="3TsBF5" to="a1af:2I_DQhwrOw" resolve="resultLocation" />
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                </node>
-              </node>
-              <node concept="3clFbJ" id="4XPt_HaDn5x" role="3cqZAp">
-                <node concept="3clFbS" id="4XPt_HaDn5z" role="3clFbx">
-                  <node concept="3clFbF" id="4XPt_HaDnKW" role="3cqZAp">
-                    <node concept="37vLTI" id="4XPt_HaDo4s" role="3clFbG">
-                      <node concept="2OqwBi" id="4XPt_HaDo59" role="37vLTx">
-                        <node concept="37vLTw" id="4XPt_HaDo4I" role="2Oq$k0">
-                          <ref role="3cqZAo" node="4XPt_HaDmUO" resolve="file" />
-                        </node>
-                        <node concept="liA8E" id="4XPt_HaDoql" role="2OqNvi">
-                          <ref role="37wK5l" to="guwi:~File.getParentFile()" resolve="getParentFile" />
-                        </node>
-                      </node>
-                      <node concept="37vLTw" id="4XPt_HaDnKU" role="37vLTJ">
-                        <ref role="3cqZAo" node="4XPt_HaDmUO" resolve="file" />
-                      </node>
-                    </node>
-                  </node>
-                </node>
-                <node concept="3fqX7Q" id="4XPt_HaDnJa" role="3clFbw">
-                  <node concept="2OqwBi" id="4XPt_HaDnJc" role="3fr31v">
-                    <node concept="37vLTw" id="4XPt_HaDnJd" role="2Oq$k0">
-                      <ref role="3cqZAo" node="4XPt_HaDmUO" resolve="file" />
-                    </node>
-                    <node concept="liA8E" id="4XPt_HaDnJe" role="2OqNvi">
-                      <ref role="37wK5l" to="guwi:~File.isDirectory()" resolve="isDirectory" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-              <node concept="3clFbF" id="4XPt_HaCGgF" role="3cqZAp">
-                <node concept="2OqwBi" id="4XPt_HaCGoE" role="3clFbG">
-                  <node concept="2YIFZM" id="4XPt_HaCGhd" role="2Oq$k0">
-                    <ref role="37wK5l" to="z60i:~Desktop.getDesktop()" resolve="getDesktop" />
-                    <ref role="1Pybhc" to="z60i:~Desktop" resolve="Desktop" />
-                  </node>
-                  <node concept="liA8E" id="4XPt_HaCGwI" role="2OqNvi">
-                    <ref role="37wK5l" to="z60i:~Desktop.open(java.io.File)" resolve="open" />
-                    <node concept="37vLTw" id="4XPt_HaDmUU" role="37wK5m">
-                      <ref role="3cqZAo" node="4XPt_HaDmUO" resolve="file" />
-                    </node>
+          <node concept="3clFbF" id="4XPt_HaEBgK" role="3cqZAp">
+            <node concept="2OqwBi" id="4XPt_HaEBqw" role="3clFbG">
+              <node concept="0IXxy" id="4XPt_HaEBgJ" role="2Oq$k0" />
+              <node concept="2qgKlT" id="4XPt_HaEB_o" role="2OqNvi">
+                <ref role="37wK5l" to="b659:4XPt_HaE_RC" resolve="openLocation" />
+                <node concept="2OqwBi" id="4XPt_HaEBHf" role="37wK5m">
+                  <node concept="1Q80Hx" id="4XPt_HaEB_S" role="2Oq$k0" />
+                  <node concept="liA8E" id="4XPt_HaEBP1" role="2OqNvi">
+                    <ref role="37wK5l" to="cj4x:~EditorContext.getRepository()" resolve="getRepository" />
                   </node>
                 </node>
               </node>
@@ -1929,33 +1832,12 @@
       <node concept="jK8Ss" id="4XPt_HaCxr4" role="jK8aL">
         <node concept="3clFbS" id="4XPt_HaCxr5" role="2VODD2">
           <node concept="3clFbF" id="4XPt_HaCrxs" role="3cqZAp">
-            <node concept="1Wc70l" id="4XPt_HaDWtU" role="3clFbG">
-              <node concept="3y3z36" id="4XPt_HaDX_6" role="3uHU7B">
-                <node concept="10Nm6u" id="4XPt_HaDX_b" role="3uHU7w" />
-                <node concept="2OqwBi" id="4XPt_HaDWRX" role="3uHU7B">
-                  <node concept="0IXxy" id="4XPt_HaDWCj" role="2Oq$k0" />
-                  <node concept="3TrcHB" id="4XPt_HaDX4O" role="2OqNvi">
-                    <ref role="3TsBF5" to="a1af:2I_DQhwrOw" resolve="resultLocation" />
-                  </node>
-                </node>
-              </node>
-              <node concept="3fqX7Q" id="4XPt_HaCF_O" role="3uHU7w">
-                <node concept="1LFfDK" id="4XPt_HaCF_Q" role="3fr31v">
-                  <node concept="3cmrfG" id="4XPt_HaCF_R" role="1LF_Uc">
-                    <property role="3cmrfH" value="1" />
-                  </node>
-                  <node concept="2OqwBi" id="4XPt_HaCF_S" role="1LFl5Q">
-                    <node concept="0IXxy" id="4XPt_HaCF_T" role="2Oq$k0" />
-                    <node concept="2qgKlT" id="4XPt_HaCF_U" role="2OqNvi">
-                      <ref role="37wK5l" to="b659:4XPt_HauH1N" resolve="formatLocation" />
-                      <node concept="2OqwBi" id="4XPt_HaCF_V" role="37wK5m">
-                        <node concept="1Q80Hx" id="4XPt_HaCF_W" role="2Oq$k0" />
-                        <node concept="liA8E" id="4XPt_HaCF_X" role="2OqNvi">
-                          <ref role="37wK5l" to="cj4x:~EditorContext.getRepository()" resolve="getRepository" />
-                        </node>
-                      </node>
-                    </node>
-                  </node>
+            <node concept="3y3z36" id="4XPt_HaDX_6" role="3clFbG">
+              <node concept="10Nm6u" id="4XPt_HaDX_b" role="3uHU7w" />
+              <node concept="2OqwBi" id="4XPt_HaDWRX" role="3uHU7B">
+                <node concept="0IXxy" id="4XPt_HaDWCj" role="2Oq$k0" />
+                <node concept="3TrcHB" id="4XPt_HaDX4O" role="2OqNvi">
+                  <ref role="3TsBF5" to="a1af:2I_DQhwrOw" resolve="resultLocation" />
                 </node>
               </node>
             </node>

--- a/code/languages/org.mpsqa.lint/languages/org.mpsqa.lint.generic/models/org.mpsqa.lint.generic.editor.mps
+++ b/code/languages/org.mpsqa.lint/languages/org.mpsqa.lint.generic/models/org.mpsqa.lint.generic.editor.mps
@@ -1192,8 +1192,8 @@
                           </node>
                         </node>
                       </node>
-                      <node concept="liA8E" id="4XPt_Hap_$A" role="2OqNvi">
-                        <ref role="37wK5l" to="mhbf:~SNode.getName()" resolve="getName" />
+                      <node concept="liA8E" id="4XPt_HaQvt0" role="2OqNvi">
+                        <ref role="37wK5l" to="mhbf:~SNode.getPresentation()" resolve="getPresentation" />
                       </node>
                     </node>
                   </node>

--- a/code/languages/org.mpsqa.lint/languages/org.mpsqa.lint.generic/models/org.mpsqa.lint.generic.editor.mps
+++ b/code/languages/org.mpsqa.lint/languages/org.mpsqa.lint.generic/models/org.mpsqa.lint.generic.editor.mps
@@ -330,6 +330,7 @@
       </concept>
     </language>
     <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
+      <concept id="1179168000618" name="jetbrains.mps.lang.smodel.structure.Node_GetIndexInParentOperation" flags="nn" index="2bSWHS" />
       <concept id="1179409122411" name="jetbrains.mps.lang.smodel.structure.Node_ConceptMethodCall" flags="nn" index="2qgKlT" />
       <concept id="1138757581985" name="jetbrains.mps.lang.smodel.structure.Link_SetNewChildOperation" flags="nn" index="zfrQC" />
       <concept id="1143224066846" name="jetbrains.mps.lang.smodel.structure.Node_InsertNextSiblingOperation" flags="nn" index="HtI8k">
@@ -1090,110 +1091,144 @@
     <property role="3GE5qa" value="previous_results" />
     <ref role="1XX52x" to="a1af:6gY6GEDvQYS" resolve="ResultEntry" />
     <node concept="3EZMnI" id="2I_DQhHcYH" role="2wV5jI">
-      <node concept="1QoScp" id="4XPt_Hatexq" role="3EZMnx">
-        <property role="1QpmdY" value="true" />
-        <node concept="pkWqt" id="4XPt_Hatext" role="3e4ffs">
-          <node concept="3clFbS" id="4XPt_Hatexv" role="2VODD2">
-            <node concept="3clFbF" id="4XPt_Hatf3y" role="3cqZAp">
-              <node concept="2OqwBi" id="2I_DQhGtI9" role="3clFbG">
-                <node concept="2OqwBi" id="2I_DQhGtfn" role="2Oq$k0">
-                  <node concept="pncrf" id="2I_DQhGtfo" role="2Oq$k0" />
-                  <node concept="2qgKlT" id="2I_DQhGtfp" role="2OqNvi">
-                    <ref role="37wK5l" to="b659:2I_DQhGejd" resolve="getNode" />
-                    <node concept="2OqwBi" id="2I_DQhGtfq" role="37wK5m">
-                      <node concept="1Q80Hx" id="2I_DQhGtfr" role="2Oq$k0" />
-                      <node concept="liA8E" id="2I_DQhGtfs" role="2OqNvi">
-                        <ref role="37wK5l" to="cj4x:~EditorContext.getRepository()" resolve="getRepository" />
+      <node concept="3EZMnI" id="3V$n2gBAOzJ" role="3EZMnx">
+        <node concept="2iRfu4" id="3V$n2gBAOzK" role="2iSdaV" />
+        <node concept="1HlG4h" id="3V$n2gBAONt" role="3EZMnx">
+          <node concept="1HfYo3" id="3V$n2gBAONv" role="1HlULh">
+            <node concept="3TQlhw" id="3V$n2gBAONx" role="1Hhtcw">
+              <node concept="3clFbS" id="3V$n2gBAONz" role="2VODD2">
+                <node concept="3clFbF" id="3V$n2gBAOUH" role="3cqZAp">
+                  <node concept="2YIFZM" id="3V$n2gBAOWB" role="3clFbG">
+                    <ref role="37wK5l" to="wyt6:~String.format(java.lang.String,java.lang.Object...)" resolve="format" />
+                    <ref role="1Pybhc" to="wyt6:~String" resolve="String" />
+                    <node concept="Xl_RD" id="3V$n2gBAOWD" role="37wK5m">
+                      <property role="Xl_RC" value="%04d" />
+                    </node>
+                    <node concept="1eOMI4" id="3V$n2gBAPjH" role="37wK5m">
+                      <node concept="3cpWs3" id="3V$n2gBARib" role="1eOMHV">
+                        <node concept="3cmrfG" id="3V$n2gBARif" role="3uHU7w">
+                          <property role="3cmrfH" value="1" />
+                        </node>
+                        <node concept="2OqwBi" id="3V$n2gBAPIb" role="3uHU7B">
+                          <node concept="pncrf" id="3V$n2gBAPqK" role="2Oq$k0" />
+                          <node concept="2bSWHS" id="3V$n2gBAQ6L" role="2OqNvi" />
+                        </node>
                       </node>
                     </node>
                   </node>
                 </node>
-                <node concept="3x8VRR" id="2I_DQhGu96" role="2OqNvi" />
               </node>
             </node>
           </node>
-        </node>
-        <node concept="3F0ifn" id="4XPt_Hatf70" role="1QoVPY">
-          <property role="3F0ifm" value="unknown location" />
-        </node>
-        <node concept="3EZMnI" id="4WO8F5MTflp" role="1QoS34">
-          <node concept="2iRfu4" id="4WO8F5MTflq" role="2iSdaV" />
-          <node concept="3F0ifn" id="2I_DQhHf0o" role="3EZMnx">
-            <property role="3F0ifm" value="model" />
+          <node concept="VechU" id="3V$n2gBB9K$" role="3F10Kt">
+            <property role="Vb096" value="fLwANPu/blue" />
           </node>
-          <node concept="1HlG4h" id="2I_DQhHf7x" role="3EZMnx">
-            <node concept="1HfYo3" id="2I_DQhHf7y" role="1HlULh">
-              <node concept="3TQlhw" id="2I_DQhHf7z" role="1Hhtcw">
-                <node concept="3clFbS" id="2I_DQhHf7$" role="2VODD2">
-                  <node concept="3clFbF" id="2I_DQhHf7_" role="3cqZAp">
-                    <node concept="2OqwBi" id="2I_DQhHf7A" role="3clFbG">
-                      <node concept="2OqwBi" id="2I_DQhHf7B" role="2Oq$k0">
-                        <node concept="2OqwBi" id="2I_DQhHf7C" role="2Oq$k0">
-                          <node concept="pncrf" id="2I_DQhHf7D" role="2Oq$k0" />
-                          <node concept="2qgKlT" id="2I_DQhHf7E" role="2OqNvi">
-                            <ref role="37wK5l" to="b659:2I_DQhGejd" resolve="getNode" />
-                            <node concept="2OqwBi" id="2I_DQhHf7F" role="37wK5m">
-                              <node concept="1Q80Hx" id="2I_DQhHf7G" role="2Oq$k0" />
-                              <node concept="liA8E" id="2I_DQhHf7H" role="2OqNvi">
-                                <ref role="37wK5l" to="cj4x:~EditorContext.getRepository()" resolve="getRepository" />
+        </node>
+        <node concept="1QoScp" id="4XPt_Hatexq" role="3EZMnx">
+          <property role="1QpmdY" value="true" />
+          <node concept="pkWqt" id="4XPt_Hatext" role="3e4ffs">
+            <node concept="3clFbS" id="4XPt_Hatexv" role="2VODD2">
+              <node concept="3clFbF" id="4XPt_Hatf3y" role="3cqZAp">
+                <node concept="2OqwBi" id="2I_DQhGtI9" role="3clFbG">
+                  <node concept="2OqwBi" id="2I_DQhGtfn" role="2Oq$k0">
+                    <node concept="pncrf" id="2I_DQhGtfo" role="2Oq$k0" />
+                    <node concept="2qgKlT" id="2I_DQhGtfp" role="2OqNvi">
+                      <ref role="37wK5l" to="b659:2I_DQhGejd" resolve="getNode" />
+                      <node concept="2OqwBi" id="2I_DQhGtfq" role="37wK5m">
+                        <node concept="1Q80Hx" id="2I_DQhGtfr" role="2Oq$k0" />
+                        <node concept="liA8E" id="2I_DQhGtfs" role="2OqNvi">
+                          <ref role="37wK5l" to="cj4x:~EditorContext.getRepository()" resolve="getRepository" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3x8VRR" id="2I_DQhGu96" role="2OqNvi" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3F0ifn" id="4XPt_Hatf70" role="1QoVPY">
+            <property role="3F0ifm" value="unknown location" />
+          </node>
+          <node concept="3EZMnI" id="4WO8F5MTflp" role="1QoS34">
+            <node concept="2iRfu4" id="4WO8F5MTflq" role="2iSdaV" />
+            <node concept="3F0ifn" id="2I_DQhHf0o" role="3EZMnx">
+              <property role="3F0ifm" value="model" />
+            </node>
+            <node concept="1HlG4h" id="2I_DQhHf7x" role="3EZMnx">
+              <node concept="1HfYo3" id="2I_DQhHf7y" role="1HlULh">
+                <node concept="3TQlhw" id="2I_DQhHf7z" role="1Hhtcw">
+                  <node concept="3clFbS" id="2I_DQhHf7$" role="2VODD2">
+                    <node concept="3clFbF" id="2I_DQhHf7_" role="3cqZAp">
+                      <node concept="2OqwBi" id="2I_DQhHf7A" role="3clFbG">
+                        <node concept="2OqwBi" id="2I_DQhHf7B" role="2Oq$k0">
+                          <node concept="2OqwBi" id="2I_DQhHf7C" role="2Oq$k0">
+                            <node concept="pncrf" id="2I_DQhHf7D" role="2Oq$k0" />
+                            <node concept="2qgKlT" id="2I_DQhHf7E" role="2OqNvi">
+                              <ref role="37wK5l" to="b659:2I_DQhGejd" resolve="getNode" />
+                              <node concept="2OqwBi" id="2I_DQhHf7F" role="37wK5m">
+                                <node concept="1Q80Hx" id="2I_DQhHf7G" role="2Oq$k0" />
+                                <node concept="liA8E" id="2I_DQhHf7H" role="2OqNvi">
+                                  <ref role="37wK5l" to="cj4x:~EditorContext.getRepository()" resolve="getRepository" />
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                          <node concept="I4A8Y" id="2I_DQhHf7I" role="2OqNvi" />
+                        </node>
+                        <node concept="LkI2h" id="2I_DQhHf7J" role="2OqNvi" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3F0ifn" id="4XPt_Hap_xJ" role="3EZMnx">
+              <property role="3F0ifm" value="with node" />
+            </node>
+            <node concept="1HlG4h" id="4XPt_Hap_$p" role="3EZMnx">
+              <node concept="3k4GqR" id="4XPt_HaqMFn" role="3F10Kt">
+                <node concept="3k4GqP" id="4XPt_HaqMFo" role="3k4GqO">
+                  <node concept="3clFbS" id="4XPt_HaqMFp" role="2VODD2">
+                    <node concept="3clFbF" id="4XPt_HaqML8" role="3cqZAp">
+                      <node concept="2OqwBi" id="4XPt_HaqMWS" role="3clFbG">
+                        <node concept="pncrf" id="4XPt_HaqML7" role="2Oq$k0" />
+                        <node concept="2qgKlT" id="4XPt_HaqN7X" role="2OqNvi">
+                          <ref role="37wK5l" to="b659:2I_DQhGejd" resolve="getNode" />
+                          <node concept="2OqwBi" id="4XPt_HaqNHU" role="37wK5m">
+                            <node concept="1Q80Hx" id="4XPt_HaqN$r" role="2Oq$k0" />
+                            <node concept="liA8E" id="4XPt_HaqO3k" role="2OqNvi">
+                              <ref role="37wK5l" to="cj4x:~EditorContext.getRepository()" resolve="getRepository" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="1HfYo3" id="4XPt_Hap_$q" role="1HlULh">
+                <node concept="3TQlhw" id="4XPt_Hap_$r" role="1Hhtcw">
+                  <node concept="3clFbS" id="4XPt_Hap_$s" role="2VODD2">
+                    <node concept="3clFbF" id="4XPt_Hap_$t" role="3cqZAp">
+                      <node concept="2OqwBi" id="4XPt_Hap_$u" role="3clFbG">
+                        <node concept="2JrnkZ" id="4XPt_Hap_$v" role="2Oq$k0">
+                          <node concept="2OqwBi" id="4XPt_Hap_$w" role="2JrQYb">
+                            <node concept="pncrf" id="4XPt_Hap_$x" role="2Oq$k0" />
+                            <node concept="2qgKlT" id="4XPt_Hap_$y" role="2OqNvi">
+                              <ref role="37wK5l" to="b659:2I_DQhGejd" resolve="getNode" />
+                              <node concept="2OqwBi" id="4XPt_Hap_$z" role="37wK5m">
+                                <node concept="1Q80Hx" id="4XPt_Hap_$$" role="2Oq$k0" />
+                                <node concept="liA8E" id="4XPt_Hap_$_" role="2OqNvi">
+                                  <ref role="37wK5l" to="cj4x:~EditorContext.getRepository()" resolve="getRepository" />
+                                </node>
                               </node>
                             </node>
                           </node>
                         </node>
-                        <node concept="I4A8Y" id="2I_DQhHf7I" role="2OqNvi" />
-                      </node>
-                      <node concept="LkI2h" id="2I_DQhHf7J" role="2OqNvi" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-          <node concept="3F0ifn" id="4XPt_Hap_xJ" role="3EZMnx">
-            <property role="3F0ifm" value="with node" />
-          </node>
-          <node concept="1HlG4h" id="4XPt_Hap_$p" role="3EZMnx">
-            <node concept="3k4GqR" id="4XPt_HaqMFn" role="3F10Kt">
-              <node concept="3k4GqP" id="4XPt_HaqMFo" role="3k4GqO">
-                <node concept="3clFbS" id="4XPt_HaqMFp" role="2VODD2">
-                  <node concept="3clFbF" id="4XPt_HaqML8" role="3cqZAp">
-                    <node concept="2OqwBi" id="4XPt_HaqMWS" role="3clFbG">
-                      <node concept="pncrf" id="4XPt_HaqML7" role="2Oq$k0" />
-                      <node concept="2qgKlT" id="4XPt_HaqN7X" role="2OqNvi">
-                        <ref role="37wK5l" to="b659:2I_DQhGejd" resolve="getNode" />
-                        <node concept="2OqwBi" id="4XPt_HaqNHU" role="37wK5m">
-                          <node concept="1Q80Hx" id="4XPt_HaqN$r" role="2Oq$k0" />
-                          <node concept="liA8E" id="4XPt_HaqO3k" role="2OqNvi">
-                            <ref role="37wK5l" to="cj4x:~EditorContext.getRepository()" resolve="getRepository" />
-                          </node>
+                        <node concept="liA8E" id="4XPt_HaQvt0" role="2OqNvi">
+                          <ref role="37wK5l" to="mhbf:~SNode.getPresentation()" resolve="getPresentation" />
                         </node>
-                      </node>
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="1HfYo3" id="4XPt_Hap_$q" role="1HlULh">
-              <node concept="3TQlhw" id="4XPt_Hap_$r" role="1Hhtcw">
-                <node concept="3clFbS" id="4XPt_Hap_$s" role="2VODD2">
-                  <node concept="3clFbF" id="4XPt_Hap_$t" role="3cqZAp">
-                    <node concept="2OqwBi" id="4XPt_Hap_$u" role="3clFbG">
-                      <node concept="2JrnkZ" id="4XPt_Hap_$v" role="2Oq$k0">
-                        <node concept="2OqwBi" id="4XPt_Hap_$w" role="2JrQYb">
-                          <node concept="pncrf" id="4XPt_Hap_$x" role="2Oq$k0" />
-                          <node concept="2qgKlT" id="4XPt_Hap_$y" role="2OqNvi">
-                            <ref role="37wK5l" to="b659:2I_DQhGejd" resolve="getNode" />
-                            <node concept="2OqwBi" id="4XPt_Hap_$z" role="37wK5m">
-                              <node concept="1Q80Hx" id="4XPt_Hap_$$" role="2Oq$k0" />
-                              <node concept="liA8E" id="4XPt_Hap_$_" role="2OqNvi">
-                                <ref role="37wK5l" to="cj4x:~EditorContext.getRepository()" resolve="getRepository" />
-                              </node>
-                            </node>
-                          </node>
-                        </node>
-                      </node>
-                      <node concept="liA8E" id="4XPt_HaQvt0" role="2OqNvi">
-                        <ref role="37wK5l" to="mhbf:~SNode.getPresentation()" resolve="getPresentation" />
                       </node>
                     </node>
                   </node>
@@ -1205,6 +1240,7 @@
       </node>
       <node concept="3EZMnI" id="4XPt_HaubZN" role="3EZMnx">
         <node concept="2iRfu4" id="4XPt_HaubZO" role="2iSdaV" />
+        <node concept="3XFhqQ" id="3V$n2gBB9HK" role="3EZMnx" />
         <node concept="3F0ifn" id="4XPt_HaubSP" role="3EZMnx">
           <property role="3F0ifm" value="location" />
         </node>

--- a/code/languages/org.mpsqa.lint/languages/org.mpsqa.lint.generic/models/org.mpsqa.lint.generic.editor.mps
+++ b/code/languages/org.mpsqa.lint/languages/org.mpsqa.lint.generic/models/org.mpsqa.lint.generic.editor.mps
@@ -17,6 +17,8 @@
     <import index="a1af" ref="r:839ac015-7de1-49f3-ac8f-8d7c6d47259d(org.mpsqa.lint.generic.structure)" />
     <import index="qqy" ref="r:baac1a2f-1e52-45fa-95c5-02a3dfae441c(org.mpsqa.lint.generic.util)" />
     <import index="lzb2" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.ui(MPS.IDEA/)" />
+    <import index="guwi" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.io(JDK/)" />
+    <import index="z60i" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.awt(JDK/)" />
     <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" implicit="true" />
     <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" implicit="true" />
     <import index="mhbf" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.model(MPS.OpenAPI/)" implicit="true" />
@@ -25,8 +27,15 @@
     <import index="tpco" ref="r:00000000-0000-4000-0000-011c89590284(jetbrains.mps.lang.core.editor)" implicit="true" />
   </imports>
   <registry>
+    <language id="a247e09e-2435-45ba-b8d2-07e93feba96a" name="jetbrains.mps.baseLanguage.tuples">
+      <concept id="1238857743184" name="jetbrains.mps.baseLanguage.tuples.structure.IndexedTupleMemberAccessExpression" flags="nn" index="1LFfDK">
+        <child id="1238857764950" name="tuple" index="1LFl5Q" />
+        <child id="1238857834412" name="index" index="1LF_Uc" />
+      </concept>
+    </language>
     <language id="18bc6592-03a6-4e29-a83a-7ff23bde13ba" name="jetbrains.mps.lang.editor">
       <concept id="1402906326896143883" name="jetbrains.mps.lang.editor.structure.CellKeyMap_FunctionParm_selectedNode" flags="nn" index="0GJ7k" />
+      <concept id="1402906326895675325" name="jetbrains.mps.lang.editor.structure.CellActionMap_FunctionParm_selectedNode" flags="nn" index="0IXxy" />
       <concept id="5991739802479784073" name="jetbrains.mps.lang.editor.structure.MenuTypeDefault" flags="ng" index="22hDWj" />
       <concept id="1071666914219" name="jetbrains.mps.lang.editor.structure.ConceptEditorDeclaration" flags="ig" index="24kQdi">
         <child id="1078153129734" name="inspectedCellModel" index="6VMZX" />
@@ -39,6 +48,7 @@
       <concept id="1106270549637" name="jetbrains.mps.lang.editor.structure.CellLayout_Horizontal" flags="nn" index="2iRfu4" />
       <concept id="1106270571710" name="jetbrains.mps.lang.editor.structure.CellLayout_Vertical" flags="nn" index="2iRkQZ" />
       <concept id="8954657570917870539" name="jetbrains.mps.lang.editor.structure.TransformationLocation_ContextAssistant" flags="ng" index="2j_NTm" />
+      <concept id="3459162043708467089" name="jetbrains.mps.lang.editor.structure.CellActionMap_CanExecuteFunction" flags="in" index="jK8Ss" />
       <concept id="1142886221719" name="jetbrains.mps.lang.editor.structure.QueryFunction_NodeCondition" flags="in" index="pkWqt" />
       <concept id="1142886811589" name="jetbrains.mps.lang.editor.structure.ConceptFunctionParameter_node" flags="nn" index="pncrf" />
       <concept id="1080736578640" name="jetbrains.mps.lang.editor.structure.BaseEditorComponent" flags="ig" index="2wURMF">
@@ -97,6 +107,16 @@
       <concept id="1103016434866" name="jetbrains.mps.lang.editor.structure.CellModel_JComponent" flags="sg" stub="8104358048506731196" index="3gTLQM">
         <child id="1176475119347" name="componentProvider" index="3FoqZy" />
       </concept>
+      <concept id="1139535219966" name="jetbrains.mps.lang.editor.structure.CellActionMapDeclaration" flags="ig" index="1h_SRR">
+        <reference id="1139535219968" name="applicableConcept" index="1h_SK9" />
+        <child id="1139535219969" name="item" index="1h_SK8" />
+      </concept>
+      <concept id="1139535280617" name="jetbrains.mps.lang.editor.structure.CellActionMapItem" flags="lg" index="1hA7zw">
+        <property id="1139535298778" name="actionId" index="1hAc7j" />
+        <child id="3459162043708468028" name="canExecuteFunction" index="jK8aL" />
+        <child id="1139535280620" name="executeFunction" index="1hA7z_" />
+      </concept>
+      <concept id="1139535439104" name="jetbrains.mps.lang.editor.structure.CellActionMap_ExecuteFunction" flags="in" index="1hAIg9" />
       <concept id="5692353713941573329" name="jetbrains.mps.lang.editor.structure.QueryFunction_TransformationMenu_ActionLabelText" flags="ig" index="1hCUdq" />
       <concept id="1088013125922" name="jetbrains.mps.lang.editor.structure.CellModel_RefCell" flags="sg" stub="730538219795941030" index="1iCGBv">
         <child id="1088186146602" name="editorComponent" index="1sWHZn" />
@@ -117,6 +137,7 @@
       </concept>
       <concept id="1073389214265" name="jetbrains.mps.lang.editor.structure.EditorCellModel" flags="ng" index="3EYTF0">
         <reference id="1081339532145" name="keyMap" index="34QXea" />
+        <reference id="1139959269582" name="actionMap" index="1ERwB7" />
         <child id="1142887637401" name="renderingCondition" index="pqm2j" />
       </concept>
       <concept id="1073389446423" name="jetbrains.mps.lang.editor.structure.CellModel_Collection" flags="sn" stub="3013115976261988961" index="3EZMnI">
@@ -171,6 +192,9 @@
       </concept>
       <concept id="4836112446988635817" name="jetbrains.mps.baseLanguage.structure.UndefinedType" flags="in" index="2jxLKc" />
       <concept id="1202948039474" name="jetbrains.mps.baseLanguage.structure.InstanceMethodCallOperation" flags="nn" index="liA8E" />
+      <concept id="8118189177080264853" name="jetbrains.mps.baseLanguage.structure.AlternativeType" flags="ig" index="nSUau">
+        <child id="8118189177080264854" name="alternative" index="nSUat" />
+      </concept>
       <concept id="1465982738277781862" name="jetbrains.mps.baseLanguage.structure.PlaceholderMember" flags="nn" index="2tJIrI" />
       <concept id="1188207840427" name="jetbrains.mps.baseLanguage.structure.AnnotationInstance" flags="nn" index="2AHcQZ">
         <reference id="1188208074048" name="annotation" index="2AI5Lk" />
@@ -192,6 +216,7 @@
       <concept id="1070475926800" name="jetbrains.mps.baseLanguage.structure.StringLiteral" flags="nn" index="Xl_RD">
         <property id="1070475926801" name="value" index="Xl_RC" />
       </concept>
+      <concept id="4952749571008284462" name="jetbrains.mps.baseLanguage.structure.CatchVariable" flags="ng" index="XOnhg" />
       <concept id="1182160077978" name="jetbrains.mps.baseLanguage.structure.AnonymousClassCreator" flags="nn" index="YeOm9">
         <child id="1182160096073" name="cls" index="YeSDq" />
       </concept>
@@ -277,9 +302,17 @@
         <child id="1081773367579" name="rightExpression" index="3uHU7w" />
         <child id="1081773367580" name="leftExpression" index="3uHU7B" />
       </concept>
+      <concept id="3093926081414150598" name="jetbrains.mps.baseLanguage.structure.MultipleCatchClause" flags="ng" index="3uVAMA">
+        <child id="8276990574895933173" name="catchBody" index="1zc67A" />
+        <child id="8276990574895933172" name="throwable" index="1zc67B" />
+      </concept>
       <concept id="1073239437375" name="jetbrains.mps.baseLanguage.structure.NotEqualsExpression" flags="nn" index="3y3z36" />
       <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ng" index="1B3ioH">
         <child id="1178549979242" name="visibility" index="1B3o_S" />
+      </concept>
+      <concept id="5351203823916750322" name="jetbrains.mps.baseLanguage.structure.TryUniversalStatement" flags="nn" index="3J1_TO">
+        <child id="8276990574886367510" name="catchClause" index="1zxBo5" />
+        <child id="8276990574886367508" name="body" index="1zxBo7" />
       </concept>
       <concept id="1163668896201" name="jetbrains.mps.baseLanguage.structure.TernaryOperatorExpression" flags="nn" index="3K4zz7">
         <child id="1163668914799" name="condition" index="3K4Cdx" />
@@ -306,6 +339,12 @@
     <language id="fd392034-7849-419d-9071-12563d152375" name="jetbrains.mps.baseLanguage.closures">
       <concept id="1199569711397" name="jetbrains.mps.baseLanguage.closures.structure.ClosureLiteral" flags="nn" index="1bVj0M">
         <child id="1199569916463" name="body" index="1bW5cS" />
+      </concept>
+    </language>
+    <language id="760a0a8c-eabb-4521-8bfd-65db761a9ba3" name="jetbrains.mps.baseLanguage.logging">
+      <concept id="2034914114981261497" name="jetbrains.mps.baseLanguage.logging.structure.LogLowLevelStatement" flags="ng" index="RRSsy">
+        <property id="2034914114981261751" name="severity" index="RRSoG" />
+        <child id="2034914114981261753" name="message" index="RRSoy" />
       </concept>
     </language>
     <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
@@ -1188,18 +1227,24 @@
           <property role="3F0ifm" value="location" />
         </node>
         <node concept="1HlG4h" id="4XPt_HauX2X" role="3EZMnx">
+          <ref role="1ERwB7" node="4XPt_HaCr29" resolve="ResultLocationClick" />
           <node concept="1HfYo3" id="4XPt_HauX2Z" role="1HlULh">
             <node concept="3TQlhw" id="4XPt_HauX31" role="1Hhtcw">
               <node concept="3clFbS" id="4XPt_HauX33" role="2VODD2">
                 <node concept="3clFbF" id="4XPt_HauX52" role="3cqZAp">
-                  <node concept="2OqwBi" id="4XPt_HauXm_" role="3clFbG">
-                    <node concept="pncrf" id="4XPt_HauX51" role="2Oq$k0" />
-                    <node concept="2qgKlT" id="4XPt_HauXxE" role="2OqNvi">
-                      <ref role="37wK5l" to="b659:4XPt_HauH1N" resolve="formatLocation" />
-                      <node concept="2OqwBi" id="4XPt_HaxFjR" role="37wK5m">
-                        <node concept="1Q80Hx" id="4XPt_HaxF24" role="2Oq$k0" />
-                        <node concept="liA8E" id="4XPt_HaxFzZ" role="2OqNvi">
-                          <ref role="37wK5l" to="cj4x:~EditorContext.getRepository()" resolve="getRepository" />
+                  <node concept="1LFfDK" id="4XPt_HaCwD1" role="3clFbG">
+                    <node concept="3cmrfG" id="4XPt_HaCwGk" role="1LF_Uc">
+                      <property role="3cmrfH" value="0" />
+                    </node>
+                    <node concept="2OqwBi" id="4XPt_HauXm_" role="1LFl5Q">
+                      <node concept="pncrf" id="4XPt_HauX51" role="2Oq$k0" />
+                      <node concept="2qgKlT" id="4XPt_HauXxE" role="2OqNvi">
+                        <ref role="37wK5l" to="b659:4XPt_HauH1N" resolve="formatLocation" />
+                        <node concept="2OqwBi" id="4XPt_HaxFjR" role="37wK5m">
+                          <node concept="1Q80Hx" id="4XPt_HaxF24" role="2Oq$k0" />
+                          <node concept="liA8E" id="4XPt_HaxFzZ" role="2OqNvi">
+                            <ref role="37wK5l" to="cj4x:~EditorContext.getRepository()" resolve="getRepository" />
+                          </node>
                         </node>
                       </node>
                     </node>
@@ -1231,6 +1276,7 @@
         <node concept="3XFhqQ" id="4XPt_Hap3VX" role="3EZMnx" />
         <node concept="3F0A7n" id="2I_DQhHdXo" role="3EZMnx">
           <ref role="1NtTu8" to="a1af:6gY6GEDvQYT" resolve="result" />
+          <ref role="1ERwB7" node="4XPt_HaCr29" resolve="ResultLocationClick" />
           <node concept="3k4GqR" id="4XPt_Har$PG" role="3F10Kt">
             <node concept="3k4GqP" id="4XPt_Har$PH" role="3k4GqO">
               <node concept="3clFbS" id="4XPt_Har$PI" role="2VODD2">
@@ -1774,6 +1820,147 @@
       <node concept="3F0ifn" id="6EiPrTPUBAW" role="3EZMnx">
         <property role="3F0ifm" value=")" />
         <ref role="1k5W1q" to="tpen:hFCSUmN" resolve="RightParen" />
+      </node>
+    </node>
+  </node>
+  <node concept="1h_SRR" id="4XPt_HaCr29">
+    <property role="3GE5qa" value="previous_results" />
+    <property role="TrG5h" value="ResultLocationClick" />
+    <ref role="1h_SK9" to="a1af:6gY6GEDvQYS" resolve="ResultEntry" />
+    <node concept="1hA7zw" id="4XPt_HaCr2a" role="1h_SK8">
+      <property role="1hAc7j" value="1FSxSwWqMNJ/click_action_id" />
+      <node concept="1hAIg9" id="4XPt_HaCr2b" role="1hA7z_">
+        <node concept="3clFbS" id="4XPt_HaCr2c" role="2VODD2">
+          <node concept="3J1_TO" id="4XPt_HaCr2T" role="3cqZAp">
+            <node concept="3uVAMA" id="4XPt_HaCr3c" role="1zxBo5">
+              <node concept="XOnhg" id="4XPt_HaCr3d" role="1zc67B">
+                <property role="TrG5h" value="io" />
+                <node concept="nSUau" id="4XPt_HaCr3e" role="1tU5fm">
+                  <node concept="3uibUv" id="4XPt_HaCr3M" role="nSUat">
+                    <ref role="3uigEE" to="guwi:~IOException" resolve="IOException" />
+                  </node>
+                </node>
+              </node>
+              <node concept="3clFbS" id="4XPt_HaCr3f" role="1zc67A">
+                <node concept="RRSsy" id="4XPt_HaCr5H" role="3cqZAp">
+                  <property role="RRSoG" value="gZ5fh_4/error" />
+                  <node concept="3cpWs3" id="4XPt_HaCruz" role="RRSoy">
+                    <node concept="2OqwBi" id="4XPt_HaCFZ2" role="3uHU7w">
+                      <node concept="0IXxy" id="4XPt_HaCFLf" role="2Oq$k0" />
+                      <node concept="3TrcHB" id="4XPt_HaCG9X" role="2OqNvi">
+                        <ref role="3TsBF5" to="a1af:2I_DQhwrOw" resolve="resultLocation" />
+                      </node>
+                    </node>
+                    <node concept="Xl_RD" id="4XPt_HaCr5J" role="3uHU7B">
+                      <property role="Xl_RC" value="Couldn't open " />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbS" id="4XPt_HaCr2U" role="1zxBo7">
+              <node concept="3cpWs8" id="4XPt_HaDmUN" role="3cqZAp">
+                <node concept="3cpWsn" id="4XPt_HaDmUO" role="3cpWs9">
+                  <property role="TrG5h" value="file" />
+                  <node concept="3uibUv" id="4XPt_HaDlNx" role="1tU5fm">
+                    <ref role="3uigEE" to="guwi:~File" resolve="File" />
+                  </node>
+                  <node concept="2ShNRf" id="4XPt_HaDmUP" role="33vP2m">
+                    <node concept="1pGfFk" id="4XPt_HaDmUQ" role="2ShVmc">
+                      <property role="373rjd" value="true" />
+                      <ref role="37wK5l" to="guwi:~File.&lt;init&gt;(java.lang.String)" resolve="File" />
+                      <node concept="2OqwBi" id="4XPt_HaDmUR" role="37wK5m">
+                        <node concept="0IXxy" id="4XPt_HaDmUS" role="2Oq$k0" />
+                        <node concept="3TrcHB" id="4XPt_HaDmUT" role="2OqNvi">
+                          <ref role="3TsBF5" to="a1af:2I_DQhwrOw" resolve="resultLocation" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3clFbJ" id="4XPt_HaDn5x" role="3cqZAp">
+                <node concept="3clFbS" id="4XPt_HaDn5z" role="3clFbx">
+                  <node concept="3clFbF" id="4XPt_HaDnKW" role="3cqZAp">
+                    <node concept="37vLTI" id="4XPt_HaDo4s" role="3clFbG">
+                      <node concept="2OqwBi" id="4XPt_HaDo59" role="37vLTx">
+                        <node concept="37vLTw" id="4XPt_HaDo4I" role="2Oq$k0">
+                          <ref role="3cqZAo" node="4XPt_HaDmUO" resolve="file" />
+                        </node>
+                        <node concept="liA8E" id="4XPt_HaDoql" role="2OqNvi">
+                          <ref role="37wK5l" to="guwi:~File.getParentFile()" resolve="getParentFile" />
+                        </node>
+                      </node>
+                      <node concept="37vLTw" id="4XPt_HaDnKU" role="37vLTJ">
+                        <ref role="3cqZAo" node="4XPt_HaDmUO" resolve="file" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="3fqX7Q" id="4XPt_HaDnJa" role="3clFbw">
+                  <node concept="2OqwBi" id="4XPt_HaDnJc" role="3fr31v">
+                    <node concept="37vLTw" id="4XPt_HaDnJd" role="2Oq$k0">
+                      <ref role="3cqZAo" node="4XPt_HaDmUO" resolve="file" />
+                    </node>
+                    <node concept="liA8E" id="4XPt_HaDnJe" role="2OqNvi">
+                      <ref role="37wK5l" to="guwi:~File.isDirectory()" resolve="isDirectory" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3clFbF" id="4XPt_HaCGgF" role="3cqZAp">
+                <node concept="2OqwBi" id="4XPt_HaCGoE" role="3clFbG">
+                  <node concept="2YIFZM" id="4XPt_HaCGhd" role="2Oq$k0">
+                    <ref role="37wK5l" to="z60i:~Desktop.getDesktop()" resolve="getDesktop" />
+                    <ref role="1Pybhc" to="z60i:~Desktop" resolve="Desktop" />
+                  </node>
+                  <node concept="liA8E" id="4XPt_HaCGwI" role="2OqNvi">
+                    <ref role="37wK5l" to="z60i:~Desktop.open(java.io.File)" resolve="open" />
+                    <node concept="37vLTw" id="4XPt_HaDmUU" role="37wK5m">
+                      <ref role="3cqZAo" node="4XPt_HaDmUO" resolve="file" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="jK8Ss" id="4XPt_HaCxr4" role="jK8aL">
+        <node concept="3clFbS" id="4XPt_HaCxr5" role="2VODD2">
+          <node concept="3clFbF" id="4XPt_HaCrxs" role="3cqZAp">
+            <node concept="1Wc70l" id="4XPt_HaDWtU" role="3clFbG">
+              <node concept="3y3z36" id="4XPt_HaDX_6" role="3uHU7B">
+                <node concept="10Nm6u" id="4XPt_HaDX_b" role="3uHU7w" />
+                <node concept="2OqwBi" id="4XPt_HaDWRX" role="3uHU7B">
+                  <node concept="0IXxy" id="4XPt_HaDWCj" role="2Oq$k0" />
+                  <node concept="3TrcHB" id="4XPt_HaDX4O" role="2OqNvi">
+                    <ref role="3TsBF5" to="a1af:2I_DQhwrOw" resolve="resultLocation" />
+                  </node>
+                </node>
+              </node>
+              <node concept="3fqX7Q" id="4XPt_HaCF_O" role="3uHU7w">
+                <node concept="1LFfDK" id="4XPt_HaCF_Q" role="3fr31v">
+                  <node concept="3cmrfG" id="4XPt_HaCF_R" role="1LF_Uc">
+                    <property role="3cmrfH" value="1" />
+                  </node>
+                  <node concept="2OqwBi" id="4XPt_HaCF_S" role="1LFl5Q">
+                    <node concept="0IXxy" id="4XPt_HaCF_T" role="2Oq$k0" />
+                    <node concept="2qgKlT" id="4XPt_HaCF_U" role="2OqNvi">
+                      <ref role="37wK5l" to="b659:4XPt_HauH1N" resolve="formatLocation" />
+                      <node concept="2OqwBi" id="4XPt_HaCF_V" role="37wK5m">
+                        <node concept="1Q80Hx" id="4XPt_HaCF_W" role="2Oq$k0" />
+                        <node concept="liA8E" id="4XPt_HaCF_X" role="2OqNvi">
+                          <ref role="37wK5l" to="cj4x:~EditorContext.getRepository()" resolve="getRepository" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
       </node>
     </node>
   </node>

--- a/code/languages/org.mpsqa.lint/languages/org.mpsqa.lint.generic/models/org.mpsqa.lint.generic.editor.mps
+++ b/code/languages/org.mpsqa.lint/languages/org.mpsqa.lint.generic/models/org.mpsqa.lint.generic.editor.mps
@@ -19,6 +19,7 @@
     <import index="lzb2" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.ui(MPS.IDEA/)" />
     <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" implicit="true" />
     <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" implicit="true" />
+    <import index="mhbf" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.model(MPS.OpenAPI/)" implicit="true" />
     <import index="tpen" ref="r:00000000-0000-4000-0000-011c895902c3(jetbrains.mps.baseLanguage.editor)" implicit="true" />
     <import index="zqge" ref="r:59e90602-6655-4552-86eb-441a42a9a0e4(jetbrains.mps.lang.text.structure)" implicit="true" />
     <import index="tpco" ref="r:00000000-0000-4000-0000-011c89590284(jetbrains.mps.lang.core.editor)" implicit="true" />
@@ -143,6 +144,12 @@
         <child id="1638911550608572412" name="sections" index="IW6Ez" />
       </concept>
       <concept id="1161622981231" name="jetbrains.mps.lang.editor.structure.ConceptFunctionParameter_editorContext" flags="nn" index="1Q80Hx" />
+      <concept id="1088612959204" name="jetbrains.mps.lang.editor.structure.CellModel_Alternation" flags="sg" stub="8104358048506729361" index="1QoScp">
+        <property id="1088613081987" name="vertical" index="1QpmdY" />
+        <child id="1145918517974" name="alternationCondition" index="3e4ffs" />
+        <child id="1088612958265" name="ifTrueCellModel" index="1QoS34" />
+        <child id="1088612973955" name="ifFalseCellModel" index="1QoVPY" />
+      </concept>
       <concept id="7980428675268276156" name="jetbrains.mps.lang.editor.structure.TransformationMenuSection" flags="ng" index="1Qtc8_">
         <child id="7980428675268276157" name="locations" index="1Qtc8$" />
         <child id="7980428675268276159" name="parts" index="1Qtc8A" />
@@ -210,6 +217,7 @@
       <concept id="1068498886292" name="jetbrains.mps.baseLanguage.structure.ParameterDeclaration" flags="ir" index="37vLTG" />
       <concept id="1068498886294" name="jetbrains.mps.baseLanguage.structure.AssignmentExpression" flags="nn" index="37vLTI" />
       <concept id="1225271177708" name="jetbrains.mps.baseLanguage.structure.StringType" flags="in" index="17QB3L" />
+      <concept id="1225271408483" name="jetbrains.mps.baseLanguage.structure.IsNotEmptyOperation" flags="nn" index="17RvpY" />
       <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
         <child id="5680397130376446158" name="type" index="1tU5fm" />
       </concept>
@@ -309,6 +317,7 @@
       <concept id="1143224127713" name="jetbrains.mps.lang.smodel.structure.Node_InsertPrevSiblingOperation" flags="nn" index="HtX7F">
         <child id="1143224127716" name="insertedNode" index="HtX7I" />
       </concept>
+      <concept id="1143234257716" name="jetbrains.mps.lang.smodel.structure.Node_GetModelOperation" flags="nn" index="I4A8Y" />
       <concept id="1883223317721008708" name="jetbrains.mps.lang.smodel.structure.IfInstanceOfStatement" flags="nn" index="Jncv_">
         <reference id="1883223317721008712" name="nodeConcept" index="JncvD" />
         <child id="1883223317721008709" name="body" index="Jncv$" />
@@ -317,6 +326,10 @@
       </concept>
       <concept id="1883223317721008713" name="jetbrains.mps.lang.smodel.structure.IfInstanceOfVariable" flags="ng" index="JncvC" />
       <concept id="1883223317721107059" name="jetbrains.mps.lang.smodel.structure.IfInstanceOfVarReference" flags="nn" index="Jnkvi" />
+      <concept id="1145404486709" name="jetbrains.mps.lang.smodel.structure.SemanticDowncastExpression" flags="nn" index="2JrnkZ">
+        <child id="1145404616321" name="leftExpression" index="2JrQYb" />
+      </concept>
+      <concept id="1212008292747" name="jetbrains.mps.lang.smodel.structure.Model_GetLongNameOperation" flags="nn" index="LkI2h" />
       <concept id="1172008320231" name="jetbrains.mps.lang.smodel.structure.Node_IsNotNullOperation" flags="nn" index="3x8VRR" />
       <concept id="1180636770613" name="jetbrains.mps.lang.smodel.structure.SNodeCreator" flags="nn" index="3zrR0B">
         <child id="1180636770616" name="createdType" index="3zrR0E" />
@@ -1055,53 +1068,112 @@
   <node concept="24kQdi" id="4WO8F5MT71H">
     <property role="3GE5qa" value="previous_results" />
     <ref role="1XX52x" to="a1af:6gY6GEDvQYS" resolve="ResultEntry" />
-    <node concept="3EZMnI" id="4WO8F5MTflp" role="2wV5jI">
-      <node concept="3F0ifn" id="4WO8F5MTfl_" role="3EZMnx">
-        <property role="3F0ifm" value="Error:" />
-      </node>
-      <node concept="2iRfu4" id="4WO8F5MTflq" role="2iSdaV" />
-      <node concept="3F0A7n" id="4WO8F5MT71M" role="3EZMnx">
-        <ref role="1NtTu8" to="a1af:6gY6GEDvQYT" resolve="result" />
-        <node concept="VPxyj" id="4WO8F5MT71P" role="3F10Kt" />
-        <node concept="3k4GqR" id="78RogMCGF1B" role="3F10Kt">
-          <node concept="3k4GqP" id="78RogMCGF1D" role="3k4GqO">
-            <node concept="3clFbS" id="78RogMCGF1F" role="2VODD2">
-              <node concept="3cpWs8" id="78RogMCGFYT" role="3cqZAp">
-                <node concept="3cpWsn" id="78RogMCGFYU" role="3cpWs9">
-                  <property role="TrG5h" value="project" />
-                  <node concept="3uibUv" id="78RogMCGFYB" role="1tU5fm">
-                    <ref role="3uigEE" to="z1c3:~Project" resolve="Project" />
-                  </node>
-                  <node concept="2OqwBi" id="78RogMCGFYV" role="33vP2m">
-                    <node concept="2OqwBi" id="78RogMCGFYW" role="2Oq$k0">
-                      <node concept="1Q80Hx" id="78RogMCGFYX" role="2Oq$k0" />
-                      <node concept="liA8E" id="78RogMCGFYY" role="2OqNvi">
-                        <ref role="37wK5l" to="cj4x:~EditorContext.getOperationContext()" resolve="getOperationContext" />
+    <node concept="3EZMnI" id="2I_DQhHcYH" role="2wV5jI">
+      <node concept="1QoScp" id="4XPt_Hatexq" role="3EZMnx">
+        <property role="1QpmdY" value="true" />
+        <node concept="pkWqt" id="4XPt_Hatext" role="3e4ffs">
+          <node concept="3clFbS" id="4XPt_Hatexv" role="2VODD2">
+            <node concept="3clFbF" id="4XPt_Hatf3y" role="3cqZAp">
+              <node concept="2OqwBi" id="2I_DQhGtI9" role="3clFbG">
+                <node concept="2OqwBi" id="2I_DQhGtfn" role="2Oq$k0">
+                  <node concept="pncrf" id="2I_DQhGtfo" role="2Oq$k0" />
+                  <node concept="2qgKlT" id="2I_DQhGtfp" role="2OqNvi">
+                    <ref role="37wK5l" to="b659:2I_DQhGejd" resolve="getNode" />
+                    <node concept="2OqwBi" id="2I_DQhGtfq" role="37wK5m">
+                      <node concept="1Q80Hx" id="2I_DQhGtfr" role="2Oq$k0" />
+                      <node concept="liA8E" id="2I_DQhGtfs" role="2OqNvi">
+                        <ref role="37wK5l" to="cj4x:~EditorContext.getRepository()" resolve="getRepository" />
                       </node>
                     </node>
-                    <node concept="liA8E" id="78RogMCGFYZ" role="2OqNvi">
-                      <ref role="37wK5l" to="w1kc:~IOperationContext.getProject()" resolve="getProject" />
+                  </node>
+                </node>
+                <node concept="3x8VRR" id="2I_DQhGu96" role="2OqNvi" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3F0ifn" id="4XPt_Hatf70" role="1QoVPY">
+          <property role="3F0ifm" value="unknown location" />
+        </node>
+        <node concept="3EZMnI" id="4WO8F5MTflp" role="1QoS34">
+          <node concept="2iRfu4" id="4WO8F5MTflq" role="2iSdaV" />
+          <node concept="3F0ifn" id="2I_DQhHf0o" role="3EZMnx">
+            <property role="3F0ifm" value="model" />
+          </node>
+          <node concept="1HlG4h" id="2I_DQhHf7x" role="3EZMnx">
+            <node concept="1HfYo3" id="2I_DQhHf7y" role="1HlULh">
+              <node concept="3TQlhw" id="2I_DQhHf7z" role="1Hhtcw">
+                <node concept="3clFbS" id="2I_DQhHf7$" role="2VODD2">
+                  <node concept="3clFbF" id="2I_DQhHf7_" role="3cqZAp">
+                    <node concept="2OqwBi" id="2I_DQhHf7A" role="3clFbG">
+                      <node concept="2OqwBi" id="2I_DQhHf7B" role="2Oq$k0">
+                        <node concept="2OqwBi" id="2I_DQhHf7C" role="2Oq$k0">
+                          <node concept="pncrf" id="2I_DQhHf7D" role="2Oq$k0" />
+                          <node concept="2qgKlT" id="2I_DQhHf7E" role="2OqNvi">
+                            <ref role="37wK5l" to="b659:2I_DQhGejd" resolve="getNode" />
+                            <node concept="2OqwBi" id="2I_DQhHf7F" role="37wK5m">
+                              <node concept="1Q80Hx" id="2I_DQhHf7G" role="2Oq$k0" />
+                              <node concept="liA8E" id="2I_DQhHf7H" role="2OqNvi">
+                                <ref role="37wK5l" to="cj4x:~EditorContext.getRepository()" resolve="getRepository" />
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="I4A8Y" id="2I_DQhHf7I" role="2OqNvi" />
+                      </node>
+                      <node concept="LkI2h" id="2I_DQhHf7J" role="2OqNvi" />
                     </node>
                   </node>
                 </node>
               </node>
-              <node concept="3clFbF" id="78RogMCHOwr" role="3cqZAp">
-                <node concept="2YIFZM" id="78RogMCHPlD" role="3clFbG">
-                  <ref role="37wK5l" to="b659:78RogMCHOPn" resolve="findNodeById" />
-                  <ref role="1Pybhc" to="b659:78RogMCHKPV" resolve="Node2ID" />
-                  <node concept="37vLTw" id="78RogMCHPtO" role="37wK5m">
-                    <ref role="3cqZAo" node="78RogMCGFYU" resolve="project" />
-                  </node>
-                  <node concept="2OqwBi" id="78RogMCHQ00" role="37wK5m">
-                    <node concept="pncrf" id="78RogMCHPIw" role="2Oq$k0" />
-                    <node concept="3TrcHB" id="78RogMCHQhE" role="2OqNvi">
-                      <ref role="3TsBF5" to="a1af:78RogMCGEW7" resolve="resultNodeModelId" />
+            </node>
+          </node>
+          <node concept="3F0ifn" id="4XPt_Hap_xJ" role="3EZMnx">
+            <property role="3F0ifm" value="with node" />
+          </node>
+          <node concept="1HlG4h" id="4XPt_Hap_$p" role="3EZMnx">
+            <node concept="3k4GqR" id="4XPt_HaqMFn" role="3F10Kt">
+              <node concept="3k4GqP" id="4XPt_HaqMFo" role="3k4GqO">
+                <node concept="3clFbS" id="4XPt_HaqMFp" role="2VODD2">
+                  <node concept="3clFbF" id="4XPt_HaqML8" role="3cqZAp">
+                    <node concept="2OqwBi" id="4XPt_HaqMWS" role="3clFbG">
+                      <node concept="pncrf" id="4XPt_HaqML7" role="2Oq$k0" />
+                      <node concept="2qgKlT" id="4XPt_HaqN7X" role="2OqNvi">
+                        <ref role="37wK5l" to="b659:2I_DQhGejd" resolve="getNode" />
+                        <node concept="2OqwBi" id="4XPt_HaqNHU" role="37wK5m">
+                          <node concept="1Q80Hx" id="4XPt_HaqN$r" role="2Oq$k0" />
+                          <node concept="liA8E" id="4XPt_HaqO3k" role="2OqNvi">
+                            <ref role="37wK5l" to="cj4x:~EditorContext.getRepository()" resolve="getRepository" />
+                          </node>
+                        </node>
+                      </node>
                     </node>
                   </node>
-                  <node concept="2OqwBi" id="78RogMCHQEb" role="37wK5m">
-                    <node concept="pncrf" id="78RogMCHQyB" role="2Oq$k0" />
-                    <node concept="3TrcHB" id="78RogMCHQP$" role="2OqNvi">
-                      <ref role="3TsBF5" to="a1af:78RogMCGEUf" resolve="resultNodeId" />
+                </node>
+              </node>
+            </node>
+            <node concept="1HfYo3" id="4XPt_Hap_$q" role="1HlULh">
+              <node concept="3TQlhw" id="4XPt_Hap_$r" role="1Hhtcw">
+                <node concept="3clFbS" id="4XPt_Hap_$s" role="2VODD2">
+                  <node concept="3clFbF" id="4XPt_Hap_$t" role="3cqZAp">
+                    <node concept="2OqwBi" id="4XPt_Hap_$u" role="3clFbG">
+                      <node concept="2JrnkZ" id="4XPt_Hap_$v" role="2Oq$k0">
+                        <node concept="2OqwBi" id="4XPt_Hap_$w" role="2JrQYb">
+                          <node concept="pncrf" id="4XPt_Hap_$x" role="2Oq$k0" />
+                          <node concept="2qgKlT" id="4XPt_Hap_$y" role="2OqNvi">
+                            <ref role="37wK5l" to="b659:2I_DQhGejd" resolve="getNode" />
+                            <node concept="2OqwBi" id="4XPt_Hap_$z" role="37wK5m">
+                              <node concept="1Q80Hx" id="4XPt_Hap_$$" role="2Oq$k0" />
+                              <node concept="liA8E" id="4XPt_Hap_$_" role="2OqNvi">
+                                <ref role="37wK5l" to="cj4x:~EditorContext.getRepository()" resolve="getRepository" />
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="liA8E" id="4XPt_Hap_$A" role="2OqNvi">
+                        <ref role="37wK5l" to="mhbf:~SNode.getName()" resolve="getName" />
+                      </node>
                     </node>
                   </node>
                 </node>
@@ -1110,17 +1182,76 @@
           </node>
         </node>
       </node>
-      <node concept="3F0ifn" id="78RogMCKwN$" role="3EZMnx">
-        <property role="3F0ifm" value="from model with ID:" />
+      <node concept="3EZMnI" id="4XPt_HaubZN" role="3EZMnx">
+        <node concept="2iRfu4" id="4XPt_HaubZO" role="2iSdaV" />
+        <node concept="3F0ifn" id="4XPt_HaubSP" role="3EZMnx">
+          <property role="3F0ifm" value="location" />
+        </node>
+        <node concept="1HlG4h" id="4XPt_HauX2X" role="3EZMnx">
+          <node concept="1HfYo3" id="4XPt_HauX2Z" role="1HlULh">
+            <node concept="3TQlhw" id="4XPt_HauX31" role="1Hhtcw">
+              <node concept="3clFbS" id="4XPt_HauX33" role="2VODD2">
+                <node concept="3clFbF" id="4XPt_HauX52" role="3cqZAp">
+                  <node concept="2OqwBi" id="4XPt_HauXm_" role="3clFbG">
+                    <node concept="pncrf" id="4XPt_HauX51" role="2Oq$k0" />
+                    <node concept="2qgKlT" id="4XPt_HauXxE" role="2OqNvi">
+                      <ref role="37wK5l" to="b659:4XPt_HauH1N" resolve="formatLocation" />
+                      <node concept="2OqwBi" id="4XPt_HaxFjR" role="37wK5m">
+                        <node concept="1Q80Hx" id="4XPt_HaxF24" role="2Oq$k0" />
+                        <node concept="liA8E" id="4XPt_HaxFzZ" role="2OqNvi">
+                          <ref role="37wK5l" to="cj4x:~EditorContext.getRepository()" resolve="getRepository" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="pkWqt" id="4XPt_Hauc6P" role="pqm2j">
+          <node concept="3clFbS" id="4XPt_Hauc6Q" role="2VODD2">
+            <node concept="3clFbF" id="4XPt_Hauc7A" role="3cqZAp">
+              <node concept="2OqwBi" id="4XPt_Haudyo" role="3clFbG">
+                <node concept="2OqwBi" id="4XPt_HaucnJ" role="2Oq$k0">
+                  <node concept="pncrf" id="4XPt_Hauc7_" role="2Oq$k0" />
+                  <node concept="3TrcHB" id="4XPt_HaucIA" role="2OqNvi">
+                    <ref role="3TsBF5" to="a1af:2I_DQhwrOw" resolve="resultLocation" />
+                  </node>
+                </node>
+                <node concept="17RvpY" id="4XPt_Haueny" role="2OqNvi" />
+              </node>
+            </node>
+          </node>
+        </node>
       </node>
-      <node concept="3F0A7n" id="78RogMCKwRi" role="3EZMnx">
-        <ref role="1NtTu8" to="a1af:78RogMCGEW7" resolve="resultNodeModelId" />
-      </node>
-      <node concept="3F0ifn" id="78RogMCKwV2" role="3EZMnx">
-        <property role="3F0ifm" value="and node ID:" />
-      </node>
-      <node concept="3F0A7n" id="78RogMCKx0I" role="3EZMnx">
-        <ref role="1NtTu8" to="a1af:78RogMCGEUf" resolve="resultNodeId" />
+      <node concept="2iRkQZ" id="2I_DQhHcYI" role="2iSdaV" />
+      <node concept="3EZMnI" id="2I_DQhHdR$" role="3EZMnx">
+        <node concept="2iRfu4" id="2I_DQhHdR_" role="2iSdaV" />
+        <node concept="3XFhqQ" id="4XPt_Hap3VX" role="3EZMnx" />
+        <node concept="3F0A7n" id="2I_DQhHdXo" role="3EZMnx">
+          <ref role="1NtTu8" to="a1af:6gY6GEDvQYT" resolve="result" />
+          <node concept="3k4GqR" id="4XPt_Har$PG" role="3F10Kt">
+            <node concept="3k4GqP" id="4XPt_Har$PH" role="3k4GqO">
+              <node concept="3clFbS" id="4XPt_Har$PI" role="2VODD2">
+                <node concept="3clFbF" id="4XPt_Har$PJ" role="3cqZAp">
+                  <node concept="2OqwBi" id="4XPt_Har$PK" role="3clFbG">
+                    <node concept="pncrf" id="4XPt_Har$PL" role="2Oq$k0" />
+                    <node concept="2qgKlT" id="4XPt_Har$PM" role="2OqNvi">
+                      <ref role="37wK5l" to="b659:2I_DQhGejd" resolve="getNode" />
+                      <node concept="2OqwBi" id="4XPt_Har$PN" role="37wK5m">
+                        <node concept="1Q80Hx" id="4XPt_Har$PO" role="2Oq$k0" />
+                        <node concept="liA8E" id="4XPt_Har$PP" role="2OqNvi">
+                          <ref role="37wK5l" to="cj4x:~EditorContext.getRepository()" resolve="getRepository" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
       </node>
     </node>
   </node>

--- a/code/languages/org.mpsqa.lint/languages/org.mpsqa.lint.generic/models/org.mpsqa.lint.generic.editor.mps
+++ b/code/languages/org.mpsqa.lint/languages/org.mpsqa.lint.generic/models/org.mpsqa.lint.generic.editor.mps
@@ -779,8 +779,8 @@
                       <ref role="3cqZAo" to="lzb2:~JBColor.ORANGE" resolve="ORANGE" />
                       <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
                     </node>
-                    <node concept="10M0yZ" id="63CQ8uYLJDf" role="3K4GZi">
-                      <ref role="3cqZAo" to="lzb2:~JBColor.LIGHT_GRAY" resolve="LIGHT_GRAY" />
+                    <node concept="10M0yZ" id="7_XHz4_JkX6" role="3K4GZi">
+                      <ref role="3cqZAo" to="lzb2:~JBColor.GREEN" resolve="GREEN" />
                       <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
                     </node>
                     <node concept="2OqwBi" id="63CQ8uYIrmU" role="3K4Cdx">
@@ -1775,8 +1775,8 @@
                       <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
                       <ref role="3cqZAo" to="lzb2:~JBColor.ORANGE" resolve="ORANGE" />
                     </node>
-                    <node concept="10M0yZ" id="63CQ8uYM8eX" role="3K4GZi">
-                      <ref role="3cqZAo" to="lzb2:~JBColor.LIGHT_GRAY" resolve="LIGHT_GRAY" />
+                    <node concept="10M0yZ" id="7_XHz4_J2PX" role="3K4GZi">
+                      <ref role="3cqZAo" to="lzb2:~JBColor.GREEN" resolve="GREEN" />
                       <ref role="1PxDUh" to="lzb2:~JBColor" resolve="JBColor" />
                     </node>
                     <node concept="2OqwBi" id="652KpqR2FTk" role="3K4Cdx">

--- a/code/languages/org.mpsqa.lint/languages/org.mpsqa.lint.generic/models/org.mpsqa.lint.generic.structure.mps
+++ b/code/languages/org.mpsqa.lint/languages/org.mpsqa.lint.generic/models/org.mpsqa.lint.generic.structure.mps
@@ -220,6 +220,11 @@
       <property role="TrG5h" value="resultNodeId" />
       <ref role="AX2Wp" to="tpck:fKAOsGN" resolve="string" />
     </node>
+    <node concept="1TJgyi" id="2I_DQhwrOw" role="1TKVEl">
+      <property role="IQ2nx" value="49142249442884896" />
+      <property role="TrG5h" value="resultLocation" />
+      <ref role="AX2Wp" to="tpck:fKAOsGN" resolve="string" />
+    </node>
   </node>
   <node concept="PlHQZ" id="6gY6GEDvQYV">
     <property role="EcuMT" value="7223240310078271419" />

--- a/code/languages/org.mpsqa.lint/languages/org.mpsqa.lint.generic/models/org.mpsqa.lint.generic.typesystem.mps
+++ b/code/languages/org.mpsqa.lint/languages/org.mpsqa.lint.generic/models/org.mpsqa.lint.generic.typesystem.mps
@@ -1258,49 +1258,72 @@
             </node>
           </node>
         </node>
-        <node concept="3cpWs8" id="106MO2l7ZVO" role="3cqZAp">
-          <node concept="3cpWsn" id="106MO2l7ZVP" role="3cpWs9">
-            <property role="TrG5h" value="resultEntry" />
-            <node concept="3Tqbb2" id="106MO2l7Wg9" role="1tU5fm">
-              <ref role="ehGHo" to="a1af:6gY6GEDvQYS" resolve="ResultEntry" />
-            </node>
-            <node concept="2pJPEk" id="106MO2l7ZVQ" role="33vP2m">
-              <node concept="2pJPED" id="106MO2l7ZVR" role="2pJPEn">
-                <ref role="2pJxaS" to="a1af:6gY6GEDvQYS" resolve="ResultEntry" />
-                <node concept="2pJxcG" id="106MO2l7ZVS" role="2pJxcM">
-                  <ref role="2pJxcJ" to="a1af:2I_DQhwrOw" resolve="resultLocation" />
-                  <node concept="WxPPo" id="106MO2l7ZVT" role="28ntcv">
-                    <node concept="2OqwBi" id="106MO2l7ZVU" role="WxPPp">
-                      <node concept="2OqwBi" id="106MO2l7ZVV" role="2Oq$k0">
-                        <node concept="37vLTw" id="106MO2l7ZVW" role="2Oq$k0">
-                          <ref role="3cqZAo" node="ST9rMmWlmc" resolve="res" />
-                        </node>
-                        <node concept="2sxana" id="106MO2l7ZVX" role="2OqNvi">
-                          <ref role="2sxfKC" to="qqy:3ghOW5H_ihW" resolve="location" />
-                        </node>
-                      </node>
-                      <node concept="liA8E" id="106MO2l7ZVY" role="2OqNvi">
-                        <ref role="37wK5l" to="wyt6:~Object.toString()" resolve="toString" />
-                      </node>
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
         <node concept="3cpWs8" id="106MO2l7QH8" role="3cqZAp">
           <node concept="3cpWsn" id="106MO2l7QHb" role="3cpWs9">
             <property role="TrG5h" value="location" />
             <node concept="3uibUv" id="106MO2l7RmX" role="1tU5fm">
               <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
             </node>
-            <node concept="2OqwBi" id="106MO2l80Ij" role="33vP2m">
-              <node concept="37vLTw" id="106MO2l7ZVZ" role="2Oq$k0">
-                <ref role="3cqZAo" node="106MO2l7ZVP" resolve="resultEntry" />
+            <node concept="10Nm6u" id="1xUl787165X" role="33vP2m" />
+          </node>
+        </node>
+        <node concept="3clFbJ" id="1xUl78716Er" role="3cqZAp">
+          <node concept="3clFbS" id="1xUl78716Et" role="3clFbx">
+            <node concept="3cpWs8" id="106MO2l7ZVO" role="3cqZAp">
+              <node concept="3cpWsn" id="106MO2l7ZVP" role="3cpWs9">
+                <property role="TrG5h" value="resultEntry" />
+                <node concept="3Tqbb2" id="106MO2l7Wg9" role="1tU5fm">
+                  <ref role="ehGHo" to="a1af:6gY6GEDvQYS" resolve="ResultEntry" />
+                </node>
+                <node concept="2pJPEk" id="106MO2l7ZVQ" role="33vP2m">
+                  <node concept="2pJPED" id="106MO2l7ZVR" role="2pJPEn">
+                    <ref role="2pJxaS" to="a1af:6gY6GEDvQYS" resolve="ResultEntry" />
+                    <node concept="2pJxcG" id="106MO2l7ZVS" role="2pJxcM">
+                      <ref role="2pJxcJ" to="a1af:2I_DQhwrOw" resolve="resultLocation" />
+                      <node concept="WxPPo" id="106MO2l7ZVT" role="28ntcv">
+                        <node concept="2OqwBi" id="106MO2l7ZVU" role="WxPPp">
+                          <node concept="2OqwBi" id="106MO2l7ZVV" role="2Oq$k0">
+                            <node concept="37vLTw" id="106MO2l7ZVW" role="2Oq$k0">
+                              <ref role="3cqZAo" node="ST9rMmWlmc" resolve="res" />
+                            </node>
+                            <node concept="2sxana" id="106MO2l7ZVX" role="2OqNvi">
+                              <ref role="2sxfKC" to="qqy:3ghOW5H_ihW" resolve="location" />
+                            </node>
+                          </node>
+                          <node concept="liA8E" id="106MO2l7ZVY" role="2OqNvi">
+                            <ref role="37wK5l" to="wyt6:~Object.toString()" resolve="toString" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
               </node>
-              <node concept="2qgKlT" id="106MO2l814J" role="2OqNvi">
-                <ref role="37wK5l" to="b659:4XPt_HaECXY" resolve="convertLocationToObject" />
+            </node>
+            <node concept="3clFbF" id="1xUl78713vs" role="3cqZAp">
+              <node concept="37vLTI" id="1xUl78713vu" role="3clFbG">
+                <node concept="2OqwBi" id="106MO2l80Ij" role="37vLTx">
+                  <node concept="37vLTw" id="106MO2l7ZVZ" role="2Oq$k0">
+                    <ref role="3cqZAo" node="106MO2l7ZVP" resolve="resultEntry" />
+                  </node>
+                  <node concept="2qgKlT" id="106MO2l814J" role="2OqNvi">
+                    <ref role="37wK5l" to="b659:4XPt_HaECXY" resolve="convertLocationToObject" />
+                  </node>
+                </node>
+                <node concept="37vLTw" id="1xUl78713vy" role="37vLTJ">
+                  <ref role="3cqZAo" node="106MO2l7QHb" resolve="location" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3y3z36" id="1xUl7871aPv" role="3clFbw">
+            <node concept="10Nm6u" id="1xUl7871aXm" role="3uHU7w" />
+            <node concept="2OqwBi" id="1xUl78718TQ" role="3uHU7B">
+              <node concept="37vLTw" id="1xUl78717qR" role="2Oq$k0">
+                <ref role="3cqZAo" node="ST9rMmWlmc" resolve="res" />
+              </node>
+              <node concept="2sxana" id="1xUl78719NJ" role="2OqNvi">
+                <ref role="2sxfKC" to="qqy:3ghOW5H_ihW" resolve="location" />
               </node>
             </node>
           </node>
@@ -1408,23 +1431,6 @@
                   </node>
                   <node concept="37vLTw" id="106MO2l7UbN" role="2ZW6bz">
                     <ref role="3cqZAo" node="106MO2l7QHb" resolve="location" />
-                  </node>
-                </node>
-              </node>
-              <node concept="9aQIb" id="1BlvkgWmXpw" role="9aQIa">
-                <node concept="3clFbS" id="1BlvkgWmXpx" role="9aQI4">
-                  <node concept="3clFbF" id="3hskWvhsDhC" role="3cqZAp">
-                    <node concept="2OqwBi" id="3hskWvhsDKY" role="3clFbG">
-                      <node concept="37vLTw" id="3hskWvhsDhA" role="2Oq$k0">
-                        <ref role="3cqZAo" node="3hskWvhsmDv" resolve="messageBuilder" />
-                      </node>
-                      <node concept="liA8E" id="3hskWvhsEfi" role="2OqNvi">
-                        <ref role="37wK5l" to="wyt6:~StringBuilder.append(java.lang.Object)" resolve="append" />
-                        <node concept="37vLTw" id="106MO2l98uS" role="37wK5m">
-                          <ref role="3cqZAo" node="106MO2l7QHb" resolve="location" />
-                        </node>
-                      </node>
-                    </node>
                   </node>
                 </node>
               </node>

--- a/code/languages/org.mpsqa.lint/languages/org.mpsqa.lint.generic/models/org.mpsqa.lint.generic.typesystem.mps
+++ b/code/languages/org.mpsqa.lint/languages/org.mpsqa.lint.generic/models/org.mpsqa.lint.generic.typesystem.mps
@@ -3864,12 +3864,24 @@
                                           </node>
                                           <node concept="2r$n1x" id="4KreBtcxwNF" role="2r_Bvh">
                                             <ref role="2r$qp6" to="qqy:3ghOW5H_ihW" resolve="location" />
-                                            <node concept="2OqwBi" id="4KreBtcybHx" role="2r_lH1">
-                                              <node concept="37vLTw" id="4KreBtcy9PZ" role="2Oq$k0">
-                                                <ref role="3cqZAo" node="4KreBtcxwNN" resolve="it" />
+                                            <node concept="2OqwBi" id="4XPt_HawF1P" role="2r_lH1">
+                                              <node concept="2OqwBi" id="4XPt_HavuJY" role="2Oq$k0">
+                                                <node concept="2JrnkZ" id="4XPt_HavsPR" role="2Oq$k0">
+                                                  <node concept="2OqwBi" id="4KreBtcybHx" role="2JrQYb">
+                                                    <node concept="37vLTw" id="4KreBtcy9PZ" role="2Oq$k0">
+                                                      <ref role="3cqZAo" node="4KreBtcxwNN" resolve="it" />
+                                                    </node>
+                                                    <node concept="2OwXpG" id="4KreBtcydFd" role="2OqNvi">
+                                                      <ref role="2Oxat5" to="zn9m:~Pair.second" resolve="second" />
+                                                    </node>
+                                                  </node>
+                                                </node>
+                                                <node concept="liA8E" id="4XPt_HawCWO" role="2OqNvi">
+                                                  <ref role="37wK5l" to="mhbf:~SModel.getReference()" resolve="getReference" />
+                                                </node>
                                               </node>
-                                              <node concept="2OwXpG" id="4KreBtcydFd" role="2OqNvi">
-                                                <ref role="2Oxat5" to="zn9m:~Pair.second" resolve="second" />
+                                              <node concept="liA8E" id="4XPt_HawHe5" role="2OqNvi">
+                                                <ref role="37wK5l" to="wyt6:~Object.toString()" resolve="toString" />
                                               </node>
                                             </node>
                                           </node>
@@ -3955,12 +3967,22 @@
                                           </node>
                                           <node concept="2r$n1x" id="4KreBtcyo_R" role="2r_Bvh">
                                             <ref role="2r$qp6" to="qqy:3ghOW5H_ihW" resolve="location" />
-                                            <node concept="2OqwBi" id="4KreBtcyo_T" role="2r_lH1">
-                                              <node concept="37vLTw" id="4KreBtcyo_U" role="2Oq$k0">
-                                                <ref role="3cqZAo" node="4KreBtcyoA3" resolve="it" />
+                                            <node concept="2OqwBi" id="4XPt_HawMmY" role="2r_lH1">
+                                              <node concept="2OqwBi" id="4XPt_HawJrJ" role="2Oq$k0">
+                                                <node concept="2OqwBi" id="4KreBtcyo_T" role="2Oq$k0">
+                                                  <node concept="37vLTw" id="4KreBtcyo_U" role="2Oq$k0">
+                                                    <ref role="3cqZAo" node="4KreBtcyoA3" resolve="it" />
+                                                  </node>
+                                                  <node concept="2OwXpG" id="4KreBtcyo_V" role="2OqNvi">
+                                                    <ref role="2Oxat5" to="zn9m:~Pair.second" resolve="second" />
+                                                  </node>
+                                                </node>
+                                                <node concept="liA8E" id="4XPt_HawLm2" role="2OqNvi">
+                                                  <ref role="37wK5l" to="lui2:~SModule.getModuleReference()" resolve="getModuleReference" />
+                                                </node>
                                               </node>
-                                              <node concept="2OwXpG" id="4KreBtcyo_V" role="2OqNvi">
-                                                <ref role="2Oxat5" to="zn9m:~Pair.second" resolve="second" />
+                                              <node concept="liA8E" id="4XPt_HawOxY" role="2OqNvi">
+                                                <ref role="37wK5l" to="wyt6:~Object.toString()" resolve="toString" />
                                               </node>
                                             </node>
                                           </node>

--- a/code/languages/org.mpsqa.lint/languages/org.mpsqa.lint.generic/models/org.mpsqa.lint.generic.typesystem.mps
+++ b/code/languages/org.mpsqa.lint/languages/org.mpsqa.lint.generic/models/org.mpsqa.lint.generic.typesystem.mps
@@ -280,6 +280,20 @@
       <concept id="1196350785113" name="jetbrains.mps.lang.quotation.structure.Quotation" flags="nn" index="2c44tf">
         <child id="1196350785114" name="quotedNode" index="2c44tc" />
       </concept>
+      <concept id="5455284157993911077" name="jetbrains.mps.lang.quotation.structure.NodeBuilderInitProperty" flags="ng" index="2pJxcG">
+        <reference id="5455284157993911078" name="property" index="2pJxcJ" />
+        <child id="1595412875168045201" name="initValue" index="28ntcv" />
+      </concept>
+      <concept id="5455284157993863837" name="jetbrains.mps.lang.quotation.structure.NodeBuilder" flags="nn" index="2pJPEk">
+        <child id="5455284157993863838" name="quotedNode" index="2pJPEn" />
+      </concept>
+      <concept id="5455284157993863840" name="jetbrains.mps.lang.quotation.structure.NodeBuilderNode" flags="nn" index="2pJPED">
+        <reference id="5455284157993910961" name="concept" index="2pJxaS" />
+        <child id="5455284157993911099" name="values" index="2pJxcM" />
+      </concept>
+      <concept id="6985522012210254362" name="jetbrains.mps.lang.quotation.structure.NodeBuilderPropertyExpression" flags="nn" index="WxPPo">
+        <child id="6985522012210254363" name="expression" index="WxPPp" />
+      </concept>
     </language>
     <language id="446c26eb-2b7b-4bf0-9b35-f83fa582753e" name="jetbrains.mps.lang.modelapi">
       <concept id="4733039728785194814" name="jetbrains.mps.lang.modelapi.structure.NamedNodeReference" flags="ng" index="ZC_QK">
@@ -1244,6 +1258,53 @@
             </node>
           </node>
         </node>
+        <node concept="3cpWs8" id="106MO2l7ZVO" role="3cqZAp">
+          <node concept="3cpWsn" id="106MO2l7ZVP" role="3cpWs9">
+            <property role="TrG5h" value="resultEntry" />
+            <node concept="3Tqbb2" id="106MO2l7Wg9" role="1tU5fm">
+              <ref role="ehGHo" to="a1af:6gY6GEDvQYS" resolve="ResultEntry" />
+            </node>
+            <node concept="2pJPEk" id="106MO2l7ZVQ" role="33vP2m">
+              <node concept="2pJPED" id="106MO2l7ZVR" role="2pJPEn">
+                <ref role="2pJxaS" to="a1af:6gY6GEDvQYS" resolve="ResultEntry" />
+                <node concept="2pJxcG" id="106MO2l7ZVS" role="2pJxcM">
+                  <ref role="2pJxcJ" to="a1af:2I_DQhwrOw" resolve="resultLocation" />
+                  <node concept="WxPPo" id="106MO2l7ZVT" role="28ntcv">
+                    <node concept="2OqwBi" id="106MO2l7ZVU" role="WxPPp">
+                      <node concept="2OqwBi" id="106MO2l7ZVV" role="2Oq$k0">
+                        <node concept="37vLTw" id="106MO2l7ZVW" role="2Oq$k0">
+                          <ref role="3cqZAo" node="ST9rMmWlmc" resolve="res" />
+                        </node>
+                        <node concept="2sxana" id="106MO2l7ZVX" role="2OqNvi">
+                          <ref role="2sxfKC" to="qqy:3ghOW5H_ihW" resolve="location" />
+                        </node>
+                      </node>
+                      <node concept="liA8E" id="106MO2l7ZVY" role="2OqNvi">
+                        <ref role="37wK5l" to="wyt6:~Object.toString()" resolve="toString" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="106MO2l7QH8" role="3cqZAp">
+          <node concept="3cpWsn" id="106MO2l7QHb" role="3cpWs9">
+            <property role="TrG5h" value="location" />
+            <node concept="3uibUv" id="106MO2l7RmX" role="1tU5fm">
+              <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
+            </node>
+            <node concept="2OqwBi" id="106MO2l80Ij" role="33vP2m">
+              <node concept="37vLTw" id="106MO2l7ZVZ" role="2Oq$k0">
+                <ref role="3cqZAo" node="106MO2l7ZVP" resolve="resultEntry" />
+              </node>
+              <node concept="2qgKlT" id="106MO2l814J" role="2OqNvi">
+                <ref role="37wK5l" to="b659:4XPt_HaECXY" resolve="convertLocationToObject" />
+              </node>
+            </node>
+          </node>
+        </node>
         <node concept="3clFbJ" id="3hskWvhsAt4" role="3cqZAp">
           <node concept="3clFbS" id="3hskWvhsAt6" role="3clFbx">
             <node concept="3clFbJ" id="1BlvkgWl8X6" role="3cqZAp">
@@ -1259,20 +1320,15 @@
                         <node concept="1eOMI4" id="1BlvkgWnbK9" role="2Oq$k0">
                           <node concept="10QFUN" id="1BlvkgWnbK6" role="1eOMHV">
                             <node concept="3uibUv" id="1BlvkgWndRG" role="10QFUM">
-                              <ref role="3uigEE" to="lui2:~SModule" resolve="SModule" />
+                              <ref role="3uigEE" to="lui2:~SModuleReference" resolve="SModuleReference" />
                             </node>
-                            <node concept="2OqwBi" id="1BlvkgWnfSm" role="10QFUP">
-                              <node concept="37vLTw" id="1BlvkgWnfSn" role="2Oq$k0">
-                                <ref role="3cqZAo" node="ST9rMmWlmc" resolve="res" />
-                              </node>
-                              <node concept="2sxana" id="1BlvkgWnfSo" role="2OqNvi">
-                                <ref role="2sxfKC" to="qqy:3ghOW5H_ihW" resolve="location" />
-                              </node>
+                            <node concept="37vLTw" id="106MO2l7Ts8" role="10QFUP">
+                              <ref role="3cqZAo" node="106MO2l7QHb" resolve="location" />
                             </node>
                           </node>
                         </node>
                         <node concept="liA8E" id="1BlvkgWnvPD" role="2OqNvi">
-                          <ref role="37wK5l" to="lui2:~SModule.getModuleName()" resolve="getModuleName" />
+                          <ref role="37wK5l" to="lui2:~SModuleReference.getModuleName()" resolve="getModuleName" />
                         </node>
                       </node>
                     </node>
@@ -1294,15 +1350,10 @@
               </node>
               <node concept="2ZW3vV" id="1BlvkgWloLC" role="3clFbw">
                 <node concept="3uibUv" id="1BlvkgWlqV2" role="2ZW6by">
-                  <ref role="3uigEE" to="lui2:~SModule" resolve="SModule" />
+                  <ref role="3uigEE" to="lui2:~SModuleReference" resolve="SModuleReference" />
                 </node>
-                <node concept="2OqwBi" id="1BlvkgWlc14" role="2ZW6bz">
-                  <node concept="37vLTw" id="1BlvkgWlb3x" role="2Oq$k0">
-                    <ref role="3cqZAo" node="ST9rMmWlmc" resolve="res" />
-                  </node>
-                  <node concept="2sxana" id="1BlvkgWleLL" role="2OqNvi">
-                    <ref role="2sxfKC" to="qqy:3ghOW5H_ihW" resolve="location" />
-                  </node>
+                <node concept="37vLTw" id="106MO2l7SGm" role="2ZW6bz">
+                  <ref role="3cqZAo" node="106MO2l7QHb" resolve="location" />
                 </node>
               </node>
               <node concept="3eNFk2" id="1BlvkgWmG6R" role="3eNLev">
@@ -1313,25 +1364,25 @@
                         <ref role="3cqZAo" node="3hskWvhsmDv" resolve="messageBuilder" />
                       </node>
                       <node concept="liA8E" id="1BlvkgWnmMG" role="2OqNvi">
-                        <ref role="37wK5l" to="wyt6:~StringBuilder.append(java.lang.Object)" resolve="append" />
-                        <node concept="2OqwBi" id="1BlvkgWnmMH" role="37wK5m">
-                          <node concept="1eOMI4" id="1BlvkgWnmMI" role="2Oq$k0">
-                            <node concept="10QFUN" id="1BlvkgWnmMJ" role="1eOMHV">
-                              <node concept="3uibUv" id="1BlvkgWnmMK" role="10QFUM">
-                                <ref role="3uigEE" to="mhbf:~SModel" resolve="SModel" />
-                              </node>
-                              <node concept="2OqwBi" id="1BlvkgWnmML" role="10QFUP">
-                                <node concept="37vLTw" id="1BlvkgWnmMM" role="2Oq$k0">
-                                  <ref role="3cqZAo" node="ST9rMmWlmc" resolve="res" />
+                        <ref role="37wK5l" to="wyt6:~StringBuilder.append(java.lang.String)" resolve="append" />
+                        <node concept="2OqwBi" id="106MO2l8VPg" role="37wK5m">
+                          <node concept="2OqwBi" id="1BlvkgWnmMH" role="2Oq$k0">
+                            <node concept="1eOMI4" id="1BlvkgWnmMI" role="2Oq$k0">
+                              <node concept="10QFUN" id="1BlvkgWnmMJ" role="1eOMHV">
+                                <node concept="3uibUv" id="1BlvkgWnmMK" role="10QFUM">
+                                  <ref role="3uigEE" to="mhbf:~SModelReference" resolve="SModelReference" />
                                 </node>
-                                <node concept="2sxana" id="1BlvkgWnmMN" role="2OqNvi">
-                                  <ref role="2sxfKC" to="qqy:3ghOW5H_ihW" resolve="location" />
+                                <node concept="37vLTw" id="106MO2l97Nr" role="10QFUP">
+                                  <ref role="3cqZAo" node="106MO2l7QHb" resolve="location" />
                                 </node>
                               </node>
                             </node>
+                            <node concept="liA8E" id="1BlvkgWnmMO" role="2OqNvi">
+                              <ref role="37wK5l" to="mhbf:~SModelReference.getName()" resolve="getName" />
+                            </node>
                           </node>
-                          <node concept="liA8E" id="1BlvkgWnmMO" role="2OqNvi">
-                            <ref role="37wK5l" to="mhbf:~SModel.getName()" resolve="getName" />
+                          <node concept="liA8E" id="106MO2l8Wbi" role="2OqNvi">
+                            <ref role="37wK5l" to="mhbf:~SModelName.toString()" resolve="toString" />
                           </node>
                         </node>
                       </node>
@@ -1353,15 +1404,10 @@
                 </node>
                 <node concept="2ZW3vV" id="1BlvkgWl_gt" role="3eO9$A">
                   <node concept="3uibUv" id="1BlvkgWl_gu" role="2ZW6by">
-                    <ref role="3uigEE" to="mhbf:~SModel" resolve="SModel" />
+                    <ref role="3uigEE" to="mhbf:~SModelReference" resolve="SModelReference" />
                   </node>
-                  <node concept="2OqwBi" id="1BlvkgWl_gv" role="2ZW6bz">
-                    <node concept="37vLTw" id="1BlvkgWl_gw" role="2Oq$k0">
-                      <ref role="3cqZAo" node="ST9rMmWlmc" resolve="res" />
-                    </node>
-                    <node concept="2sxana" id="1BlvkgWl_gx" role="2OqNvi">
-                      <ref role="2sxfKC" to="qqy:3ghOW5H_ihW" resolve="location" />
-                    </node>
+                  <node concept="37vLTw" id="106MO2l7UbN" role="2ZW6bz">
+                    <ref role="3cqZAo" node="106MO2l7QHb" resolve="location" />
                   </node>
                 </node>
               </node>
@@ -1374,13 +1420,8 @@
                       </node>
                       <node concept="liA8E" id="3hskWvhsEfi" role="2OqNvi">
                         <ref role="37wK5l" to="wyt6:~StringBuilder.append(java.lang.Object)" resolve="append" />
-                        <node concept="2OqwBi" id="3hskWvhsFi2" role="37wK5m">
-                          <node concept="37vLTw" id="3hskWvhsEm8" role="2Oq$k0">
-                            <ref role="3cqZAo" node="ST9rMmWlmc" resolve="res" />
-                          </node>
-                          <node concept="2sxana" id="3hskWvhsG0D" role="2OqNvi">
-                            <ref role="2sxfKC" to="qqy:3ghOW5H_ihW" resolve="location" />
-                          </node>
+                        <node concept="37vLTw" id="106MO2l98uS" role="37wK5m">
+                          <ref role="3cqZAo" node="106MO2l7QHb" resolve="location" />
                         </node>
                       </node>
                     </node>
@@ -1404,13 +1445,8 @@
           </node>
           <node concept="3y3z36" id="3hskWvhsD4p" role="3clFbw">
             <node concept="10Nm6u" id="3hskWvhsDew" role="3uHU7w" />
-            <node concept="2OqwBi" id="3hskWvhsC7a" role="3uHU7B">
-              <node concept="37vLTw" id="3hskWvhsBHb" role="2Oq$k0">
-                <ref role="3cqZAo" node="ST9rMmWlmc" resolve="res" />
-              </node>
-              <node concept="2sxana" id="3hskWvhsCNk" role="2OqNvi">
-                <ref role="2sxfKC" to="qqy:3ghOW5H_ihW" resolve="location" />
-              </node>
+            <node concept="37vLTw" id="106MO2l7S7e" role="3uHU7B">
+              <ref role="3cqZAo" node="106MO2l7QHb" resolve="location" />
             </node>
           </node>
         </node>

--- a/code/languages/org.mpsqa.lint/languages/org.mpsqa.lint.generic/models/org.mpsqa.lint.generic.typesystem.mps
+++ b/code/languages/org.mpsqa.lint/languages/org.mpsqa.lint.generic/models/org.mpsqa.lint.generic.typesystem.mps
@@ -46,6 +46,7 @@
     <import index="tp25" ref="r:00000000-0000-4000-0000-011c89590301(jetbrains.mps.lang.smodel.structure)" />
     <import index="xlb7" ref="r:cf42fd0a-68d2-493b-8b77-961658617704(jetbrains.mps.lang.modelapi.behavior)" />
     <import index="4o98" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.core.platform(MPS.Core/)" />
+    <import index="9w4s" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.util(MPS.IDEA/)" />
     <import index="wyuk" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.components(MPS.Core/)" implicit="true" />
     <import index="tpcu" ref="r:00000000-0000-4000-0000-011c89590282(jetbrains.mps.lang.core.behavior)" implicit="true" />
   </imports>
@@ -2951,12 +2952,11 @@
                                   </node>
                                   <node concept="liA8E" id="6EiPrTPFOXT" role="2OqNvi">
                                     <ref role="37wK5l" to="wyt6:~StringBuilder.append(java.lang.String)" resolve="append" />
-                                    <node concept="2OqwBi" id="6EiPrTPFS8h" role="37wK5m">
-                                      <node concept="37vLTw" id="6EiPrTPFRso" role="2Oq$k0">
+                                    <node concept="2YIFZM" id="4XPt_HaWEc$" role="37wK5m">
+                                      <ref role="37wK5l" to="9w4s:~ExceptionUtil.getMessage(java.lang.Throwable)" resolve="getMessage" />
+                                      <ref role="1Pybhc" to="9w4s:~ExceptionUtil" resolve="ExceptionUtil" />
+                                      <node concept="37vLTw" id="4XPt_HaWFKU" role="37wK5m">
                                         <ref role="3cqZAo" node="fofa_o7AcY" resolve="ex" />
-                                      </node>
-                                      <node concept="liA8E" id="6EiPrTPFSMa" role="2OqNvi">
-                                        <ref role="37wK5l" to="wyt6:~Throwable.getMessage()" resolve="getMessage" />
                                       </node>
                                     </node>
                                   </node>

--- a/code/languages/org.mpsqa.lint/solutions/org.mpsqa.lint.generic.linters_library/models/org.mpsqa.lint.generic.linters_library.filesystem.mps
+++ b/code/languages/org.mpsqa.lint/solutions/org.mpsqa.lint.generic.linters_library/models/org.mpsqa.lint.generic.linters_library.filesystem.mps
@@ -23,6 +23,8 @@
     <import index="3ju5" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.vfs(MPS.Core/)" />
     <import index="w1kc" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.smodel(MPS.Core/)" />
     <import index="j8aq" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.module(MPS.Core/)" />
+    <import index="18ew" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.util(MPS.Core/)" />
+    <import index="zn9m" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.openapi.util(MPS.IDEA/)" />
     <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" implicit="true" />
   </imports>
   <registry>
@@ -139,6 +141,7 @@
       </concept>
       <concept id="1107535904670" name="jetbrains.mps.baseLanguage.structure.ClassifierType" flags="in" index="3uibUv">
         <reference id="1107535924139" name="classifier" index="3uigEE" />
+        <child id="1109201940907" name="parameter" index="11_B2D" />
       </concept>
       <concept id="1081773326031" name="jetbrains.mps.baseLanguage.structure.BinaryOperation" flags="nn" index="3uHJSO">
         <child id="1081773367579" name="rightExpression" index="3uHU7w" />
@@ -256,11 +259,23 @@
           <node concept="3cpWsn" id="4mUq39YEamm" role="3cpWs9">
             <property role="TrG5h" value="res" />
             <node concept="_YKpA" id="4mUq39YEamf" role="1tU5fm">
-              <node concept="17QB3L" id="4mUq39YEaNC" role="_ZDj9" />
+              <node concept="3uibUv" id="4XPt_HaAEXb" role="_ZDj9">
+                <ref role="3uigEE" to="zn9m:~Pair" resolve="Pair" />
+                <node concept="17QB3L" id="4XPt_HaAJ$c" role="11_B2D" />
+                <node concept="3uibUv" id="4XPt_HaAMo2" role="11_B2D">
+                  <ref role="3uigEE" to="guwi:~File" resolve="File" />
+                </node>
+              </node>
             </node>
             <node concept="2ShNRf" id="4mUq39YEbPZ" role="33vP2m">
-              <node concept="2Jqq0_" id="4mUq39YEcDU" role="2ShVmc">
-                <node concept="17QB3L" id="4mUq39YEddI" role="HW$YZ" />
+              <node concept="2Jqq0_" id="4XPt_HaAHjs" role="2ShVmc">
+                <node concept="3uibUv" id="4XPt_HaAHJO" role="HW$YZ">
+                  <ref role="3uigEE" to="zn9m:~Pair" resolve="Pair" />
+                  <node concept="17QB3L" id="4XPt_HaAOml" role="11_B2D" />
+                  <node concept="3uibUv" id="4XPt_HaAOTJ" role="11_B2D">
+                    <ref role="3uigEE" to="guwi:~File" resolve="File" />
+                  </node>
+                </node>
               </node>
             </node>
           </node>
@@ -338,9 +353,15 @@
                     <ref role="3cqZAo" node="4mUq39YEamm" resolve="res" />
                   </node>
                   <node concept="TSZUe" id="6EiPrTPS7dZ" role="2OqNvi">
-                    <node concept="vsK6v" id="6EiPrTPUBp4" role="25WWJ7">
-                      <node concept="37vLTw" id="6EiPrTPVj5$" role="vsfCu">
-                        <ref role="3cqZAo" node="4mUq39YBw_j" resolve="ioe" />
+                    <node concept="2ShNRf" id="4XPt_HaB7jl" role="25WWJ7">
+                      <node concept="1pGfFk" id="4XPt_HaB8Wf" role="2ShVmc">
+                        <ref role="37wK5l" to="zn9m:~Pair.&lt;init&gt;(java.lang.Object,java.lang.Object)" resolve="Pair" />
+                        <node concept="vsK6v" id="6EiPrTPUBp4" role="37wK5m">
+                          <node concept="37vLTw" id="6EiPrTPVj5$" role="vsfCu">
+                            <ref role="3cqZAo" node="4mUq39YBw_j" resolve="ioe" />
+                          </node>
+                        </node>
+                        <node concept="10Nm6u" id="4XPt_HaB9Qy" role="37wK5m" />
                       </node>
                     </node>
                   </node>
@@ -354,56 +375,69 @@
                 <property role="TrG5h" value="file" />
               </node>
               <node concept="3clFbS" id="4mUq39YE21$" role="2LFqv$">
-                <node concept="3clFbF" id="4mUq39YEd_S" role="3cqZAp">
-                  <node concept="2OqwBi" id="4mUq39YEhxP" role="3clFbG">
-                    <node concept="37vLTw" id="4mUq39YEd_Q" role="2Oq$k0">
+                <node concept="3clFbF" id="4XPt_HaAPtR" role="3cqZAp">
+                  <node concept="2OqwBi" id="4XPt_HaAThm" role="3clFbG">
+                    <node concept="37vLTw" id="4XPt_HaAPtP" role="2Oq$k0">
                       <ref role="3cqZAo" node="4mUq39YEamm" resolve="res" />
                     </node>
-                    <node concept="TSZUe" id="4mUq39YEkBa" role="2OqNvi">
-                      <node concept="3cpWs3" id="4mUq39YDSLq" role="25WWJ7">
-                        <node concept="Xl_RD" id="4mUq39YDSLr" role="3uHU7w">
-                          <property role="Xl_RC" value="KB" />
-                        </node>
-                        <node concept="3cpWs3" id="4mUq39YDSLs" role="3uHU7B">
-                          <node concept="3cpWs3" id="4mUq39YDSLt" role="3uHU7B">
-                            <node concept="3cpWs3" id="4mUq39YDSLu" role="3uHU7B">
-                              <node concept="Xl_RD" id="4mUq39YDSLv" role="3uHU7B">
-                                <property role="Xl_RC" value="File '" />
-                              </node>
-                              <node concept="2OqwBi" id="4mUq39YDSLw" role="3uHU7w">
-                                <node concept="2OqwBi" id="4mUq39YDSLx" role="2Oq$k0">
-                                  <node concept="2OqwBi" id="4mUq39YDSLy" role="2Oq$k0">
-                                    <node concept="liA8E" id="4mUq39YDSLz" role="2OqNvi">
-                                      <ref role="37wK5l" to="eoo2:~Path.relativize(java.nio.file.Path)" resolve="relativize" />
-                                      <node concept="2GrUjf" id="4mUq39YE9xp" role="37wK5m">
-                                        <ref role="2Gs0qQ" node="4mUq39YE21w" resolve="file" />
+                    <node concept="TSZUe" id="4XPt_HaAUWG" role="2OqNvi">
+                      <node concept="2ShNRf" id="4XPt_HaAVeF" role="25WWJ7">
+                        <node concept="1pGfFk" id="4XPt_HaAVF4" role="2ShVmc">
+                          <ref role="37wK5l" to="zn9m:~Pair.&lt;init&gt;(java.lang.Object,java.lang.Object)" resolve="Pair" />
+                          <node concept="3cpWs3" id="4mUq39YDSLq" role="37wK5m">
+                            <node concept="Xl_RD" id="4mUq39YDSLr" role="3uHU7w">
+                              <property role="Xl_RC" value="KB" />
+                            </node>
+                            <node concept="3cpWs3" id="4mUq39YDSLs" role="3uHU7B">
+                              <node concept="3cpWs3" id="4mUq39YDSLt" role="3uHU7B">
+                                <node concept="3cpWs3" id="4mUq39YDSLu" role="3uHU7B">
+                                  <node concept="Xl_RD" id="4mUq39YDSLv" role="3uHU7B">
+                                    <property role="Xl_RC" value="File '" />
+                                  </node>
+                                  <node concept="2OqwBi" id="4mUq39YDSLw" role="3uHU7w">
+                                    <node concept="2OqwBi" id="4mUq39YDSLx" role="2Oq$k0">
+                                      <node concept="2OqwBi" id="4mUq39YDSLy" role="2Oq$k0">
+                                        <node concept="liA8E" id="4mUq39YDSLz" role="2OqNvi">
+                                          <ref role="37wK5l" to="eoo2:~Path.relativize(java.nio.file.Path)" resolve="relativize" />
+                                          <node concept="2GrUjf" id="4mUq39YE9xp" role="37wK5m">
+                                            <ref role="2Gs0qQ" node="4mUq39YE21w" resolve="file" />
+                                          </node>
+                                        </node>
+                                        <node concept="37vLTw" id="4mUq39YDSL_" role="2Oq$k0">
+                                          <ref role="3cqZAo" node="4mUq39YDTMh" resolve="pathOfDirectoryContainingProject" />
+                                        </node>
+                                      </node>
+                                      <node concept="liA8E" id="4mUq39YDSLA" role="2OqNvi">
+                                        <ref role="37wK5l" to="eoo2:~Path.toString()" resolve="toString" />
                                       </node>
                                     </node>
-                                    <node concept="37vLTw" id="4mUq39YDSL_" role="2Oq$k0">
-                                      <ref role="3cqZAo" node="4mUq39YDTMh" resolve="pathOfDirectoryContainingProject" />
+                                    <node concept="liA8E" id="4mUq39YDSLB" role="2OqNvi">
+                                      <ref role="37wK5l" to="wyt6:~String.replace(char,char)" resolve="replace" />
+                                      <node concept="1Xhbcc" id="4mUq39YDSLC" role="37wK5m">
+                                        <property role="1XhdNS" value="\\" />
+                                      </node>
+                                      <node concept="1Xhbcc" id="4mUq39YDSLD" role="37wK5m">
+                                        <property role="1XhdNS" value="/" />
+                                      </node>
                                     </node>
                                   </node>
-                                  <node concept="liA8E" id="4mUq39YDSLA" role="2OqNvi">
-                                    <ref role="37wK5l" to="eoo2:~Path.toString()" resolve="toString" />
-                                  </node>
                                 </node>
-                                <node concept="liA8E" id="4mUq39YDSLB" role="2OqNvi">
-                                  <ref role="37wK5l" to="wyt6:~String.replace(char,char)" resolve="replace" />
-                                  <node concept="1Xhbcc" id="4mUq39YDSLC" role="37wK5m">
-                                    <property role="1XhdNS" value="\\" />
-                                  </node>
-                                  <node concept="1Xhbcc" id="4mUq39YDSLD" role="37wK5m">
-                                    <property role="1XhdNS" value="/" />
-                                  </node>
+                                <node concept="Xl_RD" id="4mUq39YDSLE" role="3uHU7w">
+                                  <property role="Xl_RC" value="' has a size bigger than " />
                                 </node>
                               </node>
-                            </node>
-                            <node concept="Xl_RD" id="4mUq39YDSLE" role="3uHU7w">
-                              <property role="Xl_RC" value="' has a size bigger than " />
+                              <node concept="2j1LYi" id="4mUq39YDT75" role="3uHU7w">
+                                <ref role="2j1LYj" node="pFzydTBLXy" resolve="sizeInKb" />
+                              </node>
                             </node>
                           </node>
-                          <node concept="2j1LYi" id="4mUq39YDT75" role="3uHU7w">
-                            <ref role="2j1LYj" node="pFzydTBLXy" resolve="sizeInKb" />
+                          <node concept="2OqwBi" id="4XPt_HaB5zA" role="37wK5m">
+                            <node concept="2GrUjf" id="4XPt_HaB4hZ" role="2Oq$k0">
+                              <ref role="2Gs0qQ" node="4mUq39YE21w" resolve="file" />
+                            </node>
+                            <node concept="liA8E" id="4XPt_HaB6IO" role="2OqNvi">
+                              <ref role="37wK5l" to="eoo2:~Path.toFile()" resolve="toFile" />
+                            </node>
                           </node>
                         </node>
                       </node>
@@ -424,7 +458,7 @@
           <node concept="1wplmZ" id="4mUq39YMPDU" role="1zxBo6">
             <node concept="3clFbS" id="4mUq39YMPDV" role="1wplMD">
               <node concept="3cpWs6" id="6HKgezSyQlD" role="3cqZAp">
-                <node concept="37vLTw" id="4mUq39YEoy4" role="3cqZAk">
+                <node concept="37vLTw" id="4XPt_HaBwfD" role="3cqZAk">
                   <ref role="3cqZAo" node="4mUq39YEamm" resolve="res" />
                 </node>
               </node>

--- a/code/languages/org.mpsqa.lint/solutions/org.mpsqa.lint.generic.linters_library/models/org.mpsqa.lint.generic.linters_library.filesystem.mps
+++ b/code/languages/org.mpsqa.lint/solutions/org.mpsqa.lint.generic.linters_library/models/org.mpsqa.lint.generic.linters_library.filesystem.mps
@@ -167,9 +167,6 @@
       </concept>
       <concept id="1146644602865" name="jetbrains.mps.baseLanguage.structure.PublicVisibility" flags="nn" index="3Tm1VV" />
       <concept id="1080120340718" name="jetbrains.mps.baseLanguage.structure.AndExpression" flags="nn" index="1Wc70l" />
-      <concept id="1200397529627" name="jetbrains.mps.baseLanguage.structure.CharConstant" flags="nn" index="1Xhbcc">
-        <property id="1200397540847" name="charConstant" index="1XhdNS" />
-      </concept>
       <concept id="1170345865475" name="jetbrains.mps.baseLanguage.structure.AnonymousClass" flags="ig" index="1Y3b0j">
         <reference id="1170346070688" name="classifier" index="1Y3XeK" />
         <child id="1201186121363" name="typeParameter" index="2Ghqu4" />
@@ -389,42 +386,8 @@
                               <property role="Xl_RC" value="KB" />
                             </node>
                             <node concept="3cpWs3" id="4mUq39YDSLs" role="3uHU7B">
-                              <node concept="3cpWs3" id="4mUq39YDSLt" role="3uHU7B">
-                                <node concept="3cpWs3" id="4mUq39YDSLu" role="3uHU7B">
-                                  <node concept="Xl_RD" id="4mUq39YDSLv" role="3uHU7B">
-                                    <property role="Xl_RC" value="File '" />
-                                  </node>
-                                  <node concept="2OqwBi" id="4mUq39YDSLw" role="3uHU7w">
-                                    <node concept="2OqwBi" id="4mUq39YDSLx" role="2Oq$k0">
-                                      <node concept="2OqwBi" id="4mUq39YDSLy" role="2Oq$k0">
-                                        <node concept="liA8E" id="4mUq39YDSLz" role="2OqNvi">
-                                          <ref role="37wK5l" to="eoo2:~Path.relativize(java.nio.file.Path)" resolve="relativize" />
-                                          <node concept="2GrUjf" id="4mUq39YE9xp" role="37wK5m">
-                                            <ref role="2Gs0qQ" node="4mUq39YE21w" resolve="file" />
-                                          </node>
-                                        </node>
-                                        <node concept="37vLTw" id="4mUq39YDSL_" role="2Oq$k0">
-                                          <ref role="3cqZAo" node="4mUq39YDTMh" resolve="pathOfDirectoryContainingProject" />
-                                        </node>
-                                      </node>
-                                      <node concept="liA8E" id="4mUq39YDSLA" role="2OqNvi">
-                                        <ref role="37wK5l" to="eoo2:~Path.toString()" resolve="toString" />
-                                      </node>
-                                    </node>
-                                    <node concept="liA8E" id="4mUq39YDSLB" role="2OqNvi">
-                                      <ref role="37wK5l" to="wyt6:~String.replace(char,char)" resolve="replace" />
-                                      <node concept="1Xhbcc" id="4mUq39YDSLC" role="37wK5m">
-                                        <property role="1XhdNS" value="\\" />
-                                      </node>
-                                      <node concept="1Xhbcc" id="4mUq39YDSLD" role="37wK5m">
-                                        <property role="1XhdNS" value="/" />
-                                      </node>
-                                    </node>
-                                  </node>
-                                </node>
-                                <node concept="Xl_RD" id="4mUq39YDSLE" role="3uHU7w">
-                                  <property role="Xl_RC" value="' has a size bigger than " />
-                                </node>
+                              <node concept="Xl_RD" id="4XPt_HaVOG0" role="3uHU7B">
+                                <property role="Xl_RC" value="File has a size bigger than " />
                               </node>
                               <node concept="2j1LYi" id="4mUq39YDT75" role="3uHU7w">
                                 <ref role="2j1LYj" node="pFzydTBLXy" resolve="sizeInKb" />

--- a/code/languages/org.mpsqa.lint/solutions/org.mpsqa.lint.generic.linters_library/models/org.mpsqa.lint.generic.linters_library.meta.mps
+++ b/code/languages/org.mpsqa.lint/solutions/org.mpsqa.lint.generic.linters_library/models/org.mpsqa.lint.generic.linters_library.meta.mps
@@ -14,6 +14,7 @@
     <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" />
     <import index="z1c3" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.project(MPS.Core/)" />
     <import index="a1af" ref="r:839ac015-7de1-49f3-ac8f-8d7c6d47259d(org.mpsqa.lint.generic.structure)" />
+    <import index="zn9m" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.openapi.util(MPS.IDEA/)" />
   </imports>
   <registry>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
@@ -38,6 +39,9 @@
       <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
         <child id="1068431790190" name="initializer" index="33vP2m" />
       </concept>
+      <concept id="1513279640923991009" name="jetbrains.mps.baseLanguage.structure.IGenericClassCreator" flags="ng" index="366HgL">
+        <property id="1513279640906337053" name="inferTypeParams" index="373rjd" />
+      </concept>
       <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
         <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
       </concept>
@@ -52,7 +56,6 @@
       <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
         <child id="1068581517665" name="statement" index="3cqZAp" />
       </concept>
-      <concept id="1068581242875" name="jetbrains.mps.baseLanguage.structure.PlusExpression" flags="nn" index="3cpWs3" />
       <concept id="1068581242878" name="jetbrains.mps.baseLanguage.structure.ReturnStatement" flags="nn" index="3cpWs6">
         <child id="1068581517676" name="expression" index="3cqZAk" />
       </concept>
@@ -62,6 +65,12 @@
       <concept id="1068581242863" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclaration" flags="nr" index="3cpWsn" />
       <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ng" index="1ndlxa">
         <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
+        <child id="1068499141038" name="actualArgument" index="37wK5m" />
+      </concept>
+      <concept id="1212685548494" name="jetbrains.mps.baseLanguage.structure.ClassCreator" flags="nn" index="1pGfFk" />
+      <concept id="1107535904670" name="jetbrains.mps.baseLanguage.structure.ClassifierType" flags="in" index="3uibUv">
+        <reference id="1107535924139" name="classifier" index="3uigEE" />
+        <child id="1109201940907" name="parameter" index="11_B2D" />
       </concept>
       <concept id="1081773326031" name="jetbrains.mps.baseLanguage.structure.BinaryOperation" flags="nn" index="3uHJSO">
         <child id="1081773367579" name="rightExpression" index="3uHU7w" />
@@ -120,7 +129,6 @@
       <concept id="1145383075378" name="jetbrains.mps.lang.smodel.structure.SNodeListType" flags="in" index="2I9FWS">
         <reference id="1145383142433" name="elementConcept" index="2I9WkF" />
       </concept>
-      <concept id="1212008292747" name="jetbrains.mps.lang.smodel.structure.Model_GetLongNameOperation" flags="nn" index="LkI2h" />
       <concept id="1171323947159" name="jetbrains.mps.lang.smodel.structure.Model_NodesOperation" flags="nn" index="2SmgA7">
         <child id="1758937410080001570" name="conceptArgument" index="1dBWTz" />
       </concept>
@@ -205,11 +213,19 @@
           <node concept="3cpWsn" id="4lfwJVEz_XA" role="3cpWs9">
             <property role="TrG5h" value="res" />
             <node concept="_YKpA" id="4lfwJVEz_XH" role="1tU5fm">
-              <node concept="17QB3L" id="4lfwJVEz_XV" role="_ZDj9" />
+              <node concept="3uibUv" id="4XPt_HaAEXb" role="_ZDj9">
+                <ref role="3uigEE" to="zn9m:~Pair" resolve="Pair" />
+                <node concept="17QB3L" id="4XPt_HaAJ$c" role="11_B2D" />
+                <node concept="3Tqbb2" id="4XPt_HaGVkB" role="11_B2D" />
+              </node>
             </node>
             <node concept="2ShNRf" id="4lfwJVEz_XI" role="33vP2m">
               <node concept="Tc6Ow" id="4lfwJVEz_XW" role="2ShVmc">
-                <node concept="17QB3L" id="4lfwJVEz_Y9" role="HW$YZ" />
+                <node concept="3uibUv" id="4XPt_HaGVSd" role="HW$YZ">
+                  <ref role="3uigEE" to="zn9m:~Pair" resolve="Pair" />
+                  <node concept="17QB3L" id="4XPt_HaGVSe" role="11_B2D" />
+                  <node concept="3Tqbb2" id="4XPt_HaGWmS" role="11_B2D" />
+                </node>
               </node>
             </node>
           </node>
@@ -364,37 +380,15 @@
                   <ref role="3cqZAo" node="4lfwJVEz_XA" resolve="res" />
                 </node>
                 <node concept="TSZUe" id="4lfwJVEz_YP" role="2OqNvi">
-                  <node concept="3cpWs3" id="4lfwJVEz_YT" role="25WWJ7">
-                    <node concept="Xl_RD" id="4lfwJVEz_YV" role="3uHU7w">
-                      <property role="Xl_RC" value="' is not re-used" />
-                    </node>
-                    <node concept="3cpWs3" id="4lfwJVEz_YW" role="3uHU7B">
-                      <node concept="3cpWs3" id="4lfwJVEz_YZ" role="3uHU7B">
-                        <node concept="3cpWs3" id="4lfwJVEz_Z3" role="3uHU7B">
-                          <node concept="Xl_RD" id="4lfwJVEz_Z5" role="3uHU7B">
-                            <property role="Xl_RC" value="Script '" />
-                          </node>
-                          <node concept="2OqwBi" id="4lfwJVEz_Z7" role="3uHU7w">
-                            <node concept="2GrUjf" id="4lfwJVEz_Z9" role="2Oq$k0">
-                              <ref role="2Gs0qQ" node="4lfwJVEz_Y6" resolve="cs" />
-                            </node>
-                            <node concept="3TrcHB" id="4lfwJVE_jzb" role="2OqNvi">
-                              <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
-                            </node>
-                          </node>
-                        </node>
-                        <node concept="Xl_RD" id="4lfwJVEz_Z4" role="3uHU7w">
-                          <property role="Xl_RC" value="' from model '" />
-                        </node>
+                  <node concept="2ShNRf" id="4XPt_HaGX0H" role="25WWJ7">
+                    <node concept="1pGfFk" id="4XPt_HaGXEy" role="2ShVmc">
+                      <property role="373rjd" value="true" />
+                      <ref role="37wK5l" to="zn9m:~Pair.&lt;init&gt;(java.lang.Object,java.lang.Object)" resolve="Pair" />
+                      <node concept="Xl_RD" id="4XPt_HaH1m6" role="37wK5m">
+                        <property role="Xl_RC" value="The Script is not re-used" />
                       </node>
-                      <node concept="2OqwBi" id="4lfwJVE_laT" role="3uHU7w">
-                        <node concept="2OqwBi" id="4lfwJVE_kEp" role="2Oq$k0">
-                          <node concept="2GrUjf" id="4lfwJVE_kny" role="2Oq$k0">
-                            <ref role="2Gs0qQ" node="4lfwJVEz_Y6" resolve="cs" />
-                          </node>
-                          <node concept="I4A8Y" id="4lfwJVE_kTK" role="2OqNvi" />
-                        </node>
-                        <node concept="LkI2h" id="4lfwJVE_lqX" role="2OqNvi" />
+                      <node concept="2GrUjf" id="4XPt_HaH3ic" role="37wK5m">
+                        <ref role="2Gs0qQ" node="4lfwJVEz_Y6" resolve="cs" />
                       </node>
                     </node>
                   </node>
@@ -571,11 +565,19 @@
           <node concept="3cpWsn" id="652KpqR3Kkb" role="3cpWs9">
             <property role="TrG5h" value="res" />
             <node concept="_YKpA" id="652KpqR3Kkc" role="1tU5fm">
-              <node concept="17QB3L" id="652KpqR3Kkd" role="_ZDj9" />
+              <node concept="3uibUv" id="4XPt_HaHj$M" role="_ZDj9">
+                <ref role="3uigEE" to="zn9m:~Pair" resolve="Pair" />
+                <node concept="17QB3L" id="4XPt_HaHj$N" role="11_B2D" />
+                <node concept="3Tqbb2" id="4XPt_HaHj$O" role="11_B2D" />
+              </node>
             </node>
             <node concept="2ShNRf" id="652KpqR3Kke" role="33vP2m">
               <node concept="Tc6Ow" id="652KpqR3Kkf" role="2ShVmc">
-                <node concept="17QB3L" id="652KpqR3Kkg" role="HW$YZ" />
+                <node concept="3uibUv" id="4XPt_HaHk85" role="HW$YZ">
+                  <ref role="3uigEE" to="zn9m:~Pair" resolve="Pair" />
+                  <node concept="17QB3L" id="4XPt_HaHk86" role="11_B2D" />
+                  <node concept="3Tqbb2" id="4XPt_HaHk87" role="11_B2D" />
+                </node>
               </node>
             </node>
           </node>
@@ -658,37 +660,15 @@
                   <ref role="3cqZAo" node="652KpqR3Kkb" resolve="res" />
                 </node>
                 <node concept="TSZUe" id="652KpqR3Kln" role="2OqNvi">
-                  <node concept="3cpWs3" id="652KpqR3Klo" role="25WWJ7">
-                    <node concept="Xl_RD" id="652KpqR3Klp" role="3uHU7w">
-                      <property role="Xl_RC" value="' is skipped" />
-                    </node>
-                    <node concept="3cpWs3" id="652KpqR3Klq" role="3uHU7B">
-                      <node concept="3cpWs3" id="652KpqR3Klr" role="3uHU7B">
-                        <node concept="3cpWs3" id="652KpqR3Kls" role="3uHU7B">
-                          <node concept="Xl_RD" id="652KpqR3Klt" role="3uHU7B">
-                            <property role="Xl_RC" value="Evaluation of the script '" />
-                          </node>
-                          <node concept="2OqwBi" id="652KpqR3Klu" role="3uHU7w">
-                            <node concept="2GrUjf" id="652KpqR3Klv" role="2Oq$k0">
-                              <ref role="2Gs0qQ" node="652KpqR3Klh" resolve="script" />
-                            </node>
-                            <node concept="3TrcHB" id="652KpqR3Klw" role="2OqNvi">
-                              <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
-                            </node>
-                          </node>
-                        </node>
-                        <node concept="Xl_RD" id="652KpqR3Klx" role="3uHU7w">
-                          <property role="Xl_RC" value="' from model '" />
-                        </node>
+                  <node concept="2ShNRf" id="4XPt_HaHkQ4" role="25WWJ7">
+                    <node concept="1pGfFk" id="4XPt_HaHlaO" role="2ShVmc">
+                      <property role="373rjd" value="true" />
+                      <ref role="37wK5l" to="zn9m:~Pair.&lt;init&gt;(java.lang.Object,java.lang.Object)" resolve="Pair" />
+                      <node concept="Xl_RD" id="4XPt_HaHoYo" role="37wK5m">
+                        <property role="Xl_RC" value="Evaluation of the script is skipped" />
                       </node>
-                      <node concept="2OqwBi" id="652KpqR3Kly" role="3uHU7w">
-                        <node concept="2OqwBi" id="652KpqR3Klz" role="2Oq$k0">
-                          <node concept="2GrUjf" id="652KpqR3Kl$" role="2Oq$k0">
-                            <ref role="2Gs0qQ" node="652KpqR3Klh" resolve="script" />
-                          </node>
-                          <node concept="I4A8Y" id="652KpqR3Kl_" role="2OqNvi" />
-                        </node>
-                        <node concept="LkI2h" id="652KpqR3KlA" role="2OqNvi" />
+                      <node concept="2GrUjf" id="4XPt_HaHn26" role="37wK5m">
+                        <ref role="2Gs0qQ" node="652KpqR3Klh" resolve="script" />
                       </node>
                     </node>
                   </node>

--- a/code/languages/org.mpsqa.lint/solutions/org.mpsqa.lint.generic.linters_library/models/org.mpsqa.lint.generic.linters_library.models.mps
+++ b/code/languages/org.mpsqa.lint/solutions/org.mpsqa.lint.generic.linters_library/models/org.mpsqa.lint.generic.linters_library.models.mps
@@ -61,9 +61,6 @@
       <concept id="1188208481402" name="jetbrains.mps.baseLanguage.structure.HasAnnotation" flags="ng" index="2AJDlI">
         <child id="1188208488637" name="annotation" index="2AJF6D" />
       </concept>
-      <concept id="2820489544401957797" name="jetbrains.mps.baseLanguage.structure.DefaultClassCreator" flags="nn" index="HV5vD">
-        <reference id="2820489544401957798" name="classifier" index="HV5vE" />
-      </concept>
       <concept id="1154032098014" name="jetbrains.mps.baseLanguage.structure.AbstractLoopStatement" flags="nn" index="2LF5Ji">
         <child id="1154032183016" name="body" index="2LFqv$" />
       </concept>
@@ -3080,8 +3077,8 @@
                   <ref role="37wK5l" to="wsw7:6nj_ILmBNrL" resolve="ModelCheckerBuilder" />
                   <node concept="2OqwBi" id="34euvBSCHBI" role="37wK5m">
                     <node concept="2ShNRf" id="6nj_ILmBUsN" role="2Oq$k0">
-                      <node concept="HV5vD" id="107f053Tj_z" role="2ShVmc">
-                        <ref role="HV5vE" to="wsw7:7X3$Ctw7ww1" resolve="ModelCheckerBuilder.ModelsExtractorImpl" />
+                      <node concept="1pGfFk" id="4XPt_HaEvW0" role="2ShVmc">
+                        <ref role="37wK5l" to="wsw7:6pnunaLnyyn" resolve="ModelCheckerBuilder.ModelsExtractorImpl" />
                       </node>
                     </node>
                     <node concept="liA8E" id="34euvBSCHOa" role="2OqNvi">

--- a/code/languages/org.mpsqa.lint/solutions/org.mpsqa.lint.generic.linters_library/models/org.mpsqa.lint.generic.linters_library.modules.mps
+++ b/code/languages/org.mpsqa.lint/solutions/org.mpsqa.lint.generic.linters_library/models/org.mpsqa.lint.generic.linters_library.modules.mps
@@ -34,6 +34,7 @@
     <import index="ovw5" ref="r:c20826af-2893-4d29-904e-89e5161f5716(org.mpsqa.lint.generic.linters_library.quickfixes.typesystem)" />
     <import index="dush" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.persistence(MPS.OpenAPI/)" />
     <import index="mhfm" ref="3f233e7f-b8a6-46d2-a57f-795d56775243/java:org.jetbrains.annotations(Annotations/)" />
+    <import index="zn9m" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.openapi.util(MPS.IDEA/)" />
   </imports>
   <registry>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
@@ -1113,11 +1114,23 @@
           <node concept="3cpWsn" id="3$9W3co2XpN" role="3cpWs9">
             <property role="TrG5h" value="res" />
             <node concept="_YKpA" id="3$9W3co2XpO" role="1tU5fm">
-              <node concept="17QB3L" id="3$9W3co2XpP" role="_ZDj9" />
+              <node concept="3uibUv" id="4XPt_HaJtRV" role="_ZDj9">
+                <ref role="3uigEE" to="zn9m:~Pair" resolve="Pair" />
+                <node concept="17QB3L" id="4XPt_HaJx2g" role="11_B2D" />
+                <node concept="3uibUv" id="4XPt_HaJyHF" role="11_B2D">
+                  <ref role="3uigEE" to="guwi:~File" resolve="File" />
+                </node>
+              </node>
             </node>
             <node concept="2ShNRf" id="3$9W3co2XpQ" role="33vP2m">
               <node concept="Tc6Ow" id="3$9W3co2XpR" role="2ShVmc">
-                <node concept="17QB3L" id="3$9W3co2XpS" role="HW$YZ" />
+                <node concept="3uibUv" id="4XPt_HaJzzC" role="HW$YZ">
+                  <ref role="3uigEE" to="zn9m:~Pair" resolve="Pair" />
+                  <node concept="17QB3L" id="4XPt_HaJzzD" role="11_B2D" />
+                  <node concept="3uibUv" id="4XPt_HaJzzE" role="11_B2D">
+                    <ref role="3uigEE" to="guwi:~File" resolve="File" />
+                  </node>
+                </node>
               </node>
             </node>
           </node>
@@ -1177,9 +1190,16 @@
                             <ref role="3cqZAo" node="3$9W3co2XpN" resolve="res" />
                           </node>
                           <node concept="TSZUe" id="6EiPrTQlhMO" role="2OqNvi">
-                            <node concept="vsK6v" id="6EiPrTQlebW" role="25WWJ7">
-                              <node concept="37vLTw" id="6EiPrTQljH4" role="vsfCu">
-                                <ref role="3cqZAo" node="3$9W3co6X7n" resolve="ioe" />
+                            <node concept="2ShNRf" id="4XPt_HaJ_b6" role="25WWJ7">
+                              <node concept="1pGfFk" id="4XPt_HaJ_Z0" role="2ShVmc">
+                                <property role="373rjd" value="true" />
+                                <ref role="37wK5l" to="zn9m:~Pair.&lt;init&gt;(java.lang.Object,java.lang.Object)" resolve="Pair" />
+                                <node concept="vsK6v" id="6EiPrTQlebW" role="37wK5m">
+                                  <node concept="37vLTw" id="6EiPrTQljH4" role="vsfCu">
+                                    <ref role="3cqZAo" node="3$9W3co6X7n" resolve="ioe" />
+                                  </node>
+                                </node>
+                                <node concept="10Nm6u" id="4XPt_HaJBch" role="37wK5m" />
                               </node>
                             </node>
                           </node>
@@ -1256,17 +1276,12 @@
                                             <ref role="3cqZAo" node="3$9W3co3U3M" resolve="msdFiles" />
                                           </node>
                                           <node concept="TSZUe" id="3$9W3co6PWq" role="2OqNvi">
-                                            <node concept="2OqwBi" id="3$9W3co6PWr" role="25WWJ7">
-                                              <node concept="2OqwBi" id="3$9W3co6PWs" role="2Oq$k0">
-                                                <node concept="37vLTw" id="3$9W3co6PWt" role="2Oq$k0">
-                                                  <ref role="3cqZAo" node="3$9W3co6PW9" resolve="file" />
-                                                </node>
-                                                <node concept="liA8E" id="3$9W3co6PWu" role="2OqNvi">
-                                                  <ref role="37wK5l" to="eoo2:~Path.toFile()" resolve="toFile" />
-                                                </node>
+                                            <node concept="2OqwBi" id="3$9W3co6PWs" role="25WWJ7">
+                                              <node concept="37vLTw" id="3$9W3co6PWt" role="2Oq$k0">
+                                                <ref role="3cqZAo" node="3$9W3co6PW9" resolve="file" />
                                               </node>
-                                              <node concept="liA8E" id="3$9W3co6PWv" role="2OqNvi">
-                                                <ref role="37wK5l" to="guwi:~File.getName()" resolve="getName" />
+                                              <node concept="liA8E" id="4XPt_HaJrH0" role="2OqNvi">
+                                                <ref role="37wK5l" to="eoo2:~Path.toString()" resolve="toString" />
                                               </node>
                                             </node>
                                           </node>
@@ -1387,7 +1402,7 @@
                               <ref role="3cqZAo" node="3$9W3co506w" resolve="descriptorFile" />
                             </node>
                             <node concept="liA8E" id="3$9W3co5$SS" role="2OqNvi">
-                              <ref role="37wK5l" to="3ju5:~IFile.getName()" resolve="getName" />
+                              <ref role="37wK5l" to="3ju5:~IFile.toRealPath()" resolve="toRealPath" />
                             </node>
                           </node>
                         </node>
@@ -1452,17 +1467,32 @@
                   <ref role="3cqZAo" node="3$9W3co2XpN" resolve="res" />
                 </node>
                 <node concept="TSZUe" id="3$9W3co5IH_" role="2OqNvi">
-                  <node concept="3cpWs3" id="3$9W3co5IHB" role="25WWJ7">
-                    <node concept="3cpWs3" id="3$9W3co5IHC" role="3uHU7B">
-                      <node concept="Xl_RD" id="3$9W3co5IHD" role="3uHU7B">
-                        <property role="Xl_RC" value="Module with file '" />
+                  <node concept="2ShNRf" id="4XPt_HaJCnv" role="25WWJ7">
+                    <node concept="1pGfFk" id="4XPt_HaJDgs" role="2ShVmc">
+                      <property role="373rjd" value="true" />
+                      <ref role="37wK5l" to="zn9m:~Pair.&lt;init&gt;(java.lang.Object,java.lang.Object)" resolve="Pair" />
+                      <node concept="3cpWs3" id="3$9W3co5IHB" role="37wK5m">
+                        <node concept="3cpWs3" id="3$9W3co5IHC" role="3uHU7B">
+                          <node concept="Xl_RD" id="3$9W3co5IHD" role="3uHU7B">
+                            <property role="Xl_RC" value="Module with file '" />
+                          </node>
+                          <node concept="2GrUjf" id="3$9W3co5KNi" role="3uHU7w">
+                            <ref role="2Gs0qQ" node="3$9W3co5Baw" resolve="fileNotInProject" />
+                          </node>
+                        </node>
+                        <node concept="Xl_RD" id="3$9W3co5IHH" role="3uHU7w">
+                          <property role="Xl_RC" value="' is located in project directory but it is not part of the project" />
+                        </node>
                       </node>
-                      <node concept="2GrUjf" id="3$9W3co5KNi" role="3uHU7w">
-                        <ref role="2Gs0qQ" node="3$9W3co5Baw" resolve="fileNotInProject" />
+                      <node concept="2ShNRf" id="4XPt_HaJHqF" role="37wK5m">
+                        <node concept="1pGfFk" id="4XPt_HaJItk" role="2ShVmc">
+                          <property role="373rjd" value="true" />
+                          <ref role="37wK5l" to="guwi:~File.&lt;init&gt;(java.lang.String)" resolve="File" />
+                          <node concept="2GrUjf" id="4XPt_HaJJ5O" role="37wK5m">
+                            <ref role="2Gs0qQ" node="3$9W3co5Baw" resolve="fileNotInProject" />
+                          </node>
+                        </node>
                       </node>
-                    </node>
-                    <node concept="Xl_RD" id="3$9W3co5IHH" role="3uHU7w">
-                      <property role="Xl_RC" value="' is located in project directory but it is not part of the project" />
                     </node>
                   </node>
                 </node>
@@ -2517,7 +2547,7 @@
                   <node concept="3cpWs3" id="7XOuq5ggEQm" role="3uHU7B">
                     <node concept="3cpWs3" id="7XOuq5ggEcZ" role="3uHU7B">
                       <node concept="Xl_RD" id="7XOuq5ggDqX" role="3uHU7B">
-                        <property role="Xl_RC" value="too many cyclic dependencies with length " />
+                        <property role="Xl_RC" value="Too many cyclic dependencies with length " />
                       </node>
                       <node concept="2j1LYi" id="7XOuq5ggEtO" role="3uHU7w">
                         <ref role="2j1LYj" node="47tbZooQUks" resolve="cycleLength" />
@@ -3053,21 +3083,8 @@
                           <property role="Xl_RC" value="' (some plugins might not be loaded)" />
                         </node>
                         <node concept="3cpWs3" id="6WYDruH6tDs" role="3uHU7B">
-                          <node concept="3cpWs3" id="6WYDruH6rp6" role="3uHU7B">
-                            <node concept="3cpWs3" id="6WYDruH6peB" role="3uHU7B">
-                              <node concept="Xl_RD" id="6WYDruH6oWM" role="3uHU7B">
-                                <property role="Xl_RC" value="Module '" />
-                              </node>
-                              <node concept="2OqwBi" id="6WYDruH6pvY" role="3uHU7w">
-                                <node concept="2vlQn3" id="2zdrQh74hCT" role="2Oq$k0" />
-                                <node concept="liA8E" id="6WYDruH6qBp" role="2OqNvi">
-                                  <ref role="37wK5l" to="lui2:~SModule.getModuleName()" resolve="getModuleName" />
-                                </node>
-                              </node>
-                            </node>
-                            <node concept="Xl_RD" id="6WYDruH6rpo" role="3uHU7w">
-                              <property role="Xl_RC" value="' uses unknown language '" />
-                            </node>
+                          <node concept="Xl_RD" id="4XPt_HaKh4T" role="3uHU7B">
+                            <property role="Xl_RC" value="Module uses unknown language '" />
                           </node>
                           <node concept="2GrUjf" id="6WYDruH6uij" role="3uHU7w">
                             <ref role="2Gs0qQ" node="52u1lglBbro" resolve="lan" />
@@ -3149,21 +3166,8 @@
                                 <property role="Xl_RC" value=" of the language " />
                               </node>
                               <node concept="3cpWs3" id="52u1lglDrWy" role="3uHU7B">
-                                <node concept="3cpWs3" id="52u1lglB0vr" role="3uHU7B">
-                                  <node concept="3cpWs3" id="52u1lglB0vs" role="3uHU7B">
-                                    <node concept="Xl_RD" id="52u1lglB0vt" role="3uHU7B">
-                                      <property role="Xl_RC" value="Module '" />
-                                    </node>
-                                    <node concept="2OqwBi" id="52u1lglB0vu" role="3uHU7w">
-                                      <node concept="2vlQn3" id="2zdrQh74hZO" role="2Oq$k0" />
-                                      <node concept="liA8E" id="52u1lglB0vw" role="2OqNvi">
-                                        <ref role="37wK5l" to="lui2:~SModule.getModuleName()" resolve="getModuleName" />
-                                      </node>
-                                    </node>
-                                  </node>
-                                  <node concept="Xl_RD" id="52u1lglB0vx" role="3uHU7w">
-                                    <property role="Xl_RC" value="' needs to be migrated to version " />
-                                  </node>
+                                <node concept="Xl_RD" id="4XPt_HaKixf" role="3uHU7B">
+                                  <property role="Xl_RC" value="Module needs to be migrated to version " />
                                 </node>
                                 <node concept="37vLTw" id="52u1lglDshq" role="3uHU7w">
                                   <ref role="3cqZAo" node="RtEeVJVV5h" resolve="languageVersion" />
@@ -5666,11 +5670,23 @@
           <node concept="3cpWsn" id="7CQ_Wpsik_b" role="3cpWs9">
             <property role="TrG5h" value="res" />
             <node concept="_YKpA" id="7CQ_Wpsik_c" role="1tU5fm">
-              <node concept="17QB3L" id="7CQ_Wpsik_d" role="_ZDj9" />
+              <node concept="3uibUv" id="4XPt_HaAEXb" role="_ZDj9">
+                <ref role="3uigEE" to="zn9m:~Pair" resolve="Pair" />
+                <node concept="17QB3L" id="4XPt_HaAJ$c" role="11_B2D" />
+                <node concept="3uibUv" id="4XPt_HaAMo2" role="11_B2D">
+                  <ref role="3uigEE" to="lui2:~SModule" resolve="SModule" />
+                </node>
+              </node>
             </node>
             <node concept="2ShNRf" id="7CQ_Wpsik_e" role="33vP2m">
               <node concept="Tc6Ow" id="7CQ_Wpsik_f" role="2ShVmc">
-                <node concept="17QB3L" id="7CQ_Wpsik_g" role="HW$YZ" />
+                <node concept="3uibUv" id="4XPt_HaHPU8" role="HW$YZ">
+                  <ref role="3uigEE" to="zn9m:~Pair" resolve="Pair" />
+                  <node concept="17QB3L" id="4XPt_HaHPU9" role="11_B2D" />
+                  <node concept="3uibUv" id="4XPt_HaHPUa" role="11_B2D">
+                    <ref role="3uigEE" to="lui2:~SModule" resolve="SModule" />
+                  </node>
+                </node>
               </node>
             </node>
           </node>
@@ -5756,8 +5772,17 @@
                               <ref role="3cqZAo" node="7CQ_Wpsik_b" resolve="res" />
                             </node>
                             <node concept="TSZUe" id="7CQ_WpsiQGk" role="2OqNvi">
-                              <node concept="Xl_RD" id="63CQ8uYFTXw" role="25WWJ7">
-                                <property role="Xl_RC" value="Language is not part of any devkit" />
+                              <node concept="2ShNRf" id="4XPt_HaHSLC" role="25WWJ7">
+                                <node concept="1pGfFk" id="4XPt_HaHT8G" role="2ShVmc">
+                                  <property role="373rjd" value="true" />
+                                  <ref role="37wK5l" to="zn9m:~Pair.&lt;init&gt;(java.lang.Object,java.lang.Object)" resolve="Pair" />
+                                  <node concept="Xl_RD" id="63CQ8uYFTXw" role="37wK5m">
+                                    <property role="Xl_RC" value="Language is not part of any devkit" />
+                                  </node>
+                                  <node concept="2GrUjf" id="4XPt_HaHTpf" role="37wK5m">
+                                    <ref role="2Gs0qQ" node="7CQ_WpsiHw1" resolve="module" />
+                                  </node>
+                                </node>
                               </node>
                             </node>
                           </node>

--- a/code/languages/org.mpsqa.lint/solutions/org.mpsqa.lint.generic.linters_library/models/org.mpsqa.lint.generic.linters_library.nodes.mps
+++ b/code/languages/org.mpsqa.lint/solutions/org.mpsqa.lint.generic.linters_library/models/org.mpsqa.lint.generic.linters_library.nodes.mps
@@ -182,18 +182,12 @@
       <concept id="7453996997717780434" name="jetbrains.mps.lang.smodel.structure.Node_GetSConceptOperation" flags="nn" index="2yIwOk" />
       <concept id="8758390115029295477" name="jetbrains.mps.lang.smodel.structure.SReferenceType" flags="in" index="2z4iKi" />
       <concept id="8758390115028452779" name="jetbrains.mps.lang.smodel.structure.Node_GetReferencesOperation" flags="nn" index="2z74zc" />
-      <concept id="2396822768958367367" name="jetbrains.mps.lang.smodel.structure.AbstractTypeCastExpression" flags="nn" index="$5XWr">
-        <child id="6733348108486823193" name="leftExpression" index="1m5AlR" />
-        <child id="3906496115198199033" name="conceptArgument" index="3oSUPX" />
-      </concept>
       <concept id="1143226024141" name="jetbrains.mps.lang.smodel.structure.SModelType" flags="in" index="H_c77" />
       <concept id="1143234257716" name="jetbrains.mps.lang.smodel.structure.Node_GetModelOperation" flags="nn" index="I4A8Y" />
       <concept id="1145404486709" name="jetbrains.mps.lang.smodel.structure.SemanticDowncastExpression" flags="nn" index="2JrnkZ">
         <child id="1145404616321" name="leftExpression" index="2JrQYb" />
       </concept>
-      <concept id="1212008292747" name="jetbrains.mps.lang.smodel.structure.Model_GetLongNameOperation" flags="nn" index="LkI2h" />
       <concept id="1171305280644" name="jetbrains.mps.lang.smodel.structure.Node_GetDescendantsOperation" flags="nn" index="2Rf3mk" />
-      <concept id="1171310072040" name="jetbrains.mps.lang.smodel.structure.Node_GetContainingRootOperation" flags="nn" index="2Rxl7S" />
       <concept id="1171315804604" name="jetbrains.mps.lang.smodel.structure.Model_RootsOperation" flags="nn" index="2RRcyG">
         <child id="6750920497477046361" name="conceptArgument" index="3MHsoP" />
       </concept>
@@ -213,7 +207,6 @@
         <child id="1207343664468" name="conceptArgument" index="ri$Ld" />
       </concept>
       <concept id="5708036808576088033" name="jetbrains.mps.lang.smodel.structure.Reference_GetResolveInfo" flags="nn" index="1FfNbt" />
-      <concept id="1140137987495" name="jetbrains.mps.lang.smodel.structure.SNodeTypeCastExpression" flags="nn" index="1PxgMI" />
       <concept id="1138055754698" name="jetbrains.mps.lang.smodel.structure.SNodeType" flags="in" index="3Tqbb2" />
       <concept id="1138056022639" name="jetbrains.mps.lang.smodel.structure.SPropertyAccess" flags="nn" index="3TrcHB">
         <reference id="1138056395725" name="property" index="3TsBF5" />
@@ -2116,53 +2109,6 @@
                                   <node concept="3clFbS" id="73he6VT0zyN" role="2LFqv$">
                                     <node concept="3clFbJ" id="73he6VT0_zd" role="3cqZAp">
                                       <node concept="3clFbS" id="73he6VT0_zf" role="3clFbx">
-                                        <node concept="3cpWs8" id="73he6VT0Mnp" role="3cqZAp">
-                                          <node concept="3cpWsn" id="73he6VT0Mns" role="3cpWs9">
-                                            <property role="TrG5h" value="msg" />
-                                            <node concept="17QB3L" id="73he6VT0Mnn" role="1tU5fm" />
-                                            <node concept="3K4zz7" id="73he6VT0MYd" role="33vP2m">
-                                              <node concept="Xl_RD" id="73he6VT0P3r" role="3K4GZi">
-                                                <property role="Xl_RC" value="" />
-                                              </node>
-                                              <node concept="2OqwBi" id="73he6VT0MBQ" role="3K4Cdx">
-                                                <node concept="2OqwBi" id="73he6VT0MBR" role="2Oq$k0">
-                                                  <node concept="2GrUjf" id="73he6VT0MBS" role="2Oq$k0">
-                                                    <ref role="2Gs0qQ" node="73he6VT0y4g" resolve="crtNode" />
-                                                  </node>
-                                                  <node concept="2Rxl7S" id="73he6VT0MBT" role="2OqNvi" />
-                                                </node>
-                                                <node concept="1mIQ4w" id="73he6VT0MBU" role="2OqNvi">
-                                                  <node concept="chp4Y" id="73he6VT0MBV" role="cj9EA">
-                                                    <ref role="cht4Q" to="tpck:h0TrEE$" resolve="INamedConcept" />
-                                                  </node>
-                                                </node>
-                                              </node>
-                                              <node concept="1eOMI4" id="73he6VT0Omo" role="3K4E3e">
-                                                <node concept="3cpWs3" id="73he6VT0O_o" role="1eOMHV">
-                                                  <node concept="Xl_RD" id="73he6VT0ONQ" role="3uHU7B">
-                                                    <property role="Xl_RC" value=" from root node named " />
-                                                  </node>
-                                                  <node concept="2OqwBi" id="73he6VT0NnW" role="3uHU7w">
-                                                    <node concept="1PxgMI" id="73he6VT0NnX" role="2Oq$k0">
-                                                      <node concept="chp4Y" id="73he6VT0NnY" role="3oSUPX">
-                                                        <ref role="cht4Q" to="tpck:h0TrEE$" resolve="INamedConcept" />
-                                                      </node>
-                                                      <node concept="2OqwBi" id="73he6VT0NnZ" role="1m5AlR">
-                                                        <node concept="2GrUjf" id="73he6VT0No0" role="2Oq$k0">
-                                                          <ref role="2Gs0qQ" node="73he6VT0y4g" resolve="crtNode" />
-                                                        </node>
-                                                        <node concept="2Rxl7S" id="73he6VT0No1" role="2OqNvi" />
-                                                      </node>
-                                                    </node>
-                                                    <node concept="3TrcHB" id="73he6VT0No2" role="2OqNvi">
-                                                      <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
-                                                    </node>
-                                                  </node>
-                                                </node>
-                                              </node>
-                                            </node>
-                                          </node>
-                                        </node>
                                         <node concept="3clFbF" id="73he6VT0o6Z" role="3cqZAp">
                                           <node concept="2OqwBi" id="73he6VT0o70" role="3clFbG">
                                             <node concept="37vLTw" id="73he6VT0o71" role="2Oq$k0">
@@ -2172,51 +2118,18 @@
                                               <node concept="2ShNRf" id="73he6VT0o73" role="25WWJ7">
                                                 <node concept="1pGfFk" id="73he6VT0o74" role="2ShVmc">
                                                   <ref role="37wK5l" to="zn9m:~Pair.&lt;init&gt;(java.lang.Object,java.lang.Object)" resolve="Pair" />
-                                                  <node concept="3cpWs3" id="73he6VT0o78" role="37wK5m">
-                                                    <node concept="3cpWs3" id="73he6VT0o79" role="3uHU7B">
-                                                      <node concept="2OqwBi" id="73he6VT0o7a" role="3uHU7w">
-                                                        <node concept="2GrUjf" id="73he6VT0o7c" role="2Oq$k0">
-                                                          <ref role="2Gs0qQ" node="73he6VT0o6G" resolve="module" />
-                                                        </node>
-                                                        <node concept="liA8E" id="73he6VT0DwC" role="2OqNvi">
-                                                          <ref role="37wK5l" to="lui2:~SModule.getModuleName()" resolve="getModuleName" />
-                                                        </node>
-                                                      </node>
-                                                      <node concept="3cpWs3" id="73he6VT0o7f" role="3uHU7B">
-                                                        <node concept="3cpWs3" id="73he6VT0o7g" role="3uHU7B">
-                                                          <node concept="3cpWs3" id="73he6VT0o7h" role="3uHU7B">
-                                                            <node concept="Xl_RD" id="73he6VT0o7n" role="3uHU7w">
-                                                              <property role="Xl_RC" value=" from model '" />
-                                                            </node>
-                                                            <node concept="3cpWs3" id="73he6VT0R67" role="3uHU7B">
-                                                              <node concept="37vLTw" id="73he6VT0RnD" role="3uHU7w">
-                                                                <ref role="3cqZAo" node="73he6VT0Mns" resolve="msg" />
-                                                              </node>
-                                                              <node concept="Xl_RD" id="73he6VT0o7j" role="3uHU7B">
-                                                                <property role="Xl_RC" value="broken references of node" />
-                                                              </node>
-                                                            </node>
-                                                          </node>
-                                                          <node concept="2OqwBi" id="73he6VT0o7o" role="3uHU7w">
-                                                            <node concept="37vLTw" id="73he6VT0CK9" role="2Oq$k0">
-                                                              <ref role="3cqZAo" node="73he6VT0yLw" resolve="m" />
-                                                            </node>
-                                                            <node concept="LkI2h" id="73he6VT0o7q" role="2OqNvi" />
-                                                          </node>
-                                                        </node>
-                                                        <node concept="Xl_RD" id="73he6VT0o7r" role="3uHU7w">
-                                                          <property role="Xl_RC" value="' and module '" />
-                                                        </node>
-                                                      </node>
-                                                    </node>
-                                                    <node concept="Xl_RD" id="73he6VT0o7s" role="3uHU7w">
-                                                      <property role="Xl_RC" value="'." />
-                                                    </node>
-                                                  </node>
                                                   <node concept="17QB3L" id="73he6VT0o7u" role="1pMfVU" />
                                                   <node concept="3Tqbb2" id="73he6VT0o7v" role="1pMfVU" />
-                                                  <node concept="2GrUjf" id="73he6VT0o7w" role="37wK5m">
-                                                    <ref role="2Gs0qQ" node="73he6VT0y4g" resolve="crtNode" />
+                                                  <node concept="Xl_RD" id="73he6VT0o7j" role="37wK5m">
+                                                    <property role="Xl_RC" value="The reference cannot be resolved" />
+                                                  </node>
+                                                  <node concept="2OqwBi" id="4XPt_HaQOzF" role="37wK5m">
+                                                    <node concept="2GrUjf" id="4XPt_HaQOle" role="2Oq$k0">
+                                                      <ref role="2Gs0qQ" node="73he6VT0zyL" resolve="crtRef" />
+                                                    </node>
+                                                    <node concept="liA8E" id="4XPt_HaQOT1" role="2OqNvi">
+                                                      <ref role="37wK5l" to="mhbf:~SReference.getSourceNode()" resolve="getSourceNode" />
+                                                    </node>
                                                   </node>
                                                 </node>
                                               </node>
@@ -2712,104 +2625,6 @@
                         </node>
                       </node>
                       <node concept="3clFbS" id="7e2zrEq$zxi" role="3clFbx">
-                        <node concept="3cpWs8" id="7e2zrEq$BwH" role="3cqZAp">
-                          <node concept="3cpWsn" id="7e2zrEq$BwK" role="3cpWs9">
-                            <property role="TrG5h" value="referencingRoot" />
-                            <node concept="3Tqbb2" id="7e2zrEq$BwF" role="1tU5fm" />
-                            <node concept="2OqwBi" id="7e2zrEq$BPA" role="33vP2m">
-                              <node concept="2GrUjf" id="7e2zrEq$BJX" role="2Oq$k0">
-                                <ref role="2Gs0qQ" node="7e2zrEq$4iH" resolve="n" />
-                              </node>
-                              <node concept="2Rxl7S" id="7e2zrEq$Cj1" role="2OqNvi" />
-                            </node>
-                          </node>
-                        </node>
-                        <node concept="3cpWs8" id="7e2zrEq$4iO" role="3cqZAp">
-                          <node concept="3cpWsn" id="7e2zrEq$4iP" role="3cpWs9">
-                            <property role="TrG5h" value="rootNodeName" />
-                            <node concept="17QB3L" id="7e2zrEq$4iQ" role="1tU5fm" />
-                            <node concept="3K4zz7" id="7e2zrEq$4iR" role="33vP2m">
-                              <node concept="2OqwBi" id="7e2zrEq$4iS" role="3K4E3e">
-                                <node concept="1PxgMI" id="7e2zrEq$4iT" role="2Oq$k0">
-                                  <node concept="chp4Y" id="7e2zrEq$4iU" role="3oSUPX">
-                                    <ref role="cht4Q" to="tpck:h0TrEE$" resolve="INamedConcept" />
-                                  </node>
-                                  <node concept="37vLTw" id="7e2zrEq$CRv" role="1m5AlR">
-                                    <ref role="3cqZAo" node="7e2zrEq$BwK" resolve="referencingRoot" />
-                                  </node>
-                                </node>
-                                <node concept="3TrcHB" id="7e2zrEq$4iW" role="2OqNvi">
-                                  <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
-                                </node>
-                              </node>
-                              <node concept="2OqwBi" id="7e2zrEq$4iX" role="3K4GZi">
-                                <node concept="2OqwBi" id="7e2zrEq$4iY" role="2Oq$k0">
-                                  <node concept="37vLTw" id="7e2zrEq$D0B" role="2Oq$k0">
-                                    <ref role="3cqZAo" node="7e2zrEq$BwK" resolve="referencingRoot" />
-                                  </node>
-                                  <node concept="2yIwOk" id="7e2zrEq$4j0" role="2OqNvi" />
-                                </node>
-                                <node concept="liA8E" id="7e2zrEq$4j1" role="2OqNvi">
-                                  <ref role="37wK5l" to="c17a:~SAbstractConcept.getName()" resolve="getName" />
-                                </node>
-                              </node>
-                              <node concept="2OqwBi" id="7e2zrEq$4j2" role="3K4Cdx">
-                                <node concept="1mIQ4w" id="7e2zrEq$4j4" role="2OqNvi">
-                                  <node concept="chp4Y" id="7e2zrEq$4j5" role="cj9EA">
-                                    <ref role="cht4Q" to="tpck:h0TrEE$" resolve="INamedConcept" />
-                                  </node>
-                                </node>
-                                <node concept="37vLTw" id="7e2zrEq$Csx" role="2Oq$k0">
-                                  <ref role="3cqZAo" node="7e2zrEq$BwK" resolve="referencingRoot" />
-                                </node>
-                              </node>
-                            </node>
-                          </node>
-                        </node>
-                        <node concept="3cpWs8" id="7e2zrEq$4j6" role="3cqZAp">
-                          <node concept="3cpWsn" id="7e2zrEq$4j7" role="3cpWs9">
-                            <property role="TrG5h" value="msg" />
-                            <node concept="17QB3L" id="7e2zrEq$4j8" role="1tU5fm" />
-                            <node concept="3cpWs3" id="7e2zrEq$4j9" role="33vP2m">
-                              <node concept="3cpWs3" id="7e2zrEq$4ja" role="3uHU7B">
-                                <node concept="3cpWs3" id="7e2zrEq$4jb" role="3uHU7B">
-                                  <node concept="3cpWs3" id="7e2zrEq$4jc" role="3uHU7B">
-                                    <node concept="37vLTw" id="7e2zrEq$4jd" role="3uHU7w">
-                                      <ref role="3cqZAo" node="7e2zrEq$4iP" resolve="rootNodeName" />
-                                    </node>
-                                    <node concept="Xl_RD" id="7e2zrEq$4je" role="3uHU7B">
-                                      <property role="Xl_RC" value="Node from root node '" />
-                                    </node>
-                                  </node>
-                                  <node concept="Xl_RD" id="7e2zrEq$4jf" role="3uHU7w">
-                                    <property role="Xl_RC" value="' from model '" />
-                                  </node>
-                                </node>
-                                <node concept="2OqwBi" id="7e2zrEq$4jg" role="3uHU7w">
-                                  <node concept="2OqwBi" id="7e2zrEq$4jh" role="2Oq$k0">
-                                    <node concept="2JrnkZ" id="7e2zrEq$4ji" role="2Oq$k0">
-                                      <node concept="2OqwBi" id="7e2zrEq$Em5" role="2JrQYb">
-                                        <node concept="37vLTw" id="7e2zrEq$Da6" role="2Oq$k0">
-                                          <ref role="3cqZAo" node="7e2zrEq$BwK" resolve="referencingRoot" />
-                                        </node>
-                                        <node concept="I4A8Y" id="7e2zrEq$FlV" role="2OqNvi" />
-                                      </node>
-                                    </node>
-                                    <node concept="liA8E" id="7e2zrEq$4jk" role="2OqNvi">
-                                      <ref role="37wK5l" to="mhbf:~SModel.getName()" resolve="getName" />
-                                    </node>
-                                  </node>
-                                  <node concept="liA8E" id="7e2zrEq$4jl" role="2OqNvi">
-                                    <ref role="37wK5l" to="mhbf:~SModelName.getValue()" resolve="getValue" />
-                                  </node>
-                                </node>
-                              </node>
-                              <node concept="Xl_RD" id="7e2zrEq$4jm" role="3uHU7w">
-                                <property role="Xl_RC" value="' references commented out code" />
-                              </node>
-                            </node>
-                          </node>
-                        </node>
                         <node concept="3clFbF" id="7e2zrEq$4jn" role="3cqZAp">
                           <node concept="2OqwBi" id="7e2zrEq$4jo" role="3clFbG">
                             <node concept="37vLTw" id="7e2zrEq$4jp" role="2Oq$k0">
@@ -2819,8 +2634,8 @@
                               <node concept="2ShNRf" id="7e2zrEq$4jr" role="25WWJ7">
                                 <node concept="1pGfFk" id="7e2zrEq$4js" role="2ShVmc">
                                   <ref role="37wK5l" to="zn9m:~Pair.&lt;init&gt;(java.lang.Object,java.lang.Object)" resolve="Pair" />
-                                  <node concept="37vLTw" id="7e2zrEq$4jt" role="37wK5m">
-                                    <ref role="3cqZAo" node="7e2zrEq$4j7" resolve="msg" />
+                                  <node concept="Xl_RD" id="4XPt_HaMjFd" role="37wK5m">
+                                    <property role="Xl_RC" value="The node references commented out code" />
                                   </node>
                                   <node concept="2GrUjf" id="7e2zrEq$4ju" role="37wK5m">
                                     <ref role="2Gs0qQ" node="7e2zrEq$4iH" resolve="n" />

--- a/code/languages/org.mpsqa.lint/solutions/org.mpsqa.lint.generic.sandbox/models/org.mpsqa.lint.generic.sandbox._010_smoke_user_defined_linters.mps
+++ b/code/languages/org.mpsqa.lint/solutions/org.mpsqa.lint.generic.sandbox/models/org.mpsqa.lint.generic.sandbox._010_smoke_user_defined_linters.mps
@@ -21,6 +21,7 @@
     <import index="eoo2" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.nio.file(JDK/)" />
     <import index="1ctc" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.util.stream(JDK/)" />
     <import index="33ny" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.util(JDK/)" />
+    <import index="zn9m" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.openapi.util(MPS.IDEA/)" />
   </imports>
   <registry>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
@@ -53,6 +54,7 @@
         <child id="1081256993305" name="classType" index="2ZW6by" />
         <child id="1081256993304" name="leftExpression" index="2ZW6bz" />
       </concept>
+      <concept id="1070534058343" name="jetbrains.mps.baseLanguage.structure.NullLiteral" flags="nn" index="10Nm6u" />
       <concept id="1070534370425" name="jetbrains.mps.baseLanguage.structure.IntegerType" flags="in" index="10Oyi0" />
       <concept id="1070534934090" name="jetbrains.mps.baseLanguage.structure.CastExpression" flags="nn" index="10QFUN">
         <child id="1070534934091" name="type" index="10QFUM" />
@@ -123,9 +125,6 @@
       <concept id="5351203823916750322" name="jetbrains.mps.baseLanguage.structure.TryUniversalStatement" flags="nn" index="3J1_TO">
         <child id="8276990574886367510" name="catchClause" index="1zxBo5" />
         <child id="8276990574886367508" name="body" index="1zxBo7" />
-      </concept>
-      <concept id="1200397529627" name="jetbrains.mps.baseLanguage.structure.CharConstant" flags="nn" index="1Xhbcc">
-        <property id="1200397540847" name="charConstant" index="1XhdNS" />
       </concept>
     </language>
     <language id="40ab19e9-751a-4433-b645-0e65160e58a0" name="org.mpsqa.lint.generic">
@@ -510,11 +509,23 @@
           <node concept="3cpWsn" id="4aEqBbbsVTY" role="3cpWs9">
             <property role="TrG5h" value="res" />
             <node concept="_YKpA" id="4aEqBbbsVU2" role="1tU5fm">
-              <node concept="17QB3L" id="4aEqBbbsVU5" role="_ZDj9" />
+              <node concept="3uibUv" id="4XPt_HaAEXb" role="_ZDj9">
+                <ref role="3uigEE" to="zn9m:~Pair" resolve="Pair" />
+                <node concept="17QB3L" id="4XPt_HaAJ$c" role="11_B2D" />
+                <node concept="3uibUv" id="4XPt_HaAMo2" role="11_B2D">
+                  <ref role="3uigEE" to="guwi:~File" resolve="File" />
+                </node>
+              </node>
             </node>
             <node concept="2ShNRf" id="4aEqBbbsVU3" role="33vP2m">
               <node concept="Tc6Ow" id="4aEqBbbsVU6" role="2ShVmc">
-                <node concept="17QB3L" id="4aEqBbbsVUa" role="HW$YZ" />
+                <node concept="3uibUv" id="4XPt_HaR73d" role="HW$YZ">
+                  <ref role="3uigEE" to="zn9m:~Pair" resolve="Pair" />
+                  <node concept="17QB3L" id="4XPt_HaR73e" role="11_B2D" />
+                  <node concept="3uibUv" id="4XPt_HaR73f" role="11_B2D">
+                    <ref role="3uigEE" to="guwi:~File" resolve="File" />
+                  </node>
+                </node>
               </node>
             </node>
           </node>
@@ -571,9 +582,16 @@
                     <ref role="3cqZAo" node="4aEqBbbsVTY" resolve="res" />
                   </node>
                   <node concept="TSZUe" id="6EiPrTQlBs_" role="2OqNvi">
-                    <node concept="vsK6v" id="6EiPrTQlBYI" role="25WWJ7">
-                      <node concept="37vLTw" id="6EiPrTQlCx5" role="vsfCu">
-                        <ref role="3cqZAo" node="6HKgezSv$LV" resolve="ioe" />
+                    <node concept="2ShNRf" id="4XPt_HaRiRa" role="25WWJ7">
+                      <node concept="1pGfFk" id="4XPt_HaRjGr" role="2ShVmc">
+                        <property role="373rjd" value="true" />
+                        <ref role="37wK5l" to="zn9m:~Pair.&lt;init&gt;(java.lang.Object,java.lang.Object)" resolve="Pair" />
+                        <node concept="vsK6v" id="6EiPrTQlBYI" role="37wK5m">
+                          <node concept="37vLTw" id="6EiPrTQlCx5" role="vsfCu">
+                            <ref role="3cqZAo" node="6HKgezSv$LV" resolve="ioe" />
+                          </node>
+                        </node>
+                        <node concept="10Nm6u" id="4XPt_HaRkV6" role="37wK5m" />
                       </node>
                     </node>
                   </node>
@@ -716,61 +734,35 @@
                           <ref role="3cqZAo" node="4aEqBbbsVTY" resolve="res" />
                         </node>
                         <node concept="TSZUe" id="6HKgezSw0kD" role="2OqNvi">
-                          <node concept="3cpWs3" id="6HKgezSwbiZ" role="25WWJ7">
-                            <node concept="Xl_RD" id="6HKgezSwbjy" role="3uHU7w">
-                              <property role="Xl_RC" value="KB" />
-                            </node>
-                            <node concept="3cpWs3" id="6HKgezSw9sy" role="3uHU7B">
-                              <node concept="3cpWs3" id="6HKgezSw6F9" role="3uHU7B">
-                                <node concept="3cpWs3" id="6HKgezSw2oo" role="3uHU7B">
-                                  <node concept="Xl_RD" id="6HKgezSw0Ik" role="3uHU7B">
-                                    <property role="Xl_RC" value="File '" />
-                                  </node>
-                                  <node concept="2OqwBi" id="7AhcwybAMmh" role="3uHU7w">
-                                    <node concept="2OqwBi" id="7AhcwybAHpK" role="2Oq$k0">
-                                      <node concept="2OqwBi" id="4zoES75HB_c" role="2Oq$k0">
-                                        <node concept="liA8E" id="4zoES75HE4O" role="2OqNvi">
-                                          <ref role="37wK5l" to="eoo2:~Path.relativize(java.nio.file.Path)" resolve="relativize" />
-                                          <node concept="2GrUjf" id="4zoES75I6Gc" role="37wK5m">
-                                            <ref role="2Gs0qQ" node="6HKgezSvwqF" resolve="p" />
-                                          </node>
-                                        </node>
-                                        <node concept="2OqwBi" id="4zoES75I4H5" role="2Oq$k0">
-                                          <node concept="2ShNRf" id="4zoES75I4H6" role="2Oq$k0">
-                                            <node concept="1pGfFk" id="4zoES75I4H7" role="2ShVmc">
-                                              <property role="373rjd" value="true" />
-                                              <ref role="37wK5l" to="guwi:~File.&lt;init&gt;(java.lang.String)" resolve="File" />
-                                              <node concept="37vLTw" id="4zoES75I4H8" role="37wK5m">
-                                                <ref role="3cqZAo" node="6HKgezSvh5b" resolve="directoryContainingProject" />
-                                              </node>
-                                            </node>
-                                          </node>
-                                          <node concept="liA8E" id="4zoES75I4H9" role="2OqNvi">
-                                            <ref role="37wK5l" to="guwi:~File.toPath()" resolve="toPath" />
-                                          </node>
-                                        </node>
-                                      </node>
-                                      <node concept="liA8E" id="7AhcwybALmh" role="2OqNvi">
-                                        <ref role="37wK5l" to="eoo2:~Path.toString()" resolve="toString" />
-                                      </node>
-                                    </node>
-                                    <node concept="liA8E" id="7AhcwybAOct" role="2OqNvi">
-                                      <ref role="37wK5l" to="wyt6:~String.replace(char,char)" resolve="replace" />
-                                      <node concept="1Xhbcc" id="7AhcwybAP6E" role="37wK5m">
-                                        <property role="1XhdNS" value="\\" />
-                                      </node>
-                                      <node concept="1Xhbcc" id="7AhcwybARGF" role="37wK5m">
-                                        <property role="1XhdNS" value="/" />
-                                      </node>
-                                    </node>
-                                  </node>
+                          <node concept="2ShNRf" id="4XPt_HaRb5v" role="25WWJ7">
+                            <node concept="1pGfFk" id="4XPt_HaRbO2" role="2ShVmc">
+                              <property role="373rjd" value="true" />
+                              <ref role="37wK5l" to="zn9m:~Pair.&lt;init&gt;(java.lang.Object,java.lang.Object)" resolve="Pair" />
+                              <node concept="3cpWs3" id="6HKgezSwbiZ" role="37wK5m">
+                                <node concept="Xl_RD" id="6HKgezSwbjy" role="3uHU7w">
+                                  <property role="Xl_RC" value="KB" />
                                 </node>
-                                <node concept="Xl_RD" id="6HKgezSw7hB" role="3uHU7w">
-                                  <property role="Xl_RC" value="' is bigger than " />
+                                <node concept="3cpWs3" id="6HKgezSw9sy" role="3uHU7B">
+                                  <node concept="3cpWs3" id="6HKgezSw6F9" role="3uHU7B">
+                                    <node concept="Xl_RD" id="6HKgezSw7hB" role="3uHU7w">
+                                      <property role="Xl_RC" value="' is bigger than " />
+                                    </node>
+                                    <node concept="Xl_RD" id="4XPt_HaR8xv" role="3uHU7B">
+                                      <property role="Xl_RC" value="The file " />
+                                    </node>
+                                  </node>
+                                  <node concept="2j1LYi" id="7AhcwybAGdN" role="3uHU7w">
+                                    <ref role="2j1LYj" node="pFzydTBLXy" resolve="sizeInKb" />
+                                  </node>
                                 </node>
                               </node>
-                              <node concept="2j1LYi" id="7AhcwybAGdN" role="3uHU7w">
-                                <ref role="2j1LYj" node="pFzydTBLXy" resolve="sizeInKb" />
+                              <node concept="2OqwBi" id="4XPt_HaRnuR" role="37wK5m">
+                                <node concept="2GrUjf" id="4XPt_HaRh6z" role="2Oq$k0">
+                                  <ref role="2Gs0qQ" node="6HKgezSvwqF" resolve="p" />
+                                </node>
+                                <node concept="liA8E" id="4XPt_HaRp2A" role="2OqNvi">
+                                  <ref role="37wK5l" to="eoo2:~Path.toFile()" resolve="toFile" />
+                                </node>
                               </node>
                             </node>
                           </node>

--- a/code/languages/org.mpsqa.lint/solutions/org.mpsqa.lint.generic.sandbox/org.mpsqa.lint.generic.sandbox.msd
+++ b/code/languages/org.mpsqa.lint/solutions/org.mpsqa.lint.generic.sandbox/org.mpsqa.lint.generic.sandbox.msd
@@ -20,6 +20,7 @@
     <dependency reexport="false">742f6602-5a2f-4313-aa6e-ae1cd4ffdc61(MPS.Platform)</dependency>
     <dependency reexport="false">a1250a4d-c090-42c3-ad7c-d298a3357dd4(jetbrains.mps.make.runtime)</dependency>
     <dependency reexport="false">215c4c45-ba99-49f5-9ab7-4b6901a63cfd(MPS.Generator)</dependency>
+    <dependency reexport="false">498d89d2-c2e9-11e2-ad49-6cf049e62fe5(MPS.IDEA)</dependency>
   </dependencies>
   <languageVersions>
     <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="12" />

--- a/code/languages/org.mpsqa.lint/solutions/org.mpsqa.lint.mps_lang.linters_library/models/org.mpsqa.lint.mps_lang.linters_library.behavior_aspect.mps
+++ b/code/languages/org.mpsqa.lint/solutions/org.mpsqa.lint.mps_lang.linters_library/models/org.mpsqa.lint.mps_lang.linters_library.behavior_aspect.mps
@@ -22,7 +22,6 @@
         <child id="1068498886297" name="rValue" index="37vLTx" />
         <child id="1068498886295" name="lValue" index="37vLTJ" />
       </concept>
-      <concept id="1202948039474" name="jetbrains.mps.baseLanguage.structure.InstanceMethodCallOperation" flags="nn" index="liA8E" />
       <concept id="1154032098014" name="jetbrains.mps.baseLanguage.structure.AbstractLoopStatement" flags="nn" index="2LF5Ji">
         <child id="1154032183016" name="body" index="2LFqv$" />
       </concept>
@@ -119,12 +118,8 @@
       <concept id="4693937538533521280" name="jetbrains.mps.lang.smodel.structure.OfConceptOperation" flags="ng" index="v3k3i">
         <child id="4693937538533538124" name="requestedConcept" index="v3oSu" />
       </concept>
-      <concept id="1143234257716" name="jetbrains.mps.lang.smodel.structure.Node_GetModelOperation" flags="nn" index="I4A8Y" />
       <concept id="1145383075378" name="jetbrains.mps.lang.smodel.structure.SNodeListType" flags="in" index="2I9FWS">
         <reference id="1145383142433" name="elementConcept" index="2I9WkF" />
-      </concept>
-      <concept id="1145404486709" name="jetbrains.mps.lang.smodel.structure.SemanticDowncastExpression" flags="nn" index="2JrnkZ">
-        <child id="1145404616321" name="leftExpression" index="2JrQYb" />
       </concept>
       <concept id="1145567426890" name="jetbrains.mps.lang.smodel.structure.SNodeListCreator" flags="nn" index="2T8Vx0">
         <child id="1145567471833" name="createdType" index="2T96Bj" />
@@ -770,58 +765,8 @@
                         <property role="Xl_RC" value="'" />
                       </node>
                       <node concept="3cpWs3" id="78RogMCDf8_" role="3uHU7B">
-                        <node concept="3cpWs3" id="78RogMCDf8A" role="3uHU7B">
-                          <node concept="3cpWs3" id="78RogMCDf8B" role="3uHU7B">
-                            <node concept="2OqwBi" id="78RogMCDf8C" role="3uHU7w">
-                              <node concept="2OqwBi" id="78RogMCDf8D" role="2Oq$k0">
-                                <node concept="2JrnkZ" id="78RogMCDf8E" role="2Oq$k0">
-                                  <node concept="2OqwBi" id="78RogMCDf8F" role="2JrQYb">
-                                    <node concept="37vLTw" id="2zdrQh7q_73" role="2Oq$k0">
-                                      <ref role="3cqZAo" node="2zdrQh7oJuy" resolve="behavior" />
-                                    </node>
-                                    <node concept="I4A8Y" id="78RogMCDf8H" role="2OqNvi" />
-                                  </node>
-                                </node>
-                                <node concept="liA8E" id="78RogMCDf8I" role="2OqNvi">
-                                  <ref role="37wK5l" to="mhbf:~SModel.getName()" resolve="getName" />
-                                </node>
-                              </node>
-                              <node concept="liA8E" id="78RogMCDf8J" role="2OqNvi">
-                                <ref role="37wK5l" to="mhbf:~SModelName.getValue()" resolve="getValue" />
-                              </node>
-                            </node>
-                            <node concept="3cpWs3" id="78RogMCDf8K" role="3uHU7B">
-                              <node concept="3cpWs3" id="78RogMCDf8L" role="3uHU7B">
-                                <node concept="2OqwBi" id="78RogMCDf8M" role="3uHU7w">
-                                  <node concept="37vLTw" id="2zdrQh7qzQ0" role="2Oq$k0">
-                                    <ref role="3cqZAo" node="2zdrQh7oJuy" resolve="behavior" />
-                                  </node>
-                                  <node concept="3TrcHB" id="78RogMCDf8O" role="2OqNvi">
-                                    <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
-                                  </node>
-                                </node>
-                                <node concept="3cpWs3" id="78RogMCDf8P" role="3uHU7B">
-                                  <node concept="3cpWs3" id="78RogMCDf8Q" role="3uHU7B">
-                                    <node concept="Xl_RD" id="78RogMCDf8R" role="3uHU7B">
-                                      <property role="Xl_RC" value="concept method '" />
-                                    </node>
-                                    <node concept="37vLTw" id="78RogMCDf8S" role="3uHU7w">
-                                      <ref role="3cqZAo" node="3pz5R1DJaEC" resolve="nameAndSignature" />
-                                    </node>
-                                  </node>
-                                  <node concept="Xl_RD" id="78RogMCDf8T" role="3uHU7w">
-                                    <property role="Xl_RC" value="' from rootNode '" />
-                                  </node>
-                                </node>
-                              </node>
-                              <node concept="Xl_RD" id="78RogMCDf8U" role="3uHU7w">
-                                <property role="Xl_RC" value="' from model '" />
-                              </node>
-                            </node>
-                          </node>
-                          <node concept="Xl_RD" id="78RogMCDf8V" role="3uHU7w">
-                            <property role="Xl_RC" value="' has the same signature as concept method from '" />
-                          </node>
+                        <node concept="Xl_RD" id="4XPt_HaT1rx" role="3uHU7B">
+                          <property role="Xl_RC" value="the concept method has the same signature as concept method from '" />
                         </node>
                         <node concept="2OqwBi" id="78RogMCDf8W" role="3uHU7w">
                           <node concept="2OqwBi" id="78RogMCDf8X" role="2Oq$k0">

--- a/code/languages/org.mpsqa.lint/solutions/org.mpsqa.lint.mps_lang.linters_library/models/org.mpsqa.lint.mps_lang.linters_library.build_scripts.mps
+++ b/code/languages/org.mpsqa.lint/solutions/org.mpsqa.lint.mps_lang.linters_library/models/org.mpsqa.lint.mps_lang.linters_library.build_scripts.mps
@@ -80,7 +80,6 @@
       <concept id="1068580123137" name="jetbrains.mps.baseLanguage.structure.BooleanConstant" flags="nn" index="3clFbT">
         <property id="1068580123138" name="value" index="3clFbU" />
       </concept>
-      <concept id="1068581242875" name="jetbrains.mps.baseLanguage.structure.PlusExpression" flags="nn" index="3cpWs3" />
       <concept id="1068581242878" name="jetbrains.mps.baseLanguage.structure.ReturnStatement" flags="nn" index="3cpWs6">
         <child id="1068581517676" name="expression" index="3cqZAk" />
       </concept>
@@ -105,10 +104,6 @@
         <reference id="1107535924139" name="classifier" index="3uigEE" />
         <child id="1109201940907" name="parameter" index="11_B2D" />
       </concept>
-      <concept id="1081773326031" name="jetbrains.mps.baseLanguage.structure.BinaryOperation" flags="nn" index="3uHJSO">
-        <child id="1081773367579" name="rightExpression" index="3uHU7w" />
-        <child id="1081773367580" name="leftExpression" index="3uHU7B" />
-      </concept>
       <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ng" index="1B3ioH">
         <child id="1178549979242" name="visibility" index="1B3o_S" />
       </concept>
@@ -126,7 +121,6 @@
       <concept id="1177026924588" name="jetbrains.mps.lang.smodel.structure.RefConcept_Reference" flags="nn" index="chp4Y">
         <reference id="1177026940964" name="conceptDeclaration" index="cht4Q" />
       </concept>
-      <concept id="8329979535468945057" name="jetbrains.mps.lang.smodel.structure.Node_PresentationOperation" flags="ng" index="2Iv5rx" />
       <concept id="3562215692195599741" name="jetbrains.mps.lang.smodel.structure.SLinkImplicitSelect" flags="nn" index="13MTOL">
         <reference id="3562215692195600259" name="link" index="13MTZf" />
       </concept>
@@ -468,21 +462,8 @@
                             <node concept="1pGfFk" id="4lmpEOOA1FT" role="2ShVmc">
                               <property role="373rjd" value="true" />
                               <ref role="37wK5l" to="zn9m:~Pair.&lt;init&gt;(java.lang.Object,java.lang.Object)" resolve="Pair" />
-                              <node concept="3cpWs3" id="1anGYsMsnoe" role="37wK5m">
-                                <node concept="3cpWs3" id="1anGYsMsnof" role="3uHU7B">
-                                  <node concept="Xl_RD" id="1anGYsMsnog" role="3uHU7B">
-                                    <property role="Xl_RC" value="Plugin '" />
-                                  </node>
-                                  <node concept="2OqwBi" id="1Ke2sdkiKwc" role="3uHU7w">
-                                    <node concept="2GrUjf" id="1Ke2sdkiKkc" role="2Oq$k0">
-                                      <ref role="2Gs0qQ" node="1Ke2sdkiFDy" resolve="ip" />
-                                    </node>
-                                    <node concept="2Iv5rx" id="1Ke2sdkjFOj" role="2OqNvi" />
-                                  </node>
-                                </node>
-                                <node concept="Xl_RD" id="1anGYsMsnok" role="3uHU7w">
-                                  <property role="Xl_RC" value="' is involved in a cyclic dependency" />
-                                </node>
+                              <node concept="Xl_RD" id="4XPt_HaTl91" role="37wK5m">
+                                <property role="Xl_RC" value="Plugin is involved in a cyclic dependency" />
                               </node>
                               <node concept="2GrUjf" id="4lmpEOOA22n" role="37wK5m">
                                 <ref role="2Gs0qQ" node="1Ke2sdkiFDy" resolve="ip" />

--- a/code/languages/org.mpsqa.lint/solutions/org.mpsqa.lint.mps_lang.linters_library/models/org.mpsqa.lint.mps_lang.linters_library.performance_editor.mps
+++ b/code/languages/org.mpsqa.lint/solutions/org.mpsqa.lint.mps_lang.linters_library/models/org.mpsqa.lint.mps_lang.linters_library.performance_editor.mps
@@ -191,6 +191,9 @@
         <child id="7741759128795045752" name="exp" index="2j1LYg" />
         <child id="7741759128795065723" name="paramRef" index="2j1YQj" />
       </concept>
+      <concept id="7679435328618353697" name="org.mpsqa.lint.generic.structure.FormatException" flags="ng" index="vsK6v">
+        <child id="7679435328618377120" name="exception" index="vsfCu" />
+      </concept>
       <concept id="7008376823202027689" name="org.mpsqa.lint.generic.structure.ICanSkipCheckerEvaluation" flags="ng" index="3miP$Z">
         <property id="7008376823202030902" name="skipEvaluation" index="3miQiw" />
       </concept>
@@ -205,12 +208,6 @@
     <language id="fd392034-7849-419d-9071-12563d152375" name="jetbrains.mps.baseLanguage.closures">
       <concept id="1199569711397" name="jetbrains.mps.baseLanguage.closures.structure.ClosureLiteral" flags="nn" index="1bVj0M">
         <child id="1199569916463" name="body" index="1bW5cS" />
-      </concept>
-    </language>
-    <language id="760a0a8c-eabb-4521-8bfd-65db761a9ba3" name="jetbrains.mps.baseLanguage.logging">
-      <concept id="6332851714983831325" name="jetbrains.mps.baseLanguage.logging.structure.MsgStatement" flags="ng" index="2xdQw9">
-        <child id="5721587534047265374" name="message" index="9lYJi" />
-        <child id="5721587534047265375" name="throwable" index="9lYJj" />
       </concept>
     </language>
     <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
@@ -1146,12 +1143,24 @@
                               </node>
                             </node>
                           </node>
-                          <node concept="2xdQw9" id="2ZPTSapgKiL" role="3cqZAp">
-                            <node concept="Xl_RD" id="2ZPTSapgKiN" role="9lYJi">
-                              <property role="Xl_RC" value="interrupted exception while waiting for the editor to open" />
-                            </node>
-                            <node concept="37vLTw" id="2ZPTSapgK$m" role="9lYJj">
-                              <ref role="3cqZAo" node="6wZqgFKVtlm" resolve="e" />
+                          <node concept="3clFbF" id="4XPt_HaTH5B" role="3cqZAp">
+                            <node concept="2OqwBi" id="4XPt_HaTH5C" role="3clFbG">
+                              <node concept="37vLTw" id="4XPt_HaTH5D" role="2Oq$k0">
+                                <ref role="3cqZAo" node="6wZqgFKVtka" resolve="res" />
+                              </node>
+                              <node concept="TSZUe" id="4XPt_HaTH5E" role="2OqNvi">
+                                <node concept="2ShNRf" id="4XPt_HaTH5F" role="25WWJ7">
+                                  <node concept="1pGfFk" id="4XPt_HaTH5G" role="2ShVmc">
+                                    <ref role="37wK5l" to="zn9m:~Pair.&lt;init&gt;(java.lang.Object,java.lang.Object)" resolve="Pair" />
+                                    <node concept="vsK6v" id="4XPt_HaTH5H" role="37wK5m">
+                                      <node concept="37vLTw" id="6EiPrTPVj5$" role="vsfCu">
+                                        <ref role="3cqZAo" node="6wZqgFKVtlm" resolve="e" />
+                                      </node>
+                                    </node>
+                                    <node concept="10Nm6u" id="4XPt_HaTH5I" role="37wK5m" />
+                                  </node>
+                                </node>
+                              </node>
                             </node>
                           </node>
                         </node>
@@ -2087,36 +2096,8 @@
                                             <property role="Xl_RC" value="MB" />
                                           </node>
                                           <node concept="3cpWs3" id="2TekImn84e8" role="3uHU7B">
-                                            <node concept="3cpWs3" id="2TekImn84e9" role="3uHU7B">
-                                              <node concept="3cpWs3" id="2TekImn84ea" role="3uHU7B">
-                                                <node concept="3cpWs3" id="2TekImn84eb" role="3uHU7B">
-                                                  <node concept="3cpWs3" id="2TekImn84ec" role="3uHU7B">
-                                                    <node concept="Xl_RD" id="2TekImn84ed" role="3uHU7B">
-                                                      <property role="Xl_RC" value="editor retained too much memory on root node '" />
-                                                    </node>
-                                                    <node concept="2OqwBi" id="2TekImn84ee" role="3uHU7w">
-                                                      <node concept="2GrUjf" id="2TekImn84ef" role="2Oq$k0">
-                                                        <ref role="2Gs0qQ" node="2TekImn84ck" resolve="rootNode" />
-                                                      </node>
-                                                      <node concept="3TrcHB" id="2TekImn84eg" role="2OqNvi">
-                                                        <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
-                                                      </node>
-                                                    </node>
-                                                  </node>
-                                                  <node concept="Xl_RD" id="2TekImn84eh" role="3uHU7w">
-                                                    <property role="Xl_RC" value="' from model " />
-                                                  </node>
-                                                </node>
-                                                <node concept="2OqwBi" id="2TekImn84ei" role="3uHU7w">
-                                                  <node concept="2GrUjf" id="2TekImn84ej" role="2Oq$k0">
-                                                    <ref role="2Gs0qQ" node="2TekImn84bL" resolve="m" />
-                                                  </node>
-                                                  <node concept="LkI2h" id="2TekImn84ek" role="2OqNvi" />
-                                                </node>
-                                              </node>
-                                              <node concept="Xl_RD" id="2TekImn84el" role="3uHU7w">
-                                                <property role="Xl_RC" value=" - it retained " />
-                                              </node>
+                                            <node concept="Xl_RD" id="4XPt_HaTvLG" role="3uHU7B">
+                                              <property role="Xl_RC" value="Editor retained too much memory:" />
                                             </node>
                                             <node concept="2YIFZM" id="5BymHIvyS5e" role="3uHU7w">
                                               <ref role="37wK5l" to="wyt6:~String.format(java.lang.String,java.lang.Object...)" resolve="format" />
@@ -2226,12 +2207,24 @@
                               </node>
                             </node>
                           </node>
-                          <node concept="2xdQw9" id="2TekImn84dp" role="3cqZAp">
-                            <node concept="Xl_RD" id="2TekImn84dq" role="9lYJi">
-                              <property role="Xl_RC" value="interrupted exception while waiting for the editor to open" />
-                            </node>
-                            <node concept="37vLTw" id="2TekImn84dr" role="9lYJj">
-                              <ref role="3cqZAo" node="2TekImn84ds" resolve="e" />
+                          <node concept="3clFbF" id="6EiPrTPS4UL" role="3cqZAp">
+                            <node concept="2OqwBi" id="6EiPrTPS6fR" role="3clFbG">
+                              <node concept="37vLTw" id="6EiPrTPS4UK" role="2Oq$k0">
+                                <ref role="3cqZAo" node="2TekImn84bv" resolve="res" />
+                              </node>
+                              <node concept="TSZUe" id="6EiPrTPS7dZ" role="2OqNvi">
+                                <node concept="2ShNRf" id="4XPt_HaB7jl" role="25WWJ7">
+                                  <node concept="1pGfFk" id="4XPt_HaB8Wf" role="2ShVmc">
+                                    <ref role="37wK5l" to="zn9m:~Pair.&lt;init&gt;(java.lang.Object,java.lang.Object)" resolve="Pair" />
+                                    <node concept="vsK6v" id="6EiPrTPUBp4" role="37wK5m">
+                                      <node concept="37vLTw" id="4XPt_HaTGkA" role="vsfCu">
+                                        <ref role="3cqZAo" node="2TekImn84ds" resolve="e" />
+                                      </node>
+                                    </node>
+                                    <node concept="10Nm6u" id="4XPt_HaB9Qy" role="37wK5m" />
+                                  </node>
+                                </node>
+                              </node>
                             </node>
                           </node>
                         </node>
@@ -2261,36 +2254,8 @@
                                       <property role="Xl_RC" value="ms" />
                                     </node>
                                     <node concept="3cpWs3" id="2TekImn84dF" role="3uHU7B">
-                                      <node concept="3cpWs3" id="2TekImn84dG" role="3uHU7B">
-                                        <node concept="3cpWs3" id="2TekImn84dH" role="3uHU7B">
-                                          <node concept="3cpWs3" id="2TekImn84dI" role="3uHU7B">
-                                            <node concept="3cpWs3" id="2TekImn84dJ" role="3uHU7B">
-                                              <node concept="Xl_RD" id="2TekImn84dK" role="3uHU7B">
-                                                <property role="Xl_RC" value="editor opened too slow on root node '" />
-                                              </node>
-                                              <node concept="2OqwBi" id="2TekImn84dL" role="3uHU7w">
-                                                <node concept="2GrUjf" id="2TekImn84dM" role="2Oq$k0">
-                                                  <ref role="2Gs0qQ" node="2TekImn84ck" resolve="rootNode" />
-                                                </node>
-                                                <node concept="3TrcHB" id="2TekImn84dN" role="2OqNvi">
-                                                  <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
-                                                </node>
-                                              </node>
-                                            </node>
-                                            <node concept="Xl_RD" id="2TekImn84dO" role="3uHU7w">
-                                              <property role="Xl_RC" value="' from model " />
-                                            </node>
-                                          </node>
-                                          <node concept="2OqwBi" id="2TekImn84dP" role="3uHU7w">
-                                            <node concept="2GrUjf" id="2TekImn84dQ" role="2Oq$k0">
-                                              <ref role="2Gs0qQ" node="2TekImn84bL" resolve="m" />
-                                            </node>
-                                            <node concept="LkI2h" id="2TekImn84dR" role="2OqNvi" />
-                                          </node>
-                                        </node>
-                                        <node concept="Xl_RD" id="2TekImn84dS" role="3uHU7w">
-                                          <property role="Xl_RC" value=". Timeout reached: " />
-                                        </node>
+                                      <node concept="Xl_RD" id="4XPt_HaTAKG" role="3uHU7B">
+                                        <property role="Xl_RC" value="Editor opened too slow. Timeout reached: " />
                                       </node>
                                       <node concept="37vLTw" id="2TekImn84dT" role="3uHU7w">
                                         <ref role="3cqZAo" node="2TekImn84cr" resolve="elapsedTime" />

--- a/code/languages/org.mpsqa.lint/solutions/org.mpsqa.lint.mps_lang.linters_library/models/org.mpsqa.lint.mps_lang.linters_library.performance_typesystem.mps
+++ b/code/languages/org.mpsqa.lint/solutions/org.mpsqa.lint.mps_lang.linters_library/models/org.mpsqa.lint.mps_lang.linters_library.performance_typesystem.mps
@@ -973,11 +973,19 @@
           <node concept="3cpWsn" id="2xFKNLWB3E1" role="3cpWs9">
             <property role="TrG5h" value="res" />
             <node concept="_YKpA" id="2xFKNLWB3E2" role="1tU5fm">
-              <node concept="17QB3L" id="2xFKNLWB3E4" role="_ZDj9" />
+              <node concept="3uibUv" id="4XPt_HaU3tX" role="_ZDj9">
+                <ref role="3uigEE" to="zn9m:~Pair" resolve="Pair" />
+                <node concept="17QB3L" id="4XPt_HaU5SH" role="11_B2D" />
+                <node concept="H_c77" id="4XPt_HaU7aX" role="11_B2D" />
+              </node>
             </node>
             <node concept="2ShNRf" id="2xFKNLWB3E6" role="33vP2m">
               <node concept="Tc6Ow" id="2xFKNLWB3E7" role="2ShVmc">
-                <node concept="17QB3L" id="2uhEaMSQHh$" role="HW$YZ" />
+                <node concept="3uibUv" id="4XPt_HaU7n5" role="HW$YZ">
+                  <ref role="3uigEE" to="zn9m:~Pair" resolve="Pair" />
+                  <node concept="17QB3L" id="4XPt_HaU7n6" role="11_B2D" />
+                  <node concept="H_c77" id="4XPt_HaU7n7" role="11_B2D" />
+                </node>
               </node>
             </node>
           </node>
@@ -1273,11 +1281,23 @@
           <node concept="3cpWsn" id="2xFKNLWBBLs" role="3cpWs9">
             <property role="TrG5h" value="res" />
             <node concept="_YKpA" id="2xFKNLWBBLt" role="1tU5fm">
-              <node concept="17QB3L" id="2uhEaMSQPkQ" role="_ZDj9" />
+              <node concept="3uibUv" id="4XPt_HaUw0y" role="_ZDj9">
+                <ref role="3uigEE" to="zn9m:~Pair" resolve="Pair" />
+                <node concept="17QB3L" id="4XPt_HaUyrm" role="11_B2D" />
+                <node concept="3uibUv" id="4XPt_HaU$W0" role="11_B2D">
+                  <ref role="3uigEE" to="lui2:~SModule" resolve="SModule" />
+                </node>
+              </node>
             </node>
             <node concept="2ShNRf" id="2xFKNLWBBLx" role="33vP2m">
               <node concept="Tc6Ow" id="2xFKNLWBBLy" role="2ShVmc">
-                <node concept="17QB3L" id="2uhEaMSQPvn" role="HW$YZ" />
+                <node concept="3uibUv" id="4XPt_HaU_dO" role="HW$YZ">
+                  <ref role="3uigEE" to="zn9m:~Pair" resolve="Pair" />
+                  <node concept="17QB3L" id="4XPt_HaU_dP" role="11_B2D" />
+                  <node concept="3uibUv" id="4XPt_HaU_dQ" role="11_B2D">
+                    <ref role="3uigEE" to="lui2:~SModule" resolve="SModule" />
+                  </node>
+                </node>
               </node>
             </node>
           </node>

--- a/code/languages/org.mpsqa.lint/solutions/org.mpsqa.lint.mps_lang.linters_library/models/org.mpsqa.lint.mps_lang.linters_library.performance_utils.mps
+++ b/code/languages/org.mpsqa.lint/solutions/org.mpsqa.lint.mps_lang.linters_library/models/org.mpsqa.lint.mps_lang.linters_library.performance_utils.mps
@@ -438,31 +438,24 @@
                       <ref role="3cqZAo" node="2xFKNLWBFC5" resolve="res" />
                     </node>
                     <node concept="TSZUe" id="2xFKNLWBFBw" role="2OqNvi">
-                      <node concept="3cpWs3" id="2xFKNLWBFBz" role="25WWJ7">
-                        <node concept="Xl_RD" id="2xFKNLWBFB$" role="3uHU7w">
-                          <property role="Xl_RC" value="ms" />
-                        </node>
-                        <node concept="3cpWs3" id="2xFKNLWBFB_" role="3uHU7B">
-                          <node concept="3cpWs3" id="2xFKNLWBFBA" role="3uHU7B">
-                            <node concept="3cpWs3" id="2xFKNLWBFBC" role="3uHU7B">
-                              <node concept="3cpWs3" id="2xFKNLWBFBD" role="3uHU7B">
-                                <node concept="Xl_RD" id="2xFKNLWBFBE" role="3uHU7B">
-                                  <property role="Xl_RC" value="non-typesystem checks too slow on module '" />
-                                </node>
-                                <node concept="2GrUjf" id="2xFKNLWBZuN" role="3uHU7w">
-                                  <ref role="2Gs0qQ" node="2xFKNLWBFAn" resolve="module" />
-                                </node>
-                              </node>
-                              <node concept="Xl_RD" id="2xFKNLWBFBG" role="3uHU7w">
-                                <property role="Xl_RC" value="'" />
-                              </node>
+                      <node concept="2ShNRf" id="4XPt_HaUd5e" role="25WWJ7">
+                        <node concept="1pGfFk" id="4XPt_HaUe3f" role="2ShVmc">
+                          <ref role="37wK5l" to="zn9m:~Pair.&lt;init&gt;(java.lang.Object,java.lang.Object)" resolve="Pair" />
+                          <node concept="3cpWs3" id="2xFKNLWBFBz" role="37wK5m">
+                            <node concept="Xl_RD" id="2xFKNLWBFB$" role="3uHU7w">
+                              <property role="Xl_RC" value="ms" />
                             </node>
-                            <node concept="Xl_RD" id="2xFKNLWBFBK" role="3uHU7w">
-                              <property role="Xl_RC" value=" - it took " />
+                            <node concept="3cpWs3" id="2xFKNLWBFB_" role="3uHU7B">
+                              <node concept="Xl_RD" id="2xFKNLWBFBE" role="3uHU7B">
+                                <property role="Xl_RC" value="Non-typesystem checks too slow: " />
+                              </node>
+                              <node concept="37vLTw" id="2uhEaMSTF4G" role="3uHU7w">
+                                <ref role="3cqZAo" node="2xFKNLWBFB0" resolve="elapsedTime" />
+                              </node>
                             </node>
                           </node>
-                          <node concept="37vLTw" id="2uhEaMSTF4G" role="3uHU7w">
-                            <ref role="3cqZAo" node="2xFKNLWBFB0" resolve="elapsedTime" />
+                          <node concept="2GrUjf" id="4XPt_HaUkw7" role="37wK5m">
+                            <ref role="2Gs0qQ" node="2xFKNLWBFAn" resolve="module" />
                           </node>
                         </node>
                       </node>
@@ -509,7 +502,13 @@
       <node concept="37vLTG" id="2xFKNLWBFC5" role="3clF46">
         <property role="TrG5h" value="res" />
         <node concept="_YKpA" id="2xFKNLWBFC6" role="1tU5fm">
-          <node concept="17QB3L" id="2uhEaMSQNsM" role="_ZDj9" />
+          <node concept="3uibUv" id="4XPt_HaU8Tc" role="_ZDj9">
+            <ref role="3uigEE" to="zn9m:~Pair" resolve="Pair" />
+            <node concept="17QB3L" id="4XPt_HaUatY" role="11_B2D" />
+            <node concept="3uibUv" id="4XPt_HaUbke" role="11_B2D">
+              <ref role="3uigEE" to="lui2:~SModule" resolve="SModule" />
+            </node>
+          </node>
         </node>
       </node>
     </node>
@@ -672,29 +671,25 @@
                       <ref role="3cqZAo" node="2xFKNLWAMro" resolve="res" />
                     </node>
                     <node concept="TSZUe" id="2xFKNLWAMqN" role="2OqNvi">
-                      <node concept="3cpWs3" id="2xFKNLWAMqQ" role="25WWJ7">
-                        <node concept="Xl_RD" id="2xFKNLWAMqR" role="3uHU7w">
-                          <property role="Xl_RC" value="ms" />
-                        </node>
-                        <node concept="3cpWs3" id="2xFKNLWAMqS" role="3uHU7B">
-                          <node concept="3cpWs3" id="2xFKNLWAMqT" role="3uHU7B">
-                            <node concept="3cpWs3" id="2xFKNLWAMqU" role="3uHU7B">
-                              <node concept="Xl_RD" id="2xFKNLWAMqX" role="3uHU7B">
-                                <property role="Xl_RC" value="non-typesystem checks too slow on model '" />
-                              </node>
-                              <node concept="2OqwBi" id="2xFKNLWAMr0" role="3uHU7w">
-                                <node concept="2GrUjf" id="2xFKNLWAMr1" role="2Oq$k0">
-                                  <ref role="2Gs0qQ" node="6o7R8__tZIO" resolve="m" />
-                                </node>
-                                <node concept="LkI2h" id="2xFKNLWAMr2" role="2OqNvi" />
-                              </node>
+                      <node concept="2ShNRf" id="4XPt_HaTUax" role="25WWJ7">
+                        <node concept="1pGfFk" id="4XPt_HaTV4D" role="2ShVmc">
+                          <property role="373rjd" value="true" />
+                          <ref role="37wK5l" to="zn9m:~Pair.&lt;init&gt;(java.lang.Object,java.lang.Object)" resolve="Pair" />
+                          <node concept="3cpWs3" id="2xFKNLWAMqQ" role="37wK5m">
+                            <node concept="Xl_RD" id="2xFKNLWAMqR" role="3uHU7w">
+                              <property role="Xl_RC" value="ms" />
                             </node>
-                            <node concept="Xl_RD" id="2xFKNLWAMr3" role="3uHU7w">
-                              <property role="Xl_RC" value="' - it took " />
+                            <node concept="3cpWs3" id="2xFKNLWAMqS" role="3uHU7B">
+                              <node concept="Xl_RD" id="2xFKNLWAMqX" role="3uHU7B">
+                                <property role="Xl_RC" value="non-typesystem checks too slow: " />
+                              </node>
+                              <node concept="37vLTw" id="2uhEaMSTD8y" role="3uHU7w">
+                                <ref role="3cqZAo" node="6o7R8__tMOz" resolve="elapsedTime" />
+                              </node>
                             </node>
                           </node>
-                          <node concept="37vLTw" id="2uhEaMSTD8y" role="3uHU7w">
-                            <ref role="3cqZAo" node="6o7R8__tMOz" resolve="elapsedTime" />
+                          <node concept="2GrUjf" id="4XPt_HaTX2s" role="37wK5m">
+                            <ref role="2Gs0qQ" node="6o7R8__tZIO" resolve="m" />
                           </node>
                         </node>
                       </node>
@@ -743,7 +738,11 @@
       <node concept="37vLTG" id="2xFKNLWAMro" role="3clF46">
         <property role="TrG5h" value="res" />
         <node concept="_YKpA" id="2xFKNLWAMrp" role="1tU5fm">
-          <node concept="17QB3L" id="2xFKNLWB3E4" role="_ZDj9" />
+          <node concept="3uibUv" id="4XPt_HaTNc$" role="_ZDj9">
+            <ref role="3uigEE" to="zn9m:~Pair" resolve="Pair" />
+            <node concept="17QB3L" id="4XPt_HaTODI" role="11_B2D" />
+            <node concept="H_c77" id="4XPt_HaTQiV" role="11_B2D" />
+          </node>
         </node>
       </node>
     </node>

--- a/code/languages/org.mpsqa.lint/solutions/org.mpsqa.lint.mps_lang.linters_library/models/org.mpsqa.lint.mps_lang.linters_library.structure_aspect.mps
+++ b/code/languages/org.mpsqa.lint/solutions/org.mpsqa.lint.mps_lang.linters_library/models/org.mpsqa.lint.mps_lang.linters_library.structure_aspect.mps
@@ -58,7 +58,6 @@
         <child id="1068581517665" name="statement" index="3cqZAp" />
       </concept>
       <concept id="1068580123137" name="jetbrains.mps.baseLanguage.structure.BooleanConstant" flags="nn" index="3clFbT" />
-      <concept id="1068581242875" name="jetbrains.mps.baseLanguage.structure.PlusExpression" flags="nn" index="3cpWs3" />
       <concept id="1068581242878" name="jetbrains.mps.baseLanguage.structure.ReturnStatement" flags="nn" index="3cpWs6">
         <child id="1068581517676" name="expression" index="3cqZAk" />
       </concept>
@@ -380,23 +379,8 @@
                       <node concept="3cpWsn" id="2s7fKStziwq" role="3cpWs9">
                         <property role="TrG5h" value="msg" />
                         <node concept="17QB3L" id="2s7fKStziwr" role="1tU5fm" />
-                        <node concept="3cpWs3" id="2s7fKStziws" role="33vP2m">
-                          <node concept="3cpWs3" id="2s7fKStziwt" role="3uHU7B">
-                            <node concept="Xl_RD" id="2s7fKStziwu" role="3uHU7B">
-                              <property role="Xl_RC" value="Concept '" />
-                            </node>
-                            <node concept="2OqwBi" id="2s7fKStziwv" role="3uHU7w">
-                              <node concept="2GrUjf" id="2s7fKStziwx" role="2Oq$k0">
-                                <ref role="2Gs0qQ" node="3bllPAaPI5n" resolve="conceptDeclaration" />
-                              </node>
-                              <node concept="3TrcHB" id="2s7fKStziwz" role="2OqNvi">
-                                <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
-                              </node>
-                            </node>
-                          </node>
-                          <node concept="Xl_RD" id="2s7fKStziw$" role="3uHU7w">
-                            <property role="Xl_RC" value="' is marked as 'can be root' but does not implement INamedConcept" />
-                          </node>
+                        <node concept="Xl_RD" id="4XPt_HaUGvw" role="33vP2m">
+                          <property role="Xl_RC" value="Concept is marked as 'can be root' but does not implement INamedConcept" />
                         </node>
                       </node>
                     </node>

--- a/code/languages/org.mpsqa.lint/solutions/org.mpsqa.lint.mps_lang.linters_library/models/org.mpsqa.lint.mps_lang.linters_library.tests.mps
+++ b/code/languages/org.mpsqa.lint/solutions/org.mpsqa.lint.mps_lang.linters_library/models/org.mpsqa.lint.mps_lang.linters_library.tests.mps
@@ -19,14 +19,21 @@
     <import index="5tjl" ref="r:5315d75f-2eea-4bf2-899f-f3d94810cea5(jetbrains.mps.build.mps.tests.structure)" />
     <import index="7f1d" ref="r:7bb3f1f1-7557-4f02-8802-5f9a48253a88(jetbrains.mps.build.mps.tests.behavior)" />
     <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" />
+    <import index="zn9m" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.openapi.util(MPS.IDEA/)" />
   </imports>
   <registry>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
       <concept id="4836112446988635817" name="jetbrains.mps.baseLanguage.structure.UndefinedType" flags="in" index="2jxLKc" />
       <concept id="1202948039474" name="jetbrains.mps.baseLanguage.structure.InstanceMethodCallOperation" flags="nn" index="liA8E" />
+      <concept id="1154032098014" name="jetbrains.mps.baseLanguage.structure.AbstractLoopStatement" flags="nn" index="2LF5Ji">
+        <child id="1154032183016" name="body" index="2LFqv$" />
+      </concept>
       <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
         <child id="1197027771414" name="operand" index="2Oq$k0" />
         <child id="1197027833540" name="operation" index="2OqNvi" />
+      </concept>
+      <concept id="1145552977093" name="jetbrains.mps.baseLanguage.structure.GenericNewExpression" flags="nn" index="2ShNRf">
+        <child id="1145553007750" name="creator" index="2ShVmc" />
       </concept>
       <concept id="1137021947720" name="jetbrains.mps.baseLanguage.structure.ConceptFunction" flags="in" index="2VMwT0">
         <child id="1137022507850" name="body" index="2VODD2" />
@@ -55,7 +62,6 @@
       <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
         <child id="1068581517665" name="statement" index="3cqZAp" />
       </concept>
-      <concept id="1068581242875" name="jetbrains.mps.baseLanguage.structure.PlusExpression" flags="nn" index="3cpWs3" />
       <concept id="1068581242878" name="jetbrains.mps.baseLanguage.structure.ReturnStatement" flags="nn" index="3cpWs6">
         <child id="1068581517676" name="expression" index="3cqZAk" />
       </concept>
@@ -70,12 +76,10 @@
         <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
         <child id="1068499141038" name="actualArgument" index="37wK5m" />
       </concept>
+      <concept id="1212685548494" name="jetbrains.mps.baseLanguage.structure.ClassCreator" flags="nn" index="1pGfFk" />
       <concept id="1107535904670" name="jetbrains.mps.baseLanguage.structure.ClassifierType" flags="in" index="3uibUv">
         <reference id="1107535924139" name="classifier" index="3uigEE" />
-      </concept>
-      <concept id="1081773326031" name="jetbrains.mps.baseLanguage.structure.BinaryOperation" flags="nn" index="3uHJSO">
-        <child id="1081773367579" name="rightExpression" index="3uHU7w" />
-        <child id="1081773367580" name="leftExpression" index="3uHU7B" />
+        <child id="1109201940907" name="parameter" index="11_B2D" />
       </concept>
     </language>
     <language id="40ab19e9-751a-4433-b645-0e65160e58a0" name="org.mpsqa.lint.generic">
@@ -137,6 +141,9 @@
       <concept id="1176906603202" name="jetbrains.mps.baseLanguage.collections.structure.BinaryOperation" flags="nn" index="56pJg">
         <child id="1176906787974" name="rightExpression" index="576Qk" />
       </concept>
+      <concept id="540871147943773365" name="jetbrains.mps.baseLanguage.collections.structure.SingleArgumentSequenceOperation" flags="nn" index="25WWJ4">
+        <child id="540871147943773366" name="argument" index="25WWJ7" />
+      </concept>
       <concept id="1176923520476" name="jetbrains.mps.baseLanguage.collections.structure.ExcludeOperation" flags="nn" index="66VNe" />
       <concept id="1151688443754" name="jetbrains.mps.baseLanguage.collections.structure.ListType" flags="in" index="_YKpA">
         <child id="1151688676805" name="elementType" index="_ZDj9" />
@@ -144,8 +151,20 @@
       <concept id="1151689724996" name="jetbrains.mps.baseLanguage.collections.structure.SequenceType" flags="in" index="A3Dl8">
         <child id="1151689745422" name="elementType" index="A3Ik2" />
       </concept>
-      <concept id="1151702311717" name="jetbrains.mps.baseLanguage.collections.structure.ToListOperation" flags="nn" index="ANE8D" />
+      <concept id="1153943597977" name="jetbrains.mps.baseLanguage.collections.structure.ForEachStatement" flags="nn" index="2Gpval">
+        <child id="1153944400369" name="variable" index="2Gsz3X" />
+        <child id="1153944424730" name="inputSequence" index="2GsD0m" />
+      </concept>
+      <concept id="1153944193378" name="jetbrains.mps.baseLanguage.collections.structure.ForEachVariable" flags="nr" index="2GrKxI" />
+      <concept id="1153944233411" name="jetbrains.mps.baseLanguage.collections.structure.ForEachVariableReference" flags="nn" index="2GrUjf">
+        <reference id="1153944258490" name="variable" index="2Gs0qQ" />
+      </concept>
+      <concept id="1237721394592" name="jetbrains.mps.baseLanguage.collections.structure.AbstractContainerCreator" flags="nn" index="HWqM0">
+        <child id="1237721435807" name="elementType" index="HW$YZ" />
+      </concept>
+      <concept id="1227008614712" name="jetbrains.mps.baseLanguage.collections.structure.LinkedListCreator" flags="nn" index="2Jqq0_" />
       <concept id="1203518072036" name="jetbrains.mps.baseLanguage.collections.structure.SmartClosureParameterDeclaration" flags="ig" index="Rh6nW" />
+      <concept id="1160612413312" name="jetbrains.mps.baseLanguage.collections.structure.AddElementOperation" flags="nn" index="TSZUe" />
       <concept id="1201792049884" name="jetbrains.mps.baseLanguage.collections.structure.TranslateOperation" flags="nn" index="3goQfb" />
       <concept id="1202120902084" name="jetbrains.mps.baseLanguage.collections.structure.WhereOperation" flags="nn" index="3zZkjj" />
       <concept id="1202128969694" name="jetbrains.mps.baseLanguage.collections.structure.SelectOperation" flags="nn" index="3$u5V9" />
@@ -155,6 +174,31 @@
     <property role="TrG5h" value="test_modules_not_part_of_build_script" />
     <node concept="1MIXq2" id="6wojtGU5kGj" role="14J5yK">
       <node concept="3clFbS" id="6wojtGU5kGk" role="2VODD2">
+        <node concept="3cpWs8" id="4XPt_HaUL0q" role="3cqZAp">
+          <node concept="3cpWsn" id="4XPt_HaUL0t" role="3cpWs9">
+            <property role="TrG5h" value="res" />
+            <node concept="_YKpA" id="3bllPAaPI5a" role="1tU5fm">
+              <node concept="3uibUv" id="3bllPAaPI5b" role="_ZDj9">
+                <ref role="3uigEE" to="zn9m:~Pair" resolve="Pair" />
+                <node concept="17QB3L" id="3bllPAaPI5c" role="11_B2D" />
+                <node concept="3uibUv" id="4XPt_HaUTTl" role="11_B2D">
+                  <ref role="3uigEE" to="lui2:~SModule" resolve="SModule" />
+                </node>
+              </node>
+            </node>
+            <node concept="2ShNRf" id="4XPt_HaUNkp" role="33vP2m">
+              <node concept="2Jqq0_" id="4XPt_HaUO4e" role="2ShVmc">
+                <node concept="3uibUv" id="4XPt_HaUOOL" role="HW$YZ">
+                  <ref role="3uigEE" to="zn9m:~Pair" resolve="Pair" />
+                  <node concept="17QB3L" id="4XPt_HaUQGh" role="11_B2D" />
+                  <node concept="3uibUv" id="4XPt_HaURvP" role="11_B2D">
+                    <ref role="3uigEE" to="lui2:~SModule" resolve="SModule" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
         <node concept="3cpWs8" id="6wojtGU69QD" role="3cqZAp">
           <node concept="3cpWsn" id="6wojtGU69QE" role="3cpWs9">
             <property role="TrG5h" value="modules" />
@@ -171,6 +215,7 @@
             </node>
           </node>
         </node>
+        <node concept="3clFbH" id="4XPt_HaUHFz" role="3cqZAp" />
         <node concept="3cpWs8" id="6wojtGUkV5_" role="3cqZAp">
           <node concept="3cpWsn" id="6wojtGUkV5A" role="3cpWs9">
             <property role="TrG5h" value="testModules" />
@@ -417,39 +462,39 @@
             </node>
           </node>
         </node>
-        <node concept="3cpWs6" id="6wojtGU6QCC" role="3cqZAp">
-          <node concept="2OqwBi" id="6wojtGU6QCE" role="3cqZAk">
-            <node concept="2OqwBi" id="4I5DMJFtpRZ" role="2Oq$k0">
-              <node concept="37vLTw" id="6wojtGUoAQM" role="2Oq$k0">
-                <ref role="3cqZAo" node="6wojtGUoAQH" resolve="missingTestModules" />
-              </node>
-              <node concept="3$u5V9" id="4I5DMJFtqRM" role="2OqNvi">
-                <node concept="1bVj0M" id="4I5DMJFtqRO" role="23t8la">
-                  <node concept="3clFbS" id="4I5DMJFtqRP" role="1bW5cS">
-                    <node concept="3clFbF" id="4I5DMJFtrDx" role="3cqZAp">
-                      <node concept="3cpWs3" id="4I5DMJFtvAN" role="3clFbG">
-                        <node concept="Xl_RD" id="4I5DMJFtvAX" role="3uHU7w">
-                          <property role="Xl_RC" value="' is not part of a build script" />
-                        </node>
-                        <node concept="3cpWs3" id="4I5DMJFttWX" role="3uHU7B">
-                          <node concept="Xl_RD" id="4I5DMJFtrDw" role="3uHU7B">
-                            <property role="Xl_RC" value="Module '" />
-                          </node>
-                          <node concept="37vLTw" id="4I5DMJFtusq" role="3uHU7w">
-                            <ref role="3cqZAo" node="4I5DMJFtqRQ" resolve="it" />
-                          </node>
-                        </node>
+        <node concept="2Gpval" id="4XPt_HaUV9D" role="3cqZAp">
+          <node concept="2GrKxI" id="4XPt_HaUV9F" role="2Gsz3X">
+            <property role="TrG5h" value="module" />
+          </node>
+          <node concept="37vLTw" id="4XPt_HaUZOb" role="2GsD0m">
+            <ref role="3cqZAo" node="6wojtGUoAQH" resolve="missingTestModules" />
+          </node>
+          <node concept="3clFbS" id="4XPt_HaUV9J" role="2LFqv$">
+            <node concept="3clFbF" id="4XPt_HaV0n8" role="3cqZAp">
+              <node concept="2OqwBi" id="4XPt_HaV55l" role="3clFbG">
+                <node concept="37vLTw" id="4XPt_HaV0n7" role="2Oq$k0">
+                  <ref role="3cqZAo" node="4XPt_HaUL0t" resolve="res" />
+                </node>
+                <node concept="TSZUe" id="4XPt_HaV95X" role="2OqNvi">
+                  <node concept="2ShNRf" id="4XPt_HaV9Of" role="25WWJ7">
+                    <node concept="1pGfFk" id="4XPt_HaVaKJ" role="2ShVmc">
+                      <ref role="37wK5l" to="zn9m:~Pair.&lt;init&gt;(java.lang.Object,java.lang.Object)" resolve="Pair" />
+                      <node concept="Xl_RD" id="4XPt_HaVf6g" role="37wK5m">
+                        <property role="Xl_RC" value="Module is not part of a build script" />
+                      </node>
+                      <node concept="2GrUjf" id="4XPt_HaViTF" role="37wK5m">
+                        <ref role="2Gs0qQ" node="4XPt_HaUV9F" resolve="module" />
                       </node>
                     </node>
-                  </node>
-                  <node concept="Rh6nW" id="4I5DMJFtqRQ" role="1bW2Oz">
-                    <property role="TrG5h" value="it" />
-                    <node concept="2jxLKc" id="4I5DMJFtqRR" role="1tU5fm" />
                   </node>
                 </node>
               </node>
             </node>
-            <node concept="ANE8D" id="6wojtGU6QDg" role="2OqNvi" />
+          </node>
+        </node>
+        <node concept="3cpWs6" id="4XPt_HaV0UW" role="3cqZAp">
+          <node concept="37vLTw" id="4XPt_HaV0Wy" role="3cqZAk">
+            <ref role="3cqZAo" node="4XPt_HaUL0t" resolve="res" />
           </node>
         </node>
       </node>

--- a/code/languages/org.mpsqa.lint/solutions/org.mpsqa.lint.mps_lang.linters_library/models/org.mpsqa.lint.mps_lang.linters_library.typesystem_aspect.mps
+++ b/code/languages/org.mpsqa.lint/solutions/org.mpsqa.lint.mps_lang.linters_library/models/org.mpsqa.lint.mps_lang.linters_library.typesystem_aspect.mps
@@ -14,12 +14,10 @@
     <import index="zn9m" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.openapi.util(MPS.IDEA/)" />
     <import index="tpd4" ref="r:00000000-0000-4000-0000-011c895902b4(jetbrains.mps.lang.typesystem.structure)" />
     <import index="tp5g" ref="r:00000000-0000-4000-0000-011c89590388(jetbrains.mps.lang.test.structure)" />
-    <import index="c17a" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.language(MPS.OpenAPI/)" implicit="true" />
     <import index="tpee" ref="r:00000000-0000-4000-0000-011c895902ca(jetbrains.mps.baseLanguage.structure)" implicit="true" />
   </imports>
   <registry>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
-      <concept id="1202948039474" name="jetbrains.mps.baseLanguage.structure.InstanceMethodCallOperation" flags="nn" index="liA8E" />
       <concept id="1154032098014" name="jetbrains.mps.baseLanguage.structure.AbstractLoopStatement" flags="nn" index="2LF5Ji">
         <child id="1154032183016" name="body" index="2LFqv$" />
       </concept>
@@ -60,7 +58,6 @@
       <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
         <child id="1068581517665" name="statement" index="3cqZAp" />
       </concept>
-      <concept id="1068581242875" name="jetbrains.mps.baseLanguage.structure.PlusExpression" flags="nn" index="3cpWs3" />
       <concept id="1068581242878" name="jetbrains.mps.baseLanguage.structure.ReturnStatement" flags="nn" index="3cpWs6">
         <child id="1068581517676" name="expression" index="3cqZAk" />
       </concept>
@@ -76,10 +73,6 @@
       <concept id="1107535904670" name="jetbrains.mps.baseLanguage.structure.ClassifierType" flags="in" index="3uibUv">
         <reference id="1107535924139" name="classifier" index="3uigEE" />
         <child id="1109201940907" name="parameter" index="11_B2D" />
-      </concept>
-      <concept id="1081773326031" name="jetbrains.mps.baseLanguage.structure.BinaryOperation" flags="nn" index="3uHJSO">
-        <child id="1081773367579" name="rightExpression" index="3uHU7w" />
-        <child id="1081773367580" name="leftExpression" index="3uHU7B" />
       </concept>
       <concept id="6329021646629104954" name="jetbrains.mps.baseLanguage.structure.SingleLineComment" flags="nn" index="3SKdUt">
         <child id="8356039341262087992" name="line" index="1aUNEU" />
@@ -113,12 +106,8 @@
       <concept id="1177026924588" name="jetbrains.mps.lang.smodel.structure.RefConcept_Reference" flags="nn" index="chp4Y">
         <reference id="1177026940964" name="conceptDeclaration" index="cht4Q" />
       </concept>
-      <concept id="7453996997717780434" name="jetbrains.mps.lang.smodel.structure.Node_GetSConceptOperation" flags="nn" index="2yIwOk" />
       <concept id="1138055754698" name="jetbrains.mps.lang.smodel.structure.SNodeType" flags="in" index="3Tqbb2">
         <reference id="1138405853777" name="concept" index="ehGHo" />
-      </concept>
-      <concept id="1138056022639" name="jetbrains.mps.lang.smodel.structure.SPropertyAccess" flags="nn" index="3TrcHB">
-        <reference id="1138056395725" name="property" index="3TsBF5" />
       </concept>
       <concept id="1138056143562" name="jetbrains.mps.lang.smodel.structure.SLinkAccess" flags="nn" index="3TrEf2">
         <reference id="1138056516764" name="link" index="3Tt5mk" />
@@ -264,41 +253,8 @@
               <node concept="3cpWsn" id="2zdrQh7uD_N" role="3cpWs9">
                 <property role="TrG5h" value="msg" />
                 <node concept="17QB3L" id="2zdrQh7uD_O" role="1tU5fm" />
-                <node concept="3cpWs3" id="2zdrQh7uD_P" role="33vP2m">
-                  <node concept="3cpWs3" id="2zdrQh7uD_Q" role="3uHU7B">
-                    <node concept="3cpWs3" id="2zdrQh7uD_R" role="3uHU7B">
-                      <node concept="Xl_RD" id="2zdrQh7uD_S" role="3uHU7w">
-                        <property role="Xl_RC" value=" of concept '" />
-                      </node>
-                      <node concept="3cpWs3" id="2zdrQh7uD_T" role="3uHU7B">
-                        <node concept="Xl_RD" id="2zdrQh7uD_U" role="3uHU7B">
-                          <property role="Xl_RC" value="Checking rule " />
-                        </node>
-                        <node concept="2OqwBi" id="2zdrQh7uD_V" role="3uHU7w">
-                          <node concept="37vLTw" id="2zdrQh7uGRr" role="2Oq$k0">
-                            <ref role="3cqZAo" node="2zdrQh7uFfS" resolve="checkingRule" />
-                          </node>
-                          <node concept="3TrcHB" id="2zdrQh7uD_X" role="2OqNvi">
-                            <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                    <node concept="2OqwBi" id="2zdrQh7uD_Y" role="3uHU7w">
-                      <node concept="2OqwBi" id="2zdrQh7uD_Z" role="2Oq$k0">
-                        <node concept="37vLTw" id="2zdrQh7uGKK" role="2Oq$k0">
-                          <ref role="3cqZAo" node="2zdrQh7uFfS" resolve="checkingRule" />
-                        </node>
-                        <node concept="2yIwOk" id="2zdrQh7uDA1" role="2OqNvi" />
-                      </node>
-                      <node concept="liA8E" id="2zdrQh7uDA2" role="2OqNvi">
-                        <ref role="37wK5l" to="c17a:~SAbstractConcept.getName()" resolve="getName" />
-                      </node>
-                    </node>
-                  </node>
-                  <node concept="Xl_RD" id="2zdrQh7uDA3" role="3uHU7w">
-                    <property role="Xl_RC" value="' is empty" />
-                  </node>
+                <node concept="Xl_RD" id="4XPt_HaVlUE" role="33vP2m">
+                  <property role="Xl_RC" value="Checking rule is empty" />
                 </node>
               </node>
             </node>
@@ -394,11 +350,6 @@
           <property role="3oM_SC" value="tests." />
         </node>
       </node>
-    </node>
-    <node concept="3dgnlM" id="5ILDA6EUYgi" role="3dgnlQ">
-      <property role="3dgnlN" value="Class for linter 'not_tested' couldn't be found. The model is probably not generated." />
-      <property role="3qxsY3" value="6607245066738849851" />
-      <property role="3qxsSb" value="r:59e2876f-999a-4af1-8c54-345ff89e1fb6" />
     </node>
     <node concept="1MIXq2" id="5ILDA6EXlkB" role="14J5yK">
       <node concept="3clFbS" id="5ILDA6EXlkC" role="2VODD2">
@@ -559,6 +510,11 @@
           </node>
         </node>
       </node>
+    </node>
+    <node concept="3dgnlM" id="5ILDA6EUYgi" role="3dgnlQ">
+      <property role="3dgnlN" value="Class for linter 'not_tested' couldn't be found. The model is probably not generated." />
+      <property role="3qxsY3" value="6607245066738849851" />
+      <property role="3qxsSb" value="r:59e2876f-999a-4af1-8c54-345ff89e1fb6" />
     </node>
   </node>
 </model>


### PR DESCRIPTION
This is a follow-up of https://github.com/mbeddr/mps-qa/pull/184 where a forgot to adapt the saved messages and I also fixed a few linters where the error reporting was missing information. With this new change, you can also navigate in the checker results to files, nodes, models and modules. Files can now be returned as a result in linters.