### PR TITLE
Improve linter empty_migration_scripts

### DIFF
--- a/code/languages/org.mpsqa.lint/solutions/org.mpsqa.lint.mps_lang.linters_library/models/org.mpsqa.lint.mps_lang.linters_library.migration_aspect.mps
+++ b/code/languages/org.mpsqa.lint/solutions/org.mpsqa.lint.mps_lang.linters_library/models/org.mpsqa.lint.mps_lang.linters_library.migration_aspect.mps
@@ -17,6 +17,8 @@
   </imports>
   <registry>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1080223426719" name="jetbrains.mps.baseLanguage.structure.OrExpression" flags="nn" index="22lmx$" />
+      <concept id="4836112446988635817" name="jetbrains.mps.baseLanguage.structure.UndefinedType" flags="in" index="2jxLKc" />
       <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
         <child id="1197027771414" name="operand" index="2Oq$k0" />
         <child id="1197027833540" name="operation" index="2OqNvi" />
@@ -40,7 +42,6 @@
       <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
         <child id="5680397130376446158" name="type" index="1tU5fm" />
       </concept>
-      <concept id="1068580123152" name="jetbrains.mps.baseLanguage.structure.EqualsExpression" flags="nn" index="3clFbC" />
       <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
         <child id="1068580123156" name="expression" index="3clFbG" />
       </concept>
@@ -51,9 +52,6 @@
       </concept>
       <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
         <child id="1068581517665" name="statement" index="3cqZAp" />
-      </concept>
-      <concept id="1068580320020" name="jetbrains.mps.baseLanguage.structure.IntegerConstant" flags="nn" index="3cmrfG">
-        <property id="1068580320021" name="value" index="3cmrfH" />
       </concept>
       <concept id="1068581242875" name="jetbrains.mps.baseLanguage.structure.PlusExpression" flags="nn" index="3cpWs3" />
       <concept id="1068581242878" name="jetbrains.mps.baseLanguage.structure.ReturnStatement" flags="nn" index="3cpWs6">
@@ -76,6 +74,9 @@
         <child id="1081773367579" name="rightExpression" index="3uHU7w" />
         <child id="1081773367580" name="leftExpression" index="3uHU7B" />
       </concept>
+      <concept id="6329021646629104954" name="jetbrains.mps.baseLanguage.structure.SingleLineComment" flags="nn" index="3SKdUt">
+        <child id="8356039341262087992" name="line" index="1aUNEU" />
+      </concept>
       <concept id="1080120340718" name="jetbrains.mps.baseLanguage.structure.AndExpression" flags="nn" index="1Wc70l" />
     </language>
     <language id="40ab19e9-751a-4433-b645-0e65160e58a0" name="org.mpsqa.lint.generic">
@@ -89,6 +90,13 @@
         <child id="2555875871751847640" name="documentation" index="1MIJl8" />
       </concept>
     </language>
+    <language id="fd392034-7849-419d-9071-12563d152375" name="jetbrains.mps.baseLanguage.closures">
+      <concept id="2524418899405758586" name="jetbrains.mps.baseLanguage.closures.structure.InferredClosureParameterDeclaration" flags="ig" index="gl6BB" />
+      <concept id="1199569711397" name="jetbrains.mps.baseLanguage.closures.structure.ClosureLiteral" flags="nn" index="1bVj0M">
+        <child id="1199569906740" name="parameter" index="1bW2Oz" />
+        <child id="1199569916463" name="body" index="1bW5cS" />
+      </concept>
+    </language>
     <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
       <concept id="1177026924588" name="jetbrains.mps.lang.smodel.structure.RefConcept_Reference" flags="nn" index="chp4Y">
         <reference id="1177026940964" name="conceptDeclaration" index="cht4Q" />
@@ -96,10 +104,20 @@
       <concept id="1138411891628" name="jetbrains.mps.lang.smodel.structure.SNodeOperation" flags="nn" index="eCIE_">
         <child id="1144104376918" name="parameter" index="1xVPHs" />
       </concept>
