### PR TITLE
[breaking] Configurable JUnit report directory

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -60,7 +60,7 @@ ext.dependencyRepositories = [
 ]
 
 // Dependency versions
-ext.mpsVersion = '2023.2'
+ext.mpsVersion = '2023.2.1'
 
 // Project versions
 ext.major = '2023'

--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,7 @@ if (ext.has('java11_home')) {
     jdk_home = System.getenv('JB_JAVA11_HOME')
 } else {
     def expected = JavaVersion.VERSION_11
-    if (JavaVersion.current() != expected) {
+    if (JavaVersion.current() < expected) {
         throw new GradleException("This build script requires Java 11 but you are currently using ${JavaVersion.current()}.\nWhat you can do:\n"
                 + "  * Use project property java11_home to point to the Java 11 JDK.\n"
                 + "  * Use environment variable JB_JAVA11_HOME to point to the Java 11 JDK\n"

--- a/code/languages/org.mpsqa.testing/languages/org.mpsqa.testcov.buildIntegration.jacoco/generator/templates/org.mpsqa.testcov.buildIntegration.jacoco.generator.templates@generator.mps
+++ b/code/languages/org.mpsqa.testing/languages/org.mpsqa.testcov.buildIntegration.jacoco/generator/templates/org.mpsqa.testcov.buildIntegration.jacoco.generator.templates@generator.mps
@@ -28,6 +28,7 @@
     <import index="arit" ref="r:0d66e868-9778-4307-b6f9-4795c00f662f(jetbrains.mps.build.workflow.preset.general)" />
     <import index="ghic" ref="r:027cef15-cbe6-4eb7-95e6-aa7a538ab07c(org.mpsqa.testcov.buildIntegration.jacoco.generator.util)" />
     <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" implicit="true" />
+    <import index="jvez" ref="r:76c0c154-d1d8-4324-a714-0c8d4f287536(org.mpsqa.testcov.buildIntegration.jacoco.behavior)" implicit="true" />
   </imports>
   <registry>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
@@ -186,9 +187,7 @@
         <property id="6666499814681447926" name="attrName" index="2pNUuO" />
         <child id="6666499814681541918" name="value" index="2pMdts" />
       </concept>
-      <concept id="1622293396948952339" name="jetbrains.mps.core.xml.structure.XmlText" flags="nn" index="3o6iSG">
-        <property id="1622293396948953704" name="value" index="3o6i5n" />
-      </concept>
+      <concept id="1622293396948952339" name="jetbrains.mps.core.xml.structure.XmlText" flags="nn" index="3o6iSG" />
     </language>
     <language id="b401a680-8325-4110-8fd3-84331ff25bef" name="jetbrains.mps.lang.generator">
       <concept id="1510949579266781519" name="jetbrains.mps.lang.generator.structure.TemplateCallMacro" flags="ln" index="5jKBG">
@@ -2105,88 +2104,54 @@
                 <node concept="2pNUuL" id="4MTm4Diq_iW" role="2pNNFR">
                   <property role="2pNUuO" value="reports" />
                   <node concept="2pMdtt" id="4MTm4DiqDZW" role="2pMdts">
-                    <property role="2pMdty" value="${build.tmp}" />
+                    <property role="2pMdty" value="getDefaultReportsDir()" />
                     <node concept="17Uvod" id="4MTm4DiqDZX" role="lGtFl">
                       <property role="2qtEX9" value="text" />
                       <property role="P4ACc" value="479c7a8c-02f9-43b5-9139-d910cb22f298/6666499814681541919/6666499814681541920" />
                       <node concept="3zFVjK" id="4MTm4DiqDZY" role="3zH0cK">
                         <node concept="3clFbS" id="4MTm4DiqDZZ" role="2VODD2">
-                          <node concept="3SKdUt" id="4MTm4Disfnn" role="3cqZAp">
-                            <node concept="1PaTwC" id="4MTm4Disfno" role="1aUNEU">
-                              <node concept="3oM_SD" id="4MTm4DisfFo" role="1PaTwD">
-                                <property role="3oM_SC" value="the" />
-                              </node>
-                              <node concept="3oM_SD" id="4MTm4DisfFt" role="1PaTwD">
-                                <property role="3oM_SC" value="value" />
-                              </node>
-                              <node concept="3oM_SD" id="4MTm4DisfJp" role="1PaTwD">
-                                <property role="3oM_SC" value="&quot;build.tmp&quot;" />
-                              </node>
-                              <node concept="3oM_SD" id="4MTm4DisfSw" role="1PaTwD">
-                                <property role="3oM_SC" value="is" />
-                              </node>
-                              <node concept="3oM_SD" id="4MTm4DisfTT" role="1PaTwD">
-                                <property role="3oM_SC" value="hardcoded" />
-                              </node>
-                              <node concept="3oM_SD" id="4MTm4Disg0u" role="1PaTwD">
-                                <property role="3oM_SC" value="in" />
-                              </node>
-                              <node concept="3oM_SD" id="4MTm4Disg1T" role="1PaTwD">
-                                <property role="3oM_SC" value="the" />
-                              </node>
-                              <node concept="3oM_SD" id="4MTm4Disg4B" role="1PaTwD">
-                                <property role="3oM_SC" value="gen" />
-                              </node>
-                              <node concept="3oM_SD" id="4MTm4Disg9S" role="1PaTwD">
-                                <property role="3oM_SC" value="template" />
-                              </node>
-                              <node concept="3oM_SD" id="4MTm4DisgcH" role="1PaTwD">
-                                <property role="3oM_SC" value="for" />
-                              </node>
-                              <node concept="3oM_SD" id="4MTm4Disgfu" role="1PaTwD">
-                                <property role="3oM_SC" value="BuildProject" />
+                          <node concept="3clFbJ" id="4rL2kFIpnW4" role="3cqZAp">
+                            <node concept="3clFbS" id="4rL2kFIpnW6" role="3clFbx">
+                              <node concept="3cpWs6" id="4MTm4DiqE0j" role="3cqZAp">
+                                <node concept="2OqwBi" id="4rL2kFIq46i" role="3cqZAk">
+                                  <node concept="30H73N" id="4rL2kFIq15O" role="2Oq$k0" />
+                                  <node concept="2qgKlT" id="4rL2kFIq56Q" role="2OqNvi">
+                                    <ref role="37wK5l" to="jvez:4rL2kFIpMLw" resolve="getDefaultReportsDir" />
+                                  </node>
+                                </node>
                               </node>
                             </node>
-                          </node>
-                          <node concept="3SKdUt" id="4MTm4Diszz2" role="3cqZAp">
-                            <node concept="1PaTwC" id="4MTm4Diszz3" role="1aUNEU">
-                              <node concept="3oM_SD" id="4MTm4DiszF1" role="1PaTwD">
-                                <property role="3oM_SC" value="as" />
-                              </node>
-                              <node concept="3oM_SD" id="4MTm4DiszGm" role="1PaTwD">
-                                <property role="3oM_SC" value="the" />
-                              </node>
-                              <node concept="3oM_SD" id="4MTm4DiszHI" role="1PaTwD">
-                                <property role="3oM_SC" value="name" />
-                              </node>
-                              <node concept="3oM_SD" id="4MTm4DiszKp" role="1PaTwD">
-                                <property role="3oM_SC" value="of" />
-                              </node>
-                              <node concept="3oM_SD" id="4MTm4DiszLM" role="1PaTwD">
-                                <property role="3oM_SC" value="a" />
-                              </node>
-                              <node concept="3oM_SD" id="4MTm4DiszPH" role="1PaTwD">
-                                <property role="3oM_SC" value="&quot;location" />
-                              </node>
-                              <node concept="3oM_SD" id="4MTm4DiszYT" role="1PaTwD">
-                                <property role="3oM_SC" value="macro&quot;" />
-                              </node>
-                              <node concept="3oM_SD" id="4MTm4Dis$9J" role="1PaTwD">
-                                <property role="3oM_SC" value="in" />
-                              </node>
-                              <node concept="3oM_SD" id="4MTm4Dis$bc" role="1PaTwD">
-                                <property role="3oM_SC" value="the" />
-                              </node>
-                              <node concept="3oM_SD" id="4MTm4Dis$cF" role="1PaTwD">
-                                <property role="3oM_SC" value="target" />
-                              </node>
-                              <node concept="3oM_SD" id="4MTm4Dis$i1" role="1PaTwD">
-                                <property role="3oM_SC" value="BwfProject" />
+                            <node concept="3clFbC" id="4rL2kFIpp65" role="3clFbw">
+                              <node concept="10Nm6u" id="4rL2kFIppaK" role="3uHU7w" />
+                              <node concept="2OqwBi" id="4rL2kFIporw" role="3uHU7B">
+                                <node concept="30H73N" id="4rL2kFIpnXm" role="2Oq$k0" />
+                                <node concept="3TrEf2" id="4rL2kFIpoGZ" role="2OqNvi">
+                                  <ref role="3Tt5mk" to="km3i:6EMlENDKT4V" resolve="reportsDir" />
+                                </node>
                               </node>
                             </node>
-                          </node>
-                          <node concept="3cpWs6" id="4MTm4DiqE0j" role="3cqZAp">
-                            <node concept="3zGtF$" id="4MTm4DiqE0k" role="3cqZAk" />
+                            <node concept="9aQIb" id="4rL2kFIppe8" role="9aQIa">
+                              <node concept="3clFbS" id="4rL2kFIppe9" role="9aQI4">
+                                <node concept="3cpWs6" id="4rL2kFIpAGX" role="3cqZAp">
+                                  <node concept="2OqwBi" id="4rL2kFIpEEQ" role="3cqZAk">
+                                    <node concept="2OqwBi" id="4rL2kFIpCGM" role="2Oq$k0">
+                                      <node concept="30H73N" id="4rL2kFIpASF" role="2Oq$k0" />
+                                      <node concept="3TrEf2" id="4rL2kFIpCNw" role="2OqNvi">
+                                        <ref role="3Tt5mk" to="km3i:6EMlENDKT4V" resolve="reportsDir" />
+                                      </node>
+                                    </node>
+                                    <node concept="2qgKlT" id="4rL2kFIpEQa" role="2OqNvi">
+                                      <ref role="37wK5l" to="vbkb:7ro1ZztyOh5" resolve="getAntPath" />
+                                      <node concept="2YIFZM" id="4rL2kFIpF0M" role="37wK5m">
+                                        <ref role="37wK5l" to="o3n2:19KdqCVerNJ" resolve="defaultContext" />
+                                        <ref role="1Pybhc" to="o3n2:4jjtc7WZOAv" resolve="Context" />
+                                        <node concept="1iwH7S" id="4rL2kFIpF6I" role="37wK5m" />
+                                      </node>
+                                    </node>
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
                           </node>
                         </node>
                       </node>
@@ -3409,207 +3374,6 @@
                       </node>
                     </node>
                   </node>
-                </node>
-              </node>
-            </node>
-            <node concept="2Vbh7Z" id="4MTm4Diqv80" role="2VaTZU">
-              <node concept="2pNNFK" id="4MTm4Diqwgv" role="2Vbh7K">
-                <property role="2pNNFO" value="copy" />
-                <node concept="2pNUuL" id="4MTm4DiD3fd" role="2pNNFR">
-                  <property role="2pNUuO" value="todir" />
-                  <node concept="2pMdtt" id="4MTm4DiD3fe" role="2pMdts">
-                    <property role="2pMdty" value="." />
-                  </node>
-                </node>
-                <node concept="3o6iSG" id="4MTm4DisS_7" role="3o6s8t" />
-                <node concept="2pNNFK" id="4MTm4DisSBU" role="3o6s8t">
-                  <property role="2pNNFO" value="fileset" />
-                  <node concept="2pNNFK" id="4MTm4DisSTK" role="3o6s8t">
-                    <property role="2pNNFO" value="include" />
-                    <node concept="2pNUuL" id="4MTm4DisSXC" role="2pNNFR">
-                      <property role="2pNUuO" value="name" />
-                      <node concept="2pMdtt" id="4MTm4DisSXD" role="2pMdts">
-                        <property role="2pMdty" value="TEST*.xml" />
-                      </node>
-                    </node>
-                  </node>
-                  <node concept="2pNNFK" id="51DD0tdOYD2" role="3o6s8t">
-                    <property role="2pNNFO" value="include" />
-                    <node concept="2pNUuL" id="51DD0tdOYD3" role="2pNNFR">
-                      <property role="2pNUuO" value="name" />
-                      <node concept="2pMdtt" id="51DD0tdOYD4" role="2pMdts">
-                        <property role="2pMdty" value="junit-platform-events*.xml" />
-                      </node>
-                    </node>
-                  </node>
-                  <node concept="2pNUuL" id="4MTm4DisSEC" role="2pNNFR">
-                    <property role="2pNUuO" value="dir" />
-                    <node concept="2pMdtt" id="4MTm4DisSHe" role="2pMdts">
-                      <property role="2pMdty" value="${build.tmp}" />
-                      <node concept="17Uvod" id="4MTm4DisSHf" role="lGtFl">
-                        <property role="2qtEX9" value="text" />
-                        <property role="P4ACc" value="479c7a8c-02f9-43b5-9139-d910cb22f298/6666499814681541919/6666499814681541920" />
-                        <node concept="3zFVjK" id="4MTm4DisSHg" role="3zH0cK">
-                          <node concept="3clFbS" id="4MTm4DisSHh" role="2VODD2">
-                            <node concept="3SKdUt" id="4MTm4DisSHi" role="3cqZAp">
-                              <node concept="1PaTwC" id="4MTm4DisSHj" role="1aUNEU">
-                                <node concept="3oM_SD" id="4MTm4DisSHk" role="1PaTwD">
-                                  <property role="3oM_SC" value="the" />
-                                </node>
-                                <node concept="3oM_SD" id="4MTm4DisSHl" role="1PaTwD">
-                                  <property role="3oM_SC" value="value" />
-                                </node>
-                                <node concept="3oM_SD" id="4MTm4DisSHm" role="1PaTwD">
-                                  <property role="3oM_SC" value="&quot;build.tmp&quot;" />
-                                </node>
-                                <node concept="3oM_SD" id="4MTm4DisSHn" role="1PaTwD">
-                                  <property role="3oM_SC" value="is" />
-                                </node>
-                                <node concept="3oM_SD" id="4MTm4DisSHo" role="1PaTwD">
-                                  <property role="3oM_SC" value="hardcoded" />
-                                </node>
-                                <node concept="3oM_SD" id="4MTm4DisSHp" role="1PaTwD">
-                                  <property role="3oM_SC" value="in" />
-                                </node>
-                                <node concept="3oM_SD" id="4MTm4DisSHq" role="1PaTwD">
-                                  <property role="3oM_SC" value="the" />
-                                </node>
-                                <node concept="3oM_SD" id="4MTm4DisSHr" role="1PaTwD">
-                                  <property role="3oM_SC" value="gen" />
-                                </node>
-                                <node concept="3oM_SD" id="4MTm4DisSHs" role="1PaTwD">
-                                  <property role="3oM_SC" value="template" />
-                                </node>
-                                <node concept="3oM_SD" id="4MTm4DisSHt" role="1PaTwD">
-                                  <property role="3oM_SC" value="for" />
-                                </node>
-                                <node concept="3oM_SD" id="4MTm4DisSHu" role="1PaTwD">
-                                  <property role="3oM_SC" value="BuildProject" />
-                                </node>
-                              </node>
-                            </node>
-                            <node concept="3SKdUt" id="4MTm4DisSHv" role="3cqZAp">
-                              <node concept="1PaTwC" id="4MTm4DisSHw" role="1aUNEU">
-                                <node concept="3oM_SD" id="4MTm4DisSHx" role="1PaTwD">
-                                  <property role="3oM_SC" value="as" />
-                                </node>
-                                <node concept="3oM_SD" id="4MTm4DisSHy" role="1PaTwD">
-                                  <property role="3oM_SC" value="the" />
-                                </node>
-                                <node concept="3oM_SD" id="4MTm4DisSHz" role="1PaTwD">
-                                  <property role="3oM_SC" value="name" />
-                                </node>
-                                <node concept="3oM_SD" id="4MTm4DisSH$" role="1PaTwD">
-                                  <property role="3oM_SC" value="of" />
-                                </node>
-                                <node concept="3oM_SD" id="4MTm4DisSH_" role="1PaTwD">
-                                  <property role="3oM_SC" value="a" />
-                                </node>
-                                <node concept="3oM_SD" id="4MTm4DisSHA" role="1PaTwD">
-                                  <property role="3oM_SC" value="&quot;location" />
-                                </node>
-                                <node concept="3oM_SD" id="4MTm4DisSHB" role="1PaTwD">
-                                  <property role="3oM_SC" value="macro&quot;" />
-                                </node>
-                                <node concept="3oM_SD" id="4MTm4DisSHC" role="1PaTwD">
-                                  <property role="3oM_SC" value="in" />
-                                </node>
-                                <node concept="3oM_SD" id="4MTm4DisSHD" role="1PaTwD">
-                                  <property role="3oM_SC" value="the" />
-                                </node>
-                                <node concept="3oM_SD" id="4MTm4DisSHE" role="1PaTwD">
-                                  <property role="3oM_SC" value="target" />
-                                </node>
-                                <node concept="3oM_SD" id="4MTm4DisSHF" role="1PaTwD">
-                                  <property role="3oM_SC" value="BwfProject" />
-                                </node>
-                              </node>
-                            </node>
-                            <node concept="3cpWs6" id="4MTm4DisSHG" role="3cqZAp">
-                              <node concept="3zGtF$" id="4MTm4DisSHH" role="3cqZAk" />
-                            </node>
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                </node>
-                <node concept="3o6iSG" id="4MTm4DisSAw" role="3o6s8t" />
-                <node concept="2pNNFK" id="4MTm4DisPI$" role="3o6s8t">
-                  <property role="2pNNFO" value="globmapper" />
-                  <node concept="2pNUuL" id="4MTm4DisPNH" role="2pNNFR">
-                    <property role="2pNUuO" value="from" />
-                    <node concept="2pMdtt" id="4MTm4DisPNI" role="2pMdts">
-                      <property role="2pMdty" value="*.xml" />
-                    </node>
-                  </node>
-                  <node concept="2pNUuL" id="4MTm4DisPQn" role="2pNNFR">
-                    <property role="2pNUuO" value="to" />
-                    <node concept="2pMdtt" id="4MTm4DisPQo" role="2pMdts">
-                      <property role="2pMdty" value="*-name.xml" />
-                      <node concept="17Uvod" id="4MTm4DiD7H8" role="lGtFl">
-                        <property role="2qtEX9" value="text" />
-                        <property role="P4ACc" value="479c7a8c-02f9-43b5-9139-d910cb22f298/6666499814681541919/6666499814681541920" />
-                        <node concept="3zFVjK" id="4MTm4DiD7H9" role="3zH0cK">
-                          <node concept="3clFbS" id="4MTm4DiD7Ha" role="2VODD2">
-                            <node concept="3cpWs8" id="4MTm4DiDa2I" role="3cqZAp">
-                              <node concept="3cpWsn" id="4MTm4DiDa2J" role="3cpWs9">
-                                <property role="TrG5h" value="project" />
-                                <node concept="1PxgMI" id="4MTm4DiDa2K" role="33vP2m">
-                                  <node concept="2OqwBi" id="4MTm4DiDa2L" role="1m5AlR">
-                                    <node concept="30H73N" id="4MTm4DiDa2M" role="2Oq$k0" />
-                                    <node concept="2Rxl7S" id="4MTm4DiDa2N" role="2OqNvi" />
-                                  </node>
-                                  <node concept="chp4Y" id="4MTm4DiDa2O" role="3oSUPX">
-                                    <ref role="cht4Q" to="3ior:4RPz6WoY4Cj" resolve="BuildProject" />
-                                  </node>
-                                </node>
-                                <node concept="3Tqbb2" id="4MTm4DiDa2P" role="1tU5fm">
-                                  <ref role="ehGHo" to="3ior:4RPz6WoY4Cj" resolve="BuildProject" />
-                                </node>
-                              </node>
-                            </node>
-                            <node concept="3clFbJ" id="4MTm4DiDa2Q" role="3cqZAp">
-                              <node concept="3clFbC" id="4MTm4DiDa2R" role="3clFbw">
-                                <node concept="10Nm6u" id="4MTm4DiDa2S" role="3uHU7w" />
-                                <node concept="37vLTw" id="4MTm4DiDa2T" role="3uHU7B">
-                                  <ref role="3cqZAo" node="4MTm4DiDa2J" resolve="project" />
-                                </node>
-                              </node>
-                              <node concept="3clFbS" id="4MTm4DiDa2U" role="3clFbx">
-                                <node concept="3cpWs6" id="4MTm4DiDa31" role="3cqZAp">
-                                  <node concept="3zGtF$" id="4MTm4DiDa32" role="3cqZAk" />
-                                </node>
-                              </node>
-                            </node>
-                            <node concept="3cpWs6" id="4MTm4DiDduc" role="3cqZAp">
-                              <node concept="3cpWs3" id="4MTm4DiDd7E" role="3cqZAk">
-                                <node concept="Xl_RD" id="4MTm4DiDd9e" role="3uHU7w">
-                                  <property role="Xl_RC" value=".xml" />
-                                </node>
-                                <node concept="3cpWs3" id="4MTm4DiDcMC" role="3uHU7B">
-                                  <node concept="Xl_RD" id="4MTm4DiDc9v" role="3uHU7B">
-                                    <property role="Xl_RC" value="*-" />
-                                  </node>
-                                  <node concept="2OqwBi" id="4MTm4DiDcXx" role="3uHU7w">
-                                    <node concept="37vLTw" id="4MTm4DiDcPT" role="2Oq$k0">
-                                      <ref role="3cqZAo" node="4MTm4DiDa2J" resolve="project" />
-                                    </node>
-                                    <node concept="3TrcHB" id="4MTm4DiDd2X" role="2OqNvi">
-                                      <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
-                                    </node>
-                                  </node>
-                                </node>
-                              </node>
-                            </node>
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                </node>
-                <node concept="3o6iSG" id="4MTm4DisPG0" role="3o6s8t">
-                  <property role="3o6i5n" value="" />
                 </node>
               </node>
             </node>

--- a/code/languages/org.mpsqa.testing/languages/org.mpsqa.testcov.buildIntegration.jacoco/models/org.mpsqa.testcov.buildIntegration.jacoco.behavior.mps
+++ b/code/languages/org.mpsqa.testing/languages/org.mpsqa.testcov.buildIntegration.jacoco/models/org.mpsqa.testcov.buildIntegration.jacoco.behavior.mps
@@ -19,6 +19,7 @@
     <import index="o8zo" ref="r:314576fc-3aee-4386-a0a5-a38348ac317d(jetbrains.mps.scope)" />
     <import index="tpcu" ref="r:00000000-0000-4000-0000-011c89590282(jetbrains.mps.lang.core.behavior)" />
     <import index="5tjl" ref="r:5315d75f-2eea-4bf2-899f-f3d94810cea5(jetbrains.mps.build.mps.tests.structure)" implicit="true" />
+    <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" implicit="true" />
   </imports>
   <registry>
     <language id="af65afd8-f0dd-4942-87d9-63a55f2a9db1" name="jetbrains.mps.lang.behavior">
@@ -55,6 +56,9 @@
       <concept id="1137021947720" name="jetbrains.mps.baseLanguage.structure.ConceptFunction" flags="in" index="2VMwT0">
         <child id="1137022507850" name="body" index="2VODD2" />
       </concept>
+      <concept id="1070475926800" name="jetbrains.mps.baseLanguage.structure.StringLiteral" flags="nn" index="Xl_RD">
+        <property id="1070475926801" name="value" index="Xl_RC" />
+      </concept>
       <concept id="1081236700937" name="jetbrains.mps.baseLanguage.structure.StaticMethodCall" flags="nn" index="2YIFZM">
         <reference id="1144433194310" name="classConcept" index="1Pybhc" />
       </concept>
@@ -66,6 +70,7 @@
         <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
       </concept>
       <concept id="1068498886292" name="jetbrains.mps.baseLanguage.structure.ParameterDeclaration" flags="ir" index="37vLTG" />
+      <concept id="1225271177708" name="jetbrains.mps.baseLanguage.structure.StringType" flags="in" index="17QB3L" />
       <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
         <child id="5680397130376446158" name="type" index="1tU5fm" />
       </concept>
@@ -87,6 +92,7 @@
       <concept id="1068580320020" name="jetbrains.mps.baseLanguage.structure.IntegerConstant" flags="nn" index="3cmrfG">
         <property id="1068580320021" name="value" index="3cmrfH" />
       </concept>
+      <concept id="1068581242875" name="jetbrains.mps.baseLanguage.structure.PlusExpression" flags="nn" index="3cpWs3" />
       <concept id="1068581242878" name="jetbrains.mps.baseLanguage.structure.ReturnStatement" flags="nn" index="3cpWs6">
         <child id="1068581517676" name="expression" index="3cqZAk" />
       </concept>
@@ -151,6 +157,9 @@
       </concept>
       <concept id="1138055754698" name="jetbrains.mps.lang.smodel.structure.SNodeType" flags="in" index="3Tqbb2">
         <reference id="1138405853777" name="concept" index="ehGHo" />
+      </concept>
+      <concept id="1138056022639" name="jetbrains.mps.lang.smodel.structure.SPropertyAccess" flags="nn" index="3TrcHB">
+        <reference id="1138056395725" name="property" index="3TsBF5" />
       </concept>
       <concept id="1138056143562" name="jetbrains.mps.lang.smodel.structure.SLinkAccess" flags="nn" index="3TrEf2">
         <reference id="1138056516764" name="link" index="3Tt5mk" />
@@ -486,6 +495,26 @@
         </node>
       </node>
       <node concept="3cqZAl" id="1qsZtnKz0Rg" role="3clF45" />
+    </node>
+    <node concept="13i0hz" id="4rL2kFIpMLw" role="13h7CS">
+      <property role="TrG5h" value="getDefaultReportsDir" />
+      <node concept="3Tm1VV" id="4rL2kFIpMLx" role="1B3o_S" />
+      <node concept="17QB3L" id="4rL2kFIpMMc" role="3clF45" />
+      <node concept="3clFbS" id="4rL2kFIpMLz" role="3clF47">
+        <node concept="3clFbF" id="4rL2kFIpT4z" role="3cqZAp">
+          <node concept="3cpWs3" id="4rL2kFIpUlg" role="3clFbG">
+            <node concept="2OqwBi" id="4rL2kFIpULk" role="3uHU7w">
+              <node concept="13iPFW" id="4rL2kFIpUlK" role="2Oq$k0" />
+              <node concept="3TrcHB" id="4rL2kFIpV3W" role="2OqNvi">
+                <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+              </node>
+            </node>
+            <node concept="Xl_RD" id="4rL2kFIpT4y" role="3uHU7B">
+              <property role="Xl_RC" value="${build.dir}/test-reports/" />
+            </node>
+          </node>
+        </node>
+      </node>
     </node>
   </node>
   <node concept="13h7C7" id="4BvAvMowvQw">

--- a/code/languages/org.mpsqa.testing/languages/org.mpsqa.testcov.buildIntegration.jacoco/models/org.mpsqa.testcov.buildIntegration.jacoco.editor.mps
+++ b/code/languages/org.mpsqa.testing/languages/org.mpsqa.testcov.buildIntegration.jacoco/models/org.mpsqa.testcov.buildIntegration.jacoco.editor.mps
@@ -13,6 +13,11 @@
     <import index="5tjl" ref="r:5315d75f-2eea-4bf2-899f-f3d94810cea5(jetbrains.mps.build.mps.tests.structure)" />
     <import index="ljzu" ref="r:6f104b69-0cfd-4b06-895f-bc1a1b43170f(jetbrains.mps.build.mps.tests.editor)" />
     <import index="tpco" ref="r:00000000-0000-4000-0000-011c89590284(jetbrains.mps.lang.core.editor)" />
+    <import index="exr9" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.nodeEditor(MPS.Editor/)" />
+    <import index="f4zo" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor.cells(MPS.Editor/)" />
+    <import index="cj4x" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.openapi.editor(MPS.Editor/)" />
+    <import index="g51k" ref="1ed103c3-3aa6-49b7-9c21-6765ee11f224/java:jetbrains.mps.nodeEditor.cells(MPS.Editor/)" />
+    <import index="jvez" ref="r:76c0c154-d1d8-4324-a714-0c8d4f287536(org.mpsqa.testcov.buildIntegration.jacoco.behavior)" implicit="true" />
   </imports>
   <registry>
     <language id="18bc6592-03a6-4e29-a83a-7ff23bde13ba" name="jetbrains.mps.lang.editor">
@@ -20,10 +25,14 @@
       <concept id="1140524381322" name="jetbrains.mps.lang.editor.structure.CellModel_ListWithRole" flags="ng" index="2czfm3">
         <child id="1140524464360" name="cellLayout" index="2czzBx" />
       </concept>
+      <concept id="1078308402140" name="jetbrains.mps.lang.editor.structure.CellModel_Custom" flags="sg" stub="8104358048506730068" index="gc7cB">
+        <child id="1176795024817" name="cellProvider" index="3YsKMw" />
+      </concept>
       <concept id="1237303669825" name="jetbrains.mps.lang.editor.structure.CellLayout_Indent" flags="nn" index="l2Vlx" />
       <concept id="1237307900041" name="jetbrains.mps.lang.editor.structure.IndentLayoutIndentStyleClassItem" flags="ln" index="lj46D" />
       <concept id="1237308012275" name="jetbrains.mps.lang.editor.structure.IndentLayoutNewLineStyleClassItem" flags="ln" index="ljvvj" />
       <concept id="1237375020029" name="jetbrains.mps.lang.editor.structure.IndentLayoutNewLineChildrenStyleClassItem" flags="ln" index="pj6Ft" />
+      <concept id="1142886811589" name="jetbrains.mps.lang.editor.structure.ConceptFunctionParameter_node" flags="nn" index="pncrf" />
       <concept id="1237385578942" name="jetbrains.mps.lang.editor.structure.IndentLayoutOnNewLineStyleClassItem" flags="ln" index="pVoyu" />
       <concept id="1080736578640" name="jetbrains.mps.lang.editor.structure.BaseEditorComponent" flags="ig" index="2wURMF">
         <child id="1080736633877" name="cellModel" index="2wV5jI" />
@@ -44,6 +53,7 @@
       </concept>
       <concept id="1088185857835" name="jetbrains.mps.lang.editor.structure.InlineEditorComponent" flags="ig" index="1sVBvm" />
       <concept id="1139848536355" name="jetbrains.mps.lang.editor.structure.CellModel_WithRole" flags="ng" index="1$h60E">
+        <property id="1139852716018" name="noTargetText" index="1$x2rV" />
         <property id="1140017977771" name="readOnly" index="1Intyy" />
         <reference id="1140103550593" name="relationDeclaration" index="1NtTu8" />
       </concept>
@@ -61,11 +71,92 @@
       <concept id="1219418625346" name="jetbrains.mps.lang.editor.structure.IStyleContainer" flags="ngI" index="3F0Thp">
         <child id="1219418656006" name="styleItem" index="3F10Kt" />
       </concept>
-      <concept id="1073389882823" name="jetbrains.mps.lang.editor.structure.CellModel_RefNode" flags="sg" stub="730538219795960754" index="3F1sOY" />
+      <concept id="1073389882823" name="jetbrains.mps.lang.editor.structure.CellModel_RefNode" flags="sg" stub="730538219795960754" index="3F1sOY">
+        <property id="16410578721444372" name="customizeEmptyCell" index="2ru_X1" />
+        <child id="16410578721629643" name="emptyCellModel" index="2ruayu" />
+      </concept>
       <concept id="1073390211982" name="jetbrains.mps.lang.editor.structure.CellModel_RefNodeList" flags="sg" stub="2794558372793454595" index="3F2HdR" />
+      <concept id="1176749715029" name="jetbrains.mps.lang.editor.structure.QueryFunction_CellProvider" flags="in" index="3VJUX4" />
       <concept id="1166049232041" name="jetbrains.mps.lang.editor.structure.AbstractComponent" flags="ng" index="1XWOmA">
         <reference id="1166049300910" name="conceptDeclaration" index="1XX52x" />
       </concept>
+    </language>
+    <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1202948039474" name="jetbrains.mps.baseLanguage.structure.InstanceMethodCallOperation" flags="nn" index="liA8E" />
+      <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
+        <child id="1197027771414" name="operand" index="2Oq$k0" />
+        <child id="1197027833540" name="operation" index="2OqNvi" />
+      </concept>
+      <concept id="1145552977093" name="jetbrains.mps.baseLanguage.structure.GenericNewExpression" flags="nn" index="2ShNRf">
+        <child id="1145553007750" name="creator" index="2ShVmc" />
+      </concept>
+      <concept id="1137021947720" name="jetbrains.mps.baseLanguage.structure.ConceptFunction" flags="in" index="2VMwT0">
+        <child id="1137022507850" name="body" index="2VODD2" />
+      </concept>
+      <concept id="1070475926800" name="jetbrains.mps.baseLanguage.structure.StringLiteral" flags="nn" index="Xl_RD">
+        <property id="1070475926801" name="value" index="Xl_RC" />
+      </concept>
+      <concept id="1182160077978" name="jetbrains.mps.baseLanguage.structure.AnonymousClassCreator" flags="nn" index="YeOm9">
+        <child id="1182160096073" name="cls" index="YeSDq" />
+      </concept>
+      <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
+        <property id="1176718929932" name="isFinal" index="3TUv4t" />
+        <child id="1068431790190" name="initializer" index="33vP2m" />
+      </concept>
+      <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
+        <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
+      </concept>
+      <concept id="1068498886292" name="jetbrains.mps.baseLanguage.structure.ParameterDeclaration" flags="ir" index="37vLTG" />
+      <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
+        <child id="5680397130376446158" name="type" index="1tU5fm" />
+      </concept>
+      <concept id="1068580123132" name="jetbrains.mps.baseLanguage.structure.BaseMethodDeclaration" flags="ng" index="3clF44">
+        <property id="1181808852946" name="isFinal" index="DiZV1" />
+        <child id="1068580123133" name="returnType" index="3clF45" />
+        <child id="1068580123134" name="parameter" index="3clF46" />
+        <child id="1068580123135" name="body" index="3clF47" />
+      </concept>
+      <concept id="1068580123165" name="jetbrains.mps.baseLanguage.structure.InstanceMethodDeclaration" flags="ig" index="3clFb_">
+        <property id="1178608670077" name="isAbstract" index="1EzhhJ" />
+      </concept>
+      <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
+        <child id="1068580123156" name="expression" index="3clFbG" />
+      </concept>
+      <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
+        <child id="1068581517665" name="statement" index="3cqZAp" />
+      </concept>
+      <concept id="1068580123137" name="jetbrains.mps.baseLanguage.structure.BooleanConstant" flags="nn" index="3clFbT">
+        <property id="1068580123138" name="value" index="3clFbU" />
+      </concept>
+      <concept id="1068581242878" name="jetbrains.mps.baseLanguage.structure.ReturnStatement" flags="nn" index="3cpWs6">
+        <child id="1068581517676" name="expression" index="3cqZAk" />
+      </concept>
+      <concept id="1068581242864" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclarationStatement" flags="nn" index="3cpWs8">
+        <child id="1068581242865" name="localVariableDeclaration" index="3cpWs9" />
+      </concept>
+      <concept id="1068581242863" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclaration" flags="nr" index="3cpWsn" />
+      <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ngI" index="1ndlxa">
+        <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
+        <child id="1068499141038" name="actualArgument" index="37wK5m" />
+      </concept>
+      <concept id="1212685548494" name="jetbrains.mps.baseLanguage.structure.ClassCreator" flags="nn" index="1pGfFk" />
+      <concept id="1107461130800" name="jetbrains.mps.baseLanguage.structure.Classifier" flags="ng" index="3pOWGL">
+        <property id="521412098689998745" name="nonStatic" index="2bfB8j" />
+        <child id="5375687026011219971" name="member" index="jymVt" unordered="true" />
+      </concept>
+      <concept id="1107535904670" name="jetbrains.mps.baseLanguage.structure.ClassifierType" flags="in" index="3uibUv">
+        <reference id="1107535924139" name="classifier" index="3uigEE" />
+      </concept>
+      <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ngI" index="1B3ioH">
+        <child id="1178549979242" name="visibility" index="1B3o_S" />
+      </concept>
+      <concept id="1146644602865" name="jetbrains.mps.baseLanguage.structure.PublicVisibility" flags="nn" index="3Tm1VV" />
+      <concept id="1170345865475" name="jetbrains.mps.baseLanguage.structure.AnonymousClass" flags="ig" index="1Y3b0j">
+        <reference id="1170346070688" name="classifier" index="1Y3XeK" />
+      </concept>
+    </language>
+    <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
+      <concept id="1179409122411" name="jetbrains.mps.lang.smodel.structure.Node_ConceptMethodCall" flags="nn" index="2qgKlT" />
     </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
       <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ngI" index="TrEIO">
@@ -148,6 +239,108 @@
           <ref role="PMmxG" node="5rJPecpIeQS" resolve="ICoverageAspect_Common" />
           <node concept="ljvvj" id="5rJPecpIeS7" role="3F10Kt">
             <property role="VOm3f" value="true" />
+          </node>
+        </node>
+        <node concept="3F0ifn" id="4rL2kFIpM$$" role="3EZMnx">
+          <property role="3F0ifm" value="reports directory:" />
+        </node>
+        <node concept="3F1sOY" id="4rL2kFIpM_1" role="3EZMnx">
+          <property role="1$x2rV" value="&lt;use default&gt;" />
+          <property role="2ru_X1" value="true" />
+          <ref role="1NtTu8" to="km3i:6EMlENDKT4V" resolve="reportsDir" />
+          <node concept="ljvvj" id="4rL2kFIpM_g" role="3F10Kt">
+            <property role="VOm3f" value="true" />
+          </node>
+          <node concept="gc7cB" id="2Y_MYwbRshq" role="2ruayu">
+            <node concept="3VJUX4" id="2Y_MYwbRshr" role="3YsKMw">
+              <node concept="3clFbS" id="2Y_MYwbRshs" role="2VODD2">
+                <node concept="3clFbF" id="2Y_MYwbRsmt" role="3cqZAp">
+                  <node concept="2ShNRf" id="klpHT7qVv6" role="3clFbG">
+                    <node concept="YeOm9" id="klpHT7rnm3" role="2ShVmc">
+                      <node concept="1Y3b0j" id="klpHT7rnm6" role="YeSDq">
+                        <property role="2bfB8j" value="true" />
+                        <ref role="1Y3XeK" to="exr9:~AbstractCellProvider" resolve="AbstractCellProvider" />
+                        <ref role="37wK5l" to="exr9:~AbstractCellProvider.&lt;init&gt;(org.jetbrains.mps.openapi.model.SNode)" resolve="AbstractCellProvider" />
+                        <node concept="pncrf" id="1A9ZZarVmNl" role="37wK5m" />
+                        <node concept="3Tm1VV" id="klpHT7rnm7" role="1B3o_S" />
+                        <node concept="3clFb_" id="klpHT7rnm8" role="jymVt">
+                          <property role="1EzhhJ" value="false" />
+                          <property role="TrG5h" value="createEditorCell" />
+                          <property role="DiZV1" value="false" />
+                          <node concept="3Tm1VV" id="klpHT7rnm9" role="1B3o_S" />
+                          <node concept="3uibUv" id="klpHT7rnmb" role="3clF45">
+                            <ref role="3uigEE" to="f4zo:~EditorCell" resolve="EditorCell" />
+                          </node>
+                          <node concept="37vLTG" id="klpHT7rnmc" role="3clF46">
+                            <property role="TrG5h" value="context" />
+                            <node concept="3uibUv" id="klpHT7vG6A" role="1tU5fm">
+                              <ref role="3uigEE" to="cj4x:~EditorContext" resolve="EditorContext" />
+                            </node>
+                          </node>
+                          <node concept="3clFbS" id="klpHT7rnme" role="3clF47">
+                            <node concept="3cpWs8" id="klpHT7rnOa" role="3cqZAp">
+                              <node concept="3cpWsn" id="klpHT7rnO9" role="3cpWs9">
+                                <property role="3TUv4t" value="false" />
+                                <property role="TrG5h" value="cell" />
+                                <node concept="3uibUv" id="klpHT7wjvj" role="1tU5fm">
+                                  <ref role="3uigEE" to="g51k:~EditorCell_Label" resolve="EditorCell_Label" />
+                                </node>
+                                <node concept="2ShNRf" id="klpHT7rpgU" role="33vP2m">
+                                  <node concept="1pGfFk" id="klpHT7rpgV" role="2ShVmc">
+                                    <ref role="37wK5l" to="g51k:~EditorCell_Constant.&lt;init&gt;(jetbrains.mps.openapi.editor.EditorContext,org.jetbrains.mps.openapi.model.SNode,java.lang.String)" resolve="EditorCell_Constant" />
+                                    <node concept="37vLTw" id="klpHT7rnOd" role="37wK5m">
+                                      <ref role="3cqZAo" node="klpHT7rnmc" resolve="context" />
+                                    </node>
+                                    <node concept="pncrf" id="klpHT7rp$b" role="37wK5m" />
+                                    <node concept="Xl_RD" id="klpHT7rnOf" role="37wK5m">
+                                      <property role="Xl_RC" value="" />
+                                    </node>
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                            <node concept="3clFbF" id="klpHT7rnOg" role="3cqZAp">
+                              <node concept="2OqwBi" id="klpHT7rnOs" role="3clFbG">
+                                <node concept="37vLTw" id="klpHT7rnOr" role="2Oq$k0">
+                                  <ref role="3cqZAo" node="klpHT7rnO9" resolve="cell" />
+                                </node>
+                                <node concept="liA8E" id="klpHT7rnOt" role="2OqNvi">
+                                  <ref role="37wK5l" to="g51k:~EditorCell_Label.setDefaultText(java.lang.String)" resolve="setDefaultText" />
+                                  <node concept="2OqwBi" id="2Y_MYwbRy$$" role="37wK5m">
+                                    <node concept="pncrf" id="2Y_MYwbRydw" role="2Oq$k0" />
+                                    <node concept="2qgKlT" id="2Y_MYwbR$YB" role="2OqNvi">
+                                      <ref role="37wK5l" to="jvez:4rL2kFIpMLw" resolve="getDefaultReportsDir" />
+                                    </node>
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                            <node concept="3clFbF" id="klpHT7yKB2" role="3cqZAp">
+                              <node concept="2OqwBi" id="klpHT7yKMP" role="3clFbG">
+                                <node concept="37vLTw" id="klpHT7yKB0" role="2Oq$k0">
+                                  <ref role="3cqZAo" node="klpHT7rnO9" resolve="cell" />
+                                </node>
+                                <node concept="liA8E" id="klpHT7yLOw" role="2OqNvi">
+                                  <ref role="37wK5l" to="g51k:~EditorCell_Basic.setSelectable(boolean)" resolve="setSelectable" />
+                                  <node concept="3clFbT" id="klpHT7yLPL" role="37wK5m">
+                                    <property role="3clFbU" value="true" />
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                            <node concept="3cpWs6" id="klpHT7rr3F" role="3cqZAp">
+                              <node concept="37vLTw" id="klpHT7rre1" role="3cqZAk">
+                                <ref role="3cqZAo" node="klpHT7rnO9" resolve="cell" />
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
           </node>
         </node>
         <node concept="3F1sOY" id="5I1s5NvGTxr" role="3EZMnx">

--- a/code/languages/org.mpsqa.testing/languages/org.mpsqa.testcov.buildIntegration.jacoco/models/org.mpsqa.testcov.buildIntegration.jacoco.structure.mps
+++ b/code/languages/org.mpsqa.testing/languages/org.mpsqa.testcov.buildIntegration.jacoco/models/org.mpsqa.testcov.buildIntegration.jacoco.structure.mps
@@ -13,6 +13,9 @@
   </imports>
   <registry>
     <language id="c72da2b9-7cce-4447-8389-f407dc1158b7" name="jetbrains.mps.lang.structure">
+      <concept id="7862711839422615209" name="jetbrains.mps.lang.structure.structure.DocumentedNodeAnnotation" flags="ng" index="t5JxF">
+        <property id="7862711839422615217" name="text" index="t5JxN" />
+      </concept>
       <concept id="1169125787135" name="jetbrains.mps.lang.structure.structure.AbstractConceptDeclaration" flags="ig" index="PkWjJ">
         <property id="6714410169261853888" name="conceptId" index="EcuMT" />
         <property id="4628067390765907488" name="conceptShortDescription" index="R4oN_" />
@@ -90,8 +93,17 @@
     <property role="TrG5h" value="BuildAspect_MpsTestModulesWithCoverage" />
     <property role="34LRSv" value="test modules with coverage" />
     <ref role="1TJDcQ" to="5tjl:3X9rC2XzJdH" resolve="BuildAspect_MpsTestModules" />
+    <node concept="1TJgyj" id="6EMlENDKT4V" role="1TKVEi">
+      <property role="IQ2ns" value="7688302814531129659" />
+      <property role="20lmBu" value="fLJjDmT/aggregation" />
+      <property role="20kJfa" value="reportsDir" />
+      <ref role="20lvS9" to="3ior:6qcrfIJFdKY" resolve="BuildSourcePath" />
+    </node>
     <node concept="PrWs8" id="5rJPecpIaV5" role="PzmwI">
       <ref role="PrY4T" node="5rJPecpIaUT" resolve="ICoverageAspect" />
+    </node>
+    <node concept="t5JxF" id="6EMlENDKRhr" role="lGtFl">
+      <property role="t5JxN" value="Extends standard MPS module tests with coverage support" />
     </node>
   </node>
   <node concept="1TIwiD" id="65fUPtD3WWf">

--- a/code/languages/org.mpsqa.testing/languages/org.mpsqa.testcov.buildIntegration.jacoco/org.mpsqa.testcov.buildIntegration.jacoco.mpl
+++ b/code/languages/org.mpsqa.testing/languages/org.mpsqa.testcov.buildIntegration.jacoco/org.mpsqa.testcov.buildIntegration.jacoco.mpl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <language namespace="org.mpsqa.testcov.buildIntegration.jacoco" uuid="bf73e6d8-133f-42d0-a056-6fd1d29d022f" languageVersion="0" moduleVersion="0">
   <models>
-    <modelRoot contentPath="${module}" type="default">
+    <modelRoot type="default" contentPath="${module}">
       <sourceRoot location="models" />
     </modelRoot>
   </models>
@@ -115,6 +115,7 @@
     <dependency reexport="false">d7eb0a2a-bd50-4576-beae-e4a89db35f20(jetbrains.mps.lang.scopes.runtime)</dependency>
     <dependency reexport="false">2d3c70e9-aab2-4870-8d8d-6036800e4103(jetbrains.mps.kernel)</dependency>
     <dependency reexport="false">ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)</dependency>
+    <dependency reexport="false">1ed103c3-3aa6-49b7-9c21-6765ee11f224(MPS.Editor)</dependency>
   </dependencies>
   <languageVersions>
     <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="12" />
@@ -154,7 +155,10 @@
     <module reference="3f233e7f-b8a6-46d2-a57f-795d56775243(Annotations)" version="0" />
     <module reference="6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)" version="0" />
     <module reference="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)" version="0" />
+    <module reference="1ed103c3-3aa6-49b7-9c21-6765ee11f224(MPS.Editor)" version="0" />
+    <module reference="498d89d2-c2e9-11e2-ad49-6cf049e62fe5(MPS.IDEA)" version="0" />
     <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
+    <module reference="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61(MPS.Platform)" version="0" />
     <module reference="798100da-4f0a-421a-b991-71f8c50ce5d2(jetbrains.mps.build)" version="0" />
     <module reference="0cf935df-4699-4e9c-a132-fa109541cba3(jetbrains.mps.build.mps)" version="0" />
     <module reference="3600cb0a-44dd-4a5b-9968-22924406419e(jetbrains.mps.build.mps.tests)" version="0" />

--- a/code/languages/org.mpsqa.testing/sandbox/build.xml
+++ b/code/languages/org.mpsqa.testing/sandbox/build.xml
@@ -8,6 +8,7 @@
   <property name="mps.home" location="" />
   <property name="mpsqa.home" location="" />
   <property name="mps.macro.mpsqa.home" location="${mpsqa.home}" />
+  <property name="build.dir" location="" />
   <property name="artifacts.mps" location="${mps.home}" />
   <property name="artifacts.org.mpsqa.testing" location="${mpsqa.home}/build/artifacts/org.mpsqa.testing" />
   <property name="artifacts.org.mpsqa.base" location="${mpsqa.home}/build/artifacts/org.mpsqa.base" />
@@ -274,6 +275,7 @@
       <macro name="mps.home" path="${mps.home}" />
       <macro name="mpsqa.home" path="${mpsqa.home}" />
       <macro name="mps.macro.mpsqa.home" path="${mps.macro.mpsqa.home}" />
+      <macro name="build.dir" path="${build.dir}" />
     </generate>
   </target>
   
@@ -389,7 +391,7 @@
     <pathconvert property="mps.tests.path.string" refid="mps.tests.path" />
     <jacoco:agent property="agent.jvmarg" xmlns:jacoco="antlib:org.jacoco.ant" destfile="${build.tmp}/jacoco/test.exec" />
     <property name="build.jna.library.path" location="${artifacts.mps}/lib/jna" />
-    <launchtests fork="true" haltonfailure="true" mpshome="${artifacts.mps}" reports="${build.tmp}">      
+    <launchtests fork="true" haltonfailure="true" mpshome="${artifacts.mps}" reports="${build.dir}/test-reports/test">      
       <jvmargs>
         <arg value="-ea" />
         <arg value="-Xss2048k" />
@@ -496,15 +498,6 @@
         <path refid="mps.tests.path" />
       </testmodules>
     </launchtests>
-    <copy todir=".">      
-      <fileset dir="${build.tmp}">
-        <include name="TEST*.xml" />
-        <include name="junit-platform-events*.xml" />
-      </fileset>
-      
-      <globmapper from="*.xml" to="*-jacoco.sandbox.xml" />
-      
-    </copy>
     <jacoco:report xmlns:jacoco="antlib:org.jacoco.ant">
       <executiondata>
         <file file="${build.tmp}/jacoco/test.exec" />

--- a/code/languages/org.mpsqa.testing/sandbox/jacoco.sandbox.build/models/jacoco.sandbox.build.mps
+++ b/code/languages/org.mpsqa.testing/sandbox/jacoco.sandbox.build/models/jacoco.sandbox.build.mps
@@ -80,7 +80,9 @@
       </concept>
     </language>
     <language id="bf73e6d8-133f-42d0-a056-6fd1d29d022f" name="org.mpsqa.testcov.buildIntegration.jacoco">
-      <concept id="3501904696383148638" name="org.mpsqa.testcov.buildIntegration.jacoco.structure.BuildAspect_MpsTestModulesWithCoverage" flags="ng" index="19Et6q" />
+      <concept id="3501904696383148638" name="org.mpsqa.testcov.buildIntegration.jacoco.structure.BuildAspect_MpsTestModulesWithCoverage" flags="ng" index="19Et6q">
+        <child id="7688302814531129659" name="reportsDir" index="23ssun" />
+      </concept>
       <concept id="6264459678549847737" name="org.mpsqa.testcov.buildIntegration.jacoco.structure.ICoverageAspect" flags="ngI" index="1flRDq">
         <property id="7012081905492226787" name="runWithModuleTests" index="9whAO" />
         <child id="1149674635298787521" name="coverageOf" index="1rHEoW" />
@@ -375,6 +377,15 @@
           </node>
         </node>
       </node>
+      <node concept="398BVA" id="4rL2kFIrsez" role="23ssun">
+        <ref role="398BVh" node="4rL2kFIrses" resolve="build.dir" />
+        <node concept="2Ry0Ak" id="4rL2kFIrseA" role="iGT6I">
+          <property role="2Ry0Am" value="test-reports" />
+          <node concept="2Ry0Ak" id="4rL2kFIrwjV" role="2Ry0An">
+            <property role="2Ry0Am" value="test" />
+          </node>
+        </node>
+      </node>
     </node>
     <node concept="1y0Vig" id="oz4hQ$QQdU" role="1hWBAP" />
     <node concept="398rNT" id="3W4BA34kLb8" role="1l3spd">
@@ -382,6 +393,9 @@
       <node concept="398BVA" id="3W4BA34kLbc" role="398pKh">
         <ref role="398BVh" node="4L8SKciIAuI" resolve="mpsqa.home" />
       </node>
+    </node>
+    <node concept="398rNT" id="4rL2kFIrses" role="1l3spd">
+      <property role="TrG5h" value="build.dir" />
     </node>
   </node>
 </model>

--- a/code/languages/org.mpsqa.testing/solutions/org.mpsqa.testing.build/models/org.mpsqa.testing.build.mps
+++ b/code/languages/org.mpsqa.testing/solutions/org.mpsqa.testing.build/models/org.mpsqa.testing.build.mps
@@ -983,6 +983,11 @@
             <ref role="3bR37D" to="ffeo:7Kfy9QB6LfQ" resolve="jetbrains.mps.kernel" />
           </node>
         </node>
+        <node concept="1SiIV0" id="2Y_MYwbTD2f" role="3bR37C">
+          <node concept="3bR9La" id="2Y_MYwbTD2g" role="1SiIV1">
+            <ref role="3bR37D" to="ffeo:1TaHNgiIbIZ" resolve="MPS.Editor" />
+          </node>
+        </node>
       </node>
       <node concept="1E1JtD" id="2WwuhUZ0zvN" role="2G$12L">
         <property role="BnDLt" value="true" />


### PR DESCRIPTION
Provide a configuration parameter to set the test reports output directory for 'test modules with coverage'. The default is changed and is now `${build.dir}/test-reports/<test-suite-name>`. This is the reason for designating this change as breaking.

The change works around [MPS-37708](https://youtrack.jetbrains.com/issue/MPS-37708/launchtests-should-write-the-XML-report-into-the-correct-place-right-away). In the built-in 'test modules' aspect, the `<launchtests>` task first writes test reports into a designated directory and then copies them to the requested location. However, the copy will not happen if tests fail and `haltonfailure` is enabled.

To fix this, 'test modules with coverage' instead configures the `<launchtests>` task with the requested directory directly. However, the generated XML files written by the JUnit framework do not include the name of the test suite and thus outputs from different test suites could overwrite each other. To avoid this, the test suite name is included in the directory name instead.

In addition, the built-in 'test modules' aspect puts test results into the project directory whereas putting them into the build directory is a better choice to avoid polluting the project directory with build artifacts.