### PR TITLE
Update outdated dependencies

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -67,7 +67,7 @@ dependencies {
 
     baseLib("org.apache.commons:commons-lang3:3.20.0")
     baseLib("commons-cli:commons-cli:1.5.0")
-    baseLib("commons-io:commons-io:2.21")
+    baseLib("commons-io:commons-io:2.21.0")
 
     treemap("net.sf.jtreemap:jtreemap:1.1.3")
     treemap("net.sf.jtreemap:ktreemap:1.1.0-atlassian-01")


### PR DESCRIPTION
This PR fixes the found vulnerabilities as suggested by Github.

Here are the links from Github Advisories:
https://github.com/advisories/GHSA-gwrp-pvrq-jmwv
https://github.com/advisories/GHSA-j288-q9x7-2f5v
https://github.com/advisories/GHSA-78wr-2p64-hpwj

for the dependencies:
- org.apache.commons:commons-lang3
- commons-io:commons-io