+      <concept id="4693937538533521280" name="jetbrains.mps.lang.smodel.structure.OfConceptOperation" flags="ng" index="v3k3i">
+        <child id="4693937538533538124" name="requestedConcept" index="v3oSu" />
+      </concept>
+      <concept id="7453996997717780434" name="jetbrains.mps.lang.smodel.structure.Node_GetSConceptOperation" flags="nn" index="2yIwOk" />
       <concept id="1171305280644" name="jetbrains.mps.lang.smodel.structure.Node_GetDescendantsOperation" flags="nn" index="2Rf3mk" />
+      <concept id="1139621453865" name="jetbrains.mps.lang.smodel.structure.Node_IsInstanceOfOperation" flags="nn" index="1mIQ4w">
+        <child id="1177027386292" name="conceptArgument" index="cj9EA" />
+      </concept>
       <concept id="1172008320231" name="jetbrains.mps.lang.smodel.structure.Node_IsNotNullOperation" flags="nn" index="3x8VRR" />
       <concept id="1144101972840" name="jetbrains.mps.lang.smodel.structure.OperationParm_Concept" flags="ng" index="1xMEDy">
         <child id="1207343664468" name="conceptArgument" index="ri$Ld" />
+      </concept>
+      <concept id="1172326502327" name="jetbrains.mps.lang.smodel.structure.Concept_IsExactlyOperation" flags="nn" index="3O6GUB">
+        <child id="1206733650006" name="conceptArgument" index="3QVz_e" />
       </concept>
       <concept id="1138055754698" name="jetbrains.mps.lang.smodel.structure.SNodeType" flags="in" index="3Tqbb2">
         <reference id="1138405853777" name="concept" index="ehGHo" />
@@ -131,19 +149,23 @@
       </concept>
     </language>
     <language id="83888646-71ce-4f1c-9c53-c54016f6ad4f" name="jetbrains.mps.baseLanguage.collections">
+      <concept id="1204796164442" name="jetbrains.mps.baseLanguage.collections.structure.InternalSequenceOperation" flags="nn" index="23sCx2">
+        <child id="1204796294226" name="closure" index="23t8la" />
+      </concept>
       <concept id="540871147943773365" name="jetbrains.mps.baseLanguage.collections.structure.SingleArgumentSequenceOperation" flags="nn" index="25WWJ4">
         <child id="540871147943773366" name="argument" index="25WWJ7" />
       </concept>
       <concept id="1151688443754" name="jetbrains.mps.baseLanguage.collections.structure.ListType" flags="in" index="_YKpA">
         <child id="1151688676805" name="elementType" index="_ZDj9" />
       </concept>
+      <concept id="1235566831861" name="jetbrains.mps.baseLanguage.collections.structure.AllOperation" flags="nn" index="2HxqBE" />
       <concept id="1237721394592" name="jetbrains.mps.baseLanguage.collections.structure.AbstractContainerCreator" flags="nn" index="HWqM0">
         <child id="1237721435807" name="elementType" index="HW$YZ" />
       </concept>
       <concept id="1160600644654" name="jetbrains.mps.baseLanguage.collections.structure.ListCreatorWithInit" flags="nn" index="Tc6Ow" />
       <concept id="1160612413312" name="jetbrains.mps.baseLanguage.collections.structure.AddElementOperation" flags="nn" index="TSZUe" />
-      <concept id="1162935959151" name="jetbrains.mps.baseLanguage.collections.structure.GetSizeOperation" flags="nn" index="34oBXx" />
       <concept id="1165525191778" name="jetbrains.mps.baseLanguage.collections.structure.GetFirstOperation" flags="nn" index="1uHKPH" />
+      <concept id="1176501494711" name="jetbrains.mps.baseLanguage.collections.structure.IsNotEmptyOperation" flags="nn" index="3GX2aA" />
     </language>
   </registry>
   <node concept="1MIHA_" id="3bllPAaPI3W">
@@ -285,33 +307,112 @@
               </node>
             </node>
           </node>
