### PR TITLE
Mark dependencies as provided in the build script

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -395,6 +395,7 @@ publishing {
                         dependencyNode.appendNode('artifactId', it.moduleName)
                         dependencyNode.appendNode('version', it.moduleVersion)
                         dependencyNode.appendNode('type', it.moduleArtifacts[0].type)
+                        dependencyNode.appendNode('scope', 'provided')
                     }
                 }
 


### PR DESCRIPTION
Otherwise, dependent projects will try to download the dependencies. This is an issue because `net.sf.jtreemap:ktreemap:1.1.0-atlassian-01` doesn't come from the public maven central repository.