-          <node concept="1Wc70l" id="5PFth5VXo9a" role="3clFbw">
+          <node concept="1Wc70l" id="19B7cLOShI$" role="3clFbw">
+            <node concept="2OqwBi" id="19B7cLOSpbR" role="3uHU7w">
+              <node concept="2OqwBi" id="19B7cLOSlQ9" role="2Oq$k0">
+                <node concept="2OqwBi" id="19B7cLOSkwZ" role="2Oq$k0">
+                  <node concept="37vLTw" id="19B7cLOSjVU" role="2Oq$k0">
+                    <ref role="3cqZAo" node="5PFth5VXnQC" resolve="method" />
+                  </node>
+                  <node concept="3TrEf2" id="19B7cLOSlvg" role="2OqNvi">
+                    <ref role="3Tt5mk" to="tpee:fzclF7Z" resolve="body" />
+                  </node>
+                </node>
+                <node concept="3Tsc0h" id="19B7cLOSmjH" role="2OqNvi">
+                  <ref role="3TtcxE" to="tpee:fzcqZ_x" resolve="statement" />
+                </node>
+              </node>
+              <node concept="2HxqBE" id="19B7cLOSrxO" role="2OqNvi">
+                <node concept="1bVj0M" id="19B7cLOSrxQ" role="23t8la">
+                  <node concept="3clFbS" id="19B7cLOSrxR" role="1bW5cS">
+                    <node concept="3SKdUt" id="19B7cLOSHcl" role="3cqZAp">
+                      <node concept="1PaTwC" id="19B7cLOSHcm" role="1aUNEU">
+                        <node concept="3oM_SD" id="19B7cLOSHqN" role="1PaTwD">
+                          <property role="3oM_SC" value="empty" />
+                        </node>
+                        <node concept="3oM_SD" id="19B7cLOSHri" role="1PaTwD">
+                          <property role="3oM_SC" value="line" />
+                        </node>
+                        <node concept="3oM_SD" id="19B7cLOSHrL" role="1PaTwD">
+                          <property role="3oM_SC" value="OR" />
+                        </node>
+                        <node concept="3oM_SD" id="19B7cLOSHSG" role="1PaTwD">
+                          <property role="3oM_SC" value="comment" />
+                        </node>
+                        <node concept="3oM_SD" id="19B7cLOSI7L" role="1PaTwD">
+                          <property role="3oM_SC" value="OR" />
+                        </node>
+                        <node concept="3oM_SD" id="19B7cLOSI$G" role="1PaTwD">
+                          <property role="3oM_SC" value="commented" />
+                        </node>
+                        <node concept="3oM_SD" id="19B7cLOSINX" role="1PaTwD">
+                          <property role="3oM_SC" value="out" />
+                        </node>
+                        <node concept="3oM_SD" id="19B7cLOSJvu" role="1PaTwD">
+                          <property role="3oM_SC" value="code" />
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="3clFbF" id="19B7cLOSrJr" role="3cqZAp">
+                      <node concept="22lmx$" id="19B7cLOSz9b" role="3clFbG">
+                        <node concept="2OqwBi" id="19B7cLOSG0V" role="3uHU7w">
+                          <node concept="2OqwBi" id="19B7cLOSAwL" role="2Oq$k0">
+                            <node concept="2OqwBi" id="19B7cLOSzyt" role="2Oq$k0">
+                              <node concept="37vLTw" id="19B7cLOSzmz" role="2Oq$k0">
+                                <ref role="3cqZAo" node="19B7cLOSrxS" resolve="it" />
+                              </node>
+                              <node concept="3Tsc0h" id="19B7cLOS$4N" role="2OqNvi">
+                                <ref role="3TtcxE" to="tpck:4uZwTti3__2" resolve="smodelAttribute" />
+                              </node>
+                            </node>
+                            <node concept="v3k3i" id="19B7cLOSChn" role="2OqNvi">
+                              <node concept="chp4Y" id="19B7cLOSCwV" role="v3oSu">
+                                <ref role="cht4Q" to="tpck:3Rc6kd0K$RF" resolve="BaseCommentAttribute" />
+                              </node>
+                            </node>
+                          </node>
+                          <node concept="3GX2aA" id="19B7cLOSGJg" role="2OqNvi" />
+                        </node>
+                        <node concept="22lmx$" id="19B7cLOSwwX" role="3uHU7B">
+                          <node concept="2OqwBi" id="19B7cLOSu0L" role="3uHU7B">
+                            <node concept="2OqwBi" id="19B7cLOSs$A" role="2Oq$k0">
+                              <node concept="37vLTw" id="19B7cLOSrJq" role="2Oq$k0">
+                                <ref role="3cqZAo" node="19B7cLOSrxS" resolve="it" />
+                              </node>
+                              <node concept="2yIwOk" id="19B7cLOStdu" role="2OqNvi" />
+                            </node>
+                            <node concept="3O6GUB" id="19B7cLOSuYo" role="2OqNvi">
+                              <node concept="chp4Y" id="19B7cLOSviL" role="3QVz_e">
+                                <ref role="cht4Q" to="tpee:fzclF8l" resolve="Statement" />
+                              </node>
+                            </node>
+                          </node>
+                          <node concept="2OqwBi" id="19B7cLOSyc3" role="3uHU7w">
+                            <node concept="37vLTw" id="19B7cLOSxWR" role="2Oq$k0">
+                              <ref role="3cqZAo" node="19B7cLOSrxS" resolve="it" />
+                            </node>
+                            <node concept="1mIQ4w" id="19B7cLOSyGx" role="2OqNvi">
+                              <node concept="chp4Y" id="19B7cLOSyVD" role="cj9EA">
+                                <ref role="cht4Q" to="tpee:fB3l7ZcM9H" resolve="IComment" />
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="gl6BB" id="19B7cLOSrxS" role="1bW2Oz">
+                    <property role="TrG5h" value="it" />
+                    <node concept="2jxLKc" id="19B7cLOSrxT" role="1tU5fm" />
+                  </node>
+                </node>
+              </node>
+            </node>
             <node concept="2OqwBi" id="5PFth5VXp5c" role="3uHU7B">
               <node concept="37vLTw" id="5PFth5VXoe6" role="2Oq$k0">
                 <ref role="3cqZAo" node="5PFth5VXnQC" resolve="method" />
               </node>
               <node concept="3x8VRR" id="5PFth5VXrw2" role="2OqNvi" />
-            </node>
-            <node concept="3clFbC" id="5PFth5VXWW5" role="3uHU7w">
-              <node concept="3cmrfG" id="5PFth5VXYed" role="3uHU7w">
-                <property role="3cmrfH" value="0" />
-              </node>
-              <node concept="2OqwBi" id="5PFth5VXQEd" role="3uHU7B">
-                <node concept="2OqwBi" id="5PFth5VXs3$" role="2Oq$k0">
-                  <node concept="2OqwBi" id="2zdrQh7u1Yk" role="2Oq$k0">
-                    <node concept="37vLTw" id="5PFth5VXnQK" role="2Oq$k0">
-                      <ref role="3cqZAo" node="5PFth5VXnQC" resolve="method" />
-                    </node>
-                    <node concept="3TrEf2" id="5PFth5VXrN3" role="2OqNvi">
-                      <ref role="3Tt5mk" to="tpee:fzclF7Z" resolve="body" />
-                    </node>
-                  </node>
-                  <node concept="3Tsc0h" id="5PFth5VXOh2" role="2OqNvi">
-                    <ref role="3TtcxE" to="tpee:fzcqZ_x" resolve="statement" />
-                  </node>
-                </node>
-                <node concept="34oBXx" id="5PFth5VXU4s" role="2OqNvi" />
-              </node>
             </node>
           </node>
         </node>


### PR DESCRIPTION
Changes the linter empty_migration_scripts to also detect migrations which only contain empty lines, comments or commented out code.