### PR TITLE
Generialize cycle checking and add linters for checking model cycles

### DIFF
--- a/code/languages/org.mpsqa.lint/solutions/org.mpsqa.lint.generic.linters_library/models/org.mpsqa.lint.generic.linters_library.models.mps
+++ b/code/languages/org.mpsqa.lint/solutions/org.mpsqa.lint.generic.linters_library/models/org.mpsqa.lint.generic.linters_library.models.mps
@@ -39,6 +39,7 @@
     <import index="4qvk" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.nio.file.attribute(JDK/)" />
     <import index="z1c4" ref="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61/java:jetbrains.mps.project(MPS.Platform/)" />
     <import index="zn9m" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.openapi.util(MPS.IDEA/)" />
+    <import index="wpu7" ref="r:cadc46fc-2365-43d7-bda1-08e980cf970d(org.mpsqa.lint.generic.linters_library.modules)" />
   </imports>
   <registry>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
@@ -82,6 +83,7 @@
       <concept id="1137021947720" name="jetbrains.mps.baseLanguage.structure.ConceptFunction" flags="in" index="2VMwT0">
         <child id="1137022507850" name="body" index="2VODD2" />
       </concept>
+      <concept id="1070462154015" name="jetbrains.mps.baseLanguage.structure.StaticFieldDeclaration" flags="ig" index="Wx3nA" />
       <concept id="1070475354124" name="jetbrains.mps.baseLanguage.structure.ThisExpression" flags="nn" index="Xjq3P" />
       <concept id="1070475926800" name="jetbrains.mps.baseLanguage.structure.StringLiteral" flags="nn" index="Xl_RD">
         <property id="1070475926801" name="value" index="Xl_RC" />
@@ -90,6 +92,7 @@
       <concept id="1182160077978" name="jetbrains.mps.baseLanguage.structure.AnonymousClassCreator" flags="nn" index="YeOm9">
         <child id="1182160096073" name="cls" index="YeSDq" />
       </concept>
+      <concept id="1081236700938" name="jetbrains.mps.baseLanguage.structure.StaticMethodDeclaration" flags="ig" index="2YIFZL" />
       <concept id="1081236700937" name="jetbrains.mps.baseLanguage.structure.StaticMethodCall" flags="nn" index="2YIFZM">
         <reference id="1144433194310" name="classConcept" index="1Pybhc" />
       </concept>
@@ -99,6 +102,7 @@
       </concept>
       <concept id="1070534058343" name="jetbrains.mps.baseLanguage.structure.NullLiteral" flags="nn" index="10Nm6u" />
       <concept id="1070534370425" name="jetbrains.mps.baseLanguage.structure.IntegerType" flags="in" index="10Oyi0" />
+      <concept id="1070534644030" name="jetbrains.mps.baseLanguage.structure.BooleanType" flags="in" index="10P_77" />
       <concept id="1070534934090" name="jetbrains.mps.baseLanguage.structure.CastExpression" flags="nn" index="10QFUN">
         <child id="1070534934091" name="type" index="10QFUM" />
         <child id="1070534934092" name="expression" index="10QFUP" />
@@ -173,12 +177,15 @@
         <child id="1068499141038" name="actualArgument" index="37wK5m" />
       </concept>
       <concept id="1073063089578" name="jetbrains.mps.baseLanguage.structure.SuperMethodCall" flags="nn" index="3nyPlj" />
-      <concept id="1212685548494" name="jetbrains.mps.baseLanguage.structure.ClassCreator" flags="nn" index="1pGfFk" />
+      <concept id="1212685548494" name="jetbrains.mps.baseLanguage.structure.ClassCreator" flags="nn" index="1pGfFk">
+        <child id="1212687122400" name="typeParameter" index="1pMfVU" />
+      </concept>
       <concept id="1107461130800" name="jetbrains.mps.baseLanguage.structure.Classifier" flags="ng" index="3pOWGL">
         <property id="521412098689998745" name="nonStatic" index="2bfB8j" />
         <child id="5375687026011219971" name="member" index="jymVt" unordered="true" />
       </concept>
       <concept id="1171903607971" name="jetbrains.mps.baseLanguage.structure.WildCardType" flags="in" index="3qTvmN" />
+      <concept id="7812454656619025412" name="jetbrains.mps.baseLanguage.structure.LocalMethodCall" flags="nn" index="1rXfSq" />
       <concept id="1107535904670" name="jetbrains.mps.baseLanguage.structure.ClassifierType" flags="in" index="3uibUv">
         <reference id="1107535924139" name="classifier" index="3uigEE" />
         <child id="1109201940907" name="parameter" index="11_B2D" />
@@ -203,6 +210,7 @@
         <child id="8356039341262087992" name="line" index="1aUNEU" />
       </concept>
       <concept id="1146644602865" name="jetbrains.mps.baseLanguage.structure.PublicVisibility" flags="nn" index="3Tm1VV" />
+      <concept id="1146644623116" name="jetbrains.mps.baseLanguage.structure.PrivateVisibility" flags="nn" index="3Tm6S6" />
       <concept id="1080120340718" name="jetbrains.mps.baseLanguage.structure.AndExpression" flags="nn" index="1Wc70l" />
       <concept id="1170345865475" name="jetbrains.mps.baseLanguage.structure.AnonymousClass" flags="ig" index="1Y3b0j">
         <reference id="1170346070688" name="classifier" index="1Y3XeK" />
@@ -265,6 +273,15 @@
         <child id="1225797361612" name="parameter" index="1BdPVh" />
       </concept>
     </language>
+    <language id="446c26eb-2b7b-4bf0-9b35-f83fa582753e" name="jetbrains.mps.lang.modelapi">
+      <concept id="361130699826193248" name="jetbrains.mps.lang.modelapi.structure.ModelPointer" flags="ng" index="1dCxOl">
+        <property id="1863527487546097494" name="modelId" index="1XweGQ" />
+        <child id="679099339649067980" name="name" index="1j$8Uc" />
+      </concept>
+      <concept id="679099339649053840" name="jetbrains.mps.lang.modelapi.structure.ModelName" flags="ng" index="1j_P7g">
+        <property id="679099339649053841" name="value" index="1j_P7h" />
+      </concept>
+    </language>
     <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
       <concept id="1143226024141" name="jetbrains.mps.lang.smodel.structure.SModelType" flags="in" index="H_c77" />
       <concept id="1145404486709" name="jetbrains.mps.lang.smodel.structure.SemanticDowncastExpression" flags="nn" index="2JrnkZ">
@@ -277,6 +294,10 @@
       <concept id="1138056022639" name="jetbrains.mps.lang.smodel.structure.SPropertyAccess" flags="nn" index="3TrcHB">
         <reference id="1138056395725" name="property" index="3TsBF5" />
       </concept>
+      <concept id="1863527487546129879" name="jetbrains.mps.lang.smodel.structure.ModelPointerExpression" flags="ng" index="1Xw6AR">
+        <child id="1863527487546132519" name="modelRef" index="1XwpL7" />
+      </concept>
+      <concept id="1863527487546132619" name="jetbrains.mps.lang.smodel.structure.SModelPointerType" flags="ig" index="1XwpNF" />
     </language>
     <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
       <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
@@ -349,6 +370,7 @@
         <child id="1237731803878" name="copyFrom" index="I$8f6" />
       </concept>
       <concept id="1227008614712" name="jetbrains.mps.baseLanguage.collections.structure.LinkedListCreator" flags="nn" index="2Jqq0_" />
+      <concept id="1227022210526" name="jetbrains.mps.baseLanguage.collections.structure.ClearAllElementsOperation" flags="nn" index="2Kehj3" />
       <concept id="1160600644654" name="jetbrains.mps.baseLanguage.collections.structure.ListCreatorWithInit" flags="nn" index="Tc6Ow" />
       <concept id="1160612413312" name="jetbrains.mps.baseLanguage.collections.structure.AddElementOperation" flags="nn" index="TSZUe" />
       <concept id="1160666733551" name="jetbrains.mps.baseLanguage.collections.structure.AddAllElementsOperation" flags="nn" index="X8dFx" />
@@ -4579,6 +4601,1653 @@
         <property role="Xl_RC" value="" />
       </node>
     </node>
+  </node>
+  <node concept="1MIHA_" id="4aEqBbb$5Kh">
+    <property role="TrG5h" value="cyclic_model_dependencies" />
+    <property role="3miQiw" value="true" />
+    <node concept="2j1K4_" id="47tbZooQUks" role="2j1K4A">
+      <property role="TrG5h" value="cycleLength" />
+      <node concept="10Oyi0" id="47tbZooQUEJ" role="2j1LY4" />
+    </node>
+    <node concept="1Pa9Pv" id="4aEqBbb$5Ki" role="1MIJl8">
+      <node concept="1PaTwC" id="4aEqBbb$5Kj" role="1PaQFQ">
+        <node concept="3oM_SD" id="4aEqBbb$5Kk" role="1PaTwD">
+          <property role="3oM_SC" value="Identifies" />
+        </node>
+        <node concept="3oM_SD" id="4aEqBbb$5Kl" role="1PaTwD">
+          <property role="3oM_SC" value="model" />
+        </node>
+        <node concept="3oM_SD" id="4aEqBbb$6Qk" role="1PaTwD">
+          <property role="3oM_SC" value="from" />
+        </node>
+        <node concept="3oM_SD" id="4aEqBbbDcmF" role="1PaTwD">
+          <property role="3oM_SC" value="the" />
+        </node>
+        <node concept="3oM_SD" id="4aEqBbbDcna" role="1PaTwD">
+          <property role="3oM_SC" value="current" />
+        </node>
+        <node concept="3oM_SD" id="4aEqBbbDcnF" role="1PaTwD">
+          <property role="3oM_SC" value="project" />
+        </node>
+        <node concept="3oM_SD" id="4aEqBbbDcoe" role="1PaTwD">
+          <property role="3oM_SC" value="which" />
+        </node>
+        <node concept="3oM_SD" id="4aEqBbb$6Qu" role="1PaTwD">
+          <property role="3oM_SC" value="are" />
+        </node>
+        <node concept="3oM_SD" id="4aEqBbb$6QD" role="1PaTwD">
+          <property role="3oM_SC" value="part" />
+        </node>
+        <node concept="3oM_SD" id="4aEqBbb$6QP" role="1PaTwD">
+          <property role="3oM_SC" value="of" />
+        </node>
+        <node concept="3oM_SD" id="4aEqBbb$6R2" role="1PaTwD">
+          <property role="3oM_SC" value="cyclic" />
+        </node>
+        <node concept="3oM_SD" id="4aEqBbb$6Rg" role="1PaTwD">
+          <property role="3oM_SC" value="dependencies" />
+        </node>
+        <node concept="3oM_SD" id="1Yf9e2l9xc1" role="1PaTwD">
+          <property role="3oM_SC" value="with" />
+        </node>
+        <node concept="3oM_SD" id="1Yf9e2l9xcf" role="1PaTwD">
+          <property role="3oM_SC" value="" />
+        </node>
+      </node>
+      <node concept="1PaTwC" id="1Yf9e2l9xd_" role="1PaQFQ">
+        <node concept="3oM_SD" id="1Yf9e2l9xd$" role="1PaTwD">
+          <property role="3oM_SC" value="cycle" />
+        </node>
+        <node concept="3oM_SD" id="1Yf9e2l9xcu" role="1PaTwD">
+          <property role="3oM_SC" value="length" />
+        </node>
+        <node concept="3oM_SD" id="1Yf9e2l9xcI" role="1PaTwD">
+          <property role="3oM_SC" value="bigger" />
+        </node>
+        <node concept="3oM_SD" id="1Yf9e2l9xcZ" role="1PaTwD">
+          <property role="3oM_SC" value="than" />
+        </node>
+        <node concept="3oM_SD" id="63CQ8uYzdUT" role="1PaTwD">
+          <property role="3oM_SC" value="the" />
+        </node>
+        <node concept="3oM_SD" id="1Yf9e2l9xdh" role="1PaTwD">
+          <property role="3oM_SC" value="threshold." />
+        </node>
+      </node>
+      <node concept="1PaTwC" id="4aEqBbb$5Ks" role="1PaQFQ">
+        <node concept="3oM_SD" id="4aEqBbb$5Kt" role="1PaTwD">
+          <property role="3oM_SC" value="" />
+        </node>
+      </node>
+      <node concept="1PaTwC" id="4aEqBbb$6RN" role="1PaQFQ">
+        <node concept="3oM_SD" id="4aEqBbb$6RM" role="1PaTwD">
+          <property role="3oM_SC" value="Cyclic" />
+        </node>
+        <node concept="3oM_SD" id="4aEqBbb$6S5" role="1PaTwD">
+          <property role="3oM_SC" value="dependencies" />
+        </node>
+        <node concept="3oM_SD" id="63CQ8uYzdUU" role="1PaTwD">
+          <property role="3oM_SC" value="are" />
+        </node>
+        <node concept="3oM_SD" id="4aEqBbb$6Sh" role="1PaTwD">
+          <property role="3oM_SC" value="unwanted" />
+        </node>
+        <node concept="3oM_SD" id="4aEqBbb$6Sn" role="1PaTwD">
+          <property role="3oM_SC" value="since" />
+        </node>
+        <node concept="3oM_SD" id="4aEqBbb$6Su" role="1PaTwD">
+          <property role="3oM_SC" value="they" />
+        </node>
+        <node concept="3oM_SD" id="4aEqBbb$6SA" role="1PaTwD">
+          <property role="3oM_SC" value="break" />
+        </node>
+        <node concept="3oM_SD" id="4aEqBbb$6Uv" role="1PaTwD">
+          <property role="3oM_SC" value="layered" />
+        </node>
+        <node concept="3oM_SD" id="4aEqBbb$6UH" role="1PaTwD">
+          <property role="3oM_SC" value="architectures" />
+        </node>
+        <node concept="3oM_SD" id="4aEqBbb$6T4" role="1PaTwD">
+          <property role="3oM_SC" value="and" />
+        </node>
+        <node concept="3oM_SD" id="4aEqBbb$6Tg" role="1PaTwD">
+          <property role="3oM_SC" value="the" />
+        </node>
+      </node>
+      <node concept="1PaTwC" id="4aEqBbb$6Tu" role="1PaQFQ">
+        <node concept="3oM_SD" id="4aEqBbb$6Tt" role="1PaTwD">
+          <property role="3oM_SC" value="possibility" />
+        </node>
+        <node concept="3oM_SD" id="4aEqBbb$6Uj" role="1PaTwD">
+          <property role="3oM_SC" value="e.g." />
+        </node>
+        <node concept="3oM_SD" id="4aEqBbb$6Um" role="1PaTwD">
+          <property role="3oM_SC" value="to" />
+        </node>
+        <node concept="3oM_SD" id="4aEqBbb$6Uq" role="1PaTwD">
+          <property role="3oM_SC" value="separate" />
+        </node>
+        <node concept="3oM_SD" id="4aEqBbb$6Vo" role="1PaTwD">
+          <property role="3oM_SC" value="projects" />
+        </node>
+        <node concept="3oM_SD" id="4aEqBbb$6Vu" role="1PaTwD">
+          <property role="3oM_SC" value="into" />
+        </node>
+        <node concept="3oM_SD" id="4aEqBbb$6V_" role="1PaTwD">
+          <property role="3oM_SC" value="multiple" />
+        </node>
+        <node concept="3oM_SD" id="47tbZooQU8G" role="1PaTwD">
+          <property role="3oM_SC" value="repositories." />
+        </node>
+      </node>
+      <node concept="1PaTwC" id="47tbZooQVnK" role="1PaQFQ">
+        <node concept="3oM_SD" id="47tbZooQVnJ" role="1PaTwD">
+          <property role="3oM_SC" value="" />
+        </node>
+      </node>
+      <node concept="1PaTwC" id="47tbZooQVoF" role="1PaQFQ">
+        <node concept="3oM_SD" id="47tbZooQVoE" role="1PaTwD">
+          <property role="3oM_SC" value="Parameters" />
+          <property role="1X82VF" value="true" />
+        </node>
+      </node>
+      <node concept="2DRihI" id="63CQ8uYzdUV" role="1PaQFQ">
+        <node concept="3oM_SD" id="63CQ8uYzdUX" role="1PaTwD">
+          <property role="3oM_SC" value="cycleLength" />
+          <property role="1X82S1" value="true" />
+        </node>
+        <node concept="3oM_SD" id="63CQ8uYzdUY" role="1PaTwD">
+          <property role="3oM_SC" value="–" />
+        </node>
+        <node concept="3oM_SD" id="63CQ8uYzdUZ" role="1PaTwD">
+          <property role="3oM_SC" value="the" />
+        </node>
+        <node concept="3oM_SD" id="63CQ8uYzdV0" role="1PaTwD">
+          <property role="3oM_SC" value="maximum" />
+        </node>
+        <node concept="3oM_SD" id="63CQ8uYzdV1" role="1PaTwD">
+          <property role="3oM_SC" value="length" />
+        </node>
+        <node concept="3oM_SD" id="63CQ8uYzdV2" role="1PaTwD">
+          <property role="3oM_SC" value="of" />
+        </node>
+        <node concept="3oM_SD" id="63CQ8uYzdV3" role="1PaTwD">
+          <property role="3oM_SC" value="the" />
+        </node>
+        <node concept="3oM_SD" id="63CQ8uYzdV4" role="1PaTwD">
+          <property role="3oM_SC" value="cycle" />
+        </node>
+        <node concept="3oM_SD" id="63CQ8uYzdV5" role="1PaTwD">
+          <property role="3oM_SC" value="which" />
+        </node>
+        <node concept="3oM_SD" id="63CQ8uYzdV6" role="1PaTwD">
+          <property role="3oM_SC" value="is" />
+        </node>
+        <node concept="3oM_SD" id="63CQ8uYzdV7" role="1PaTwD">
+          <property role="3oM_SC" value="accepted." />
+        </node>
+        <node concept="3oM_SD" id="63CQ8uYzdV8" role="1PaTwD">
+          <property role="3oM_SC" value="cycleLength" />
+          <property role="1X82VY" value="true" />
+        </node>
+        <node concept="3oM_SD" id="63CQ8uYzdV9" role="1PaTwD">
+          <property role="3oM_SC" value="&lt;=" />
+        </node>
+        <node concept="3oM_SD" id="63CQ8uYzdVa" role="1PaTwD">
+          <property role="3oM_SC" value="1" />
+        </node>
+        <node concept="3oM_SD" id="63CQ8uYzdVb" role="1PaTwD">
+          <property role="3oM_SC" value="" />
+        </node>
+      </node>
+      <node concept="1PaTwC" id="47tbZooQVuW" role="1PaQFQ">
+        <node concept="3oM_SD" id="47tbZooQVuV" role="1PaTwD">
+          <property role="3oM_SC" value="" />
+        </node>
+        <node concept="3oM_SD" id="47tbZooQVwH" role="1PaTwD">
+          <property role="3oM_SC" value="" />
+        </node>
+        <node concept="3oM_SD" id="47tbZooQVwN" role="1PaTwD">
+          <property role="3oM_SC" value="" />
+        </node>
+        <node concept="3oM_SD" id="47tbZooQVwU" role="1PaTwD">
+          <property role="3oM_SC" value="" />
+        </node>
+        <node concept="3oM_SD" id="47tbZooQVx2" role="1PaTwD">
+          <property role="3oM_SC" value="" />
+        </node>
+        <node concept="3oM_SD" id="47tbZooQVxb" role="1PaTwD">
+          <property role="3oM_SC" value="" />
+        </node>
+        <node concept="3oM_SD" id="47tbZooQVxl" role="1PaTwD">
+          <property role="3oM_SC" value="" />
+        </node>
+        <node concept="3oM_SD" id="47tbZooQVxw" role="1PaTwD">
+          <property role="3oM_SC" value="" />
+        </node>
+        <node concept="3oM_SD" id="47tbZooQVxG" role="1PaTwD">
+          <property role="3oM_SC" value="" />
+        </node>
+        <node concept="3oM_SD" id="47tbZooQVxT" role="1PaTwD">
+          <property role="3oM_SC" value="" />
+        </node>
+        <node concept="3oM_SD" id="47tbZooQVy7" role="1PaTwD">
+          <property role="3oM_SC" value="" />
+        </node>
+        <node concept="3oM_SD" id="47tbZooQVym" role="1PaTwD">
+          <property role="3oM_SC" value="means" />
+        </node>
+        <node concept="3oM_SD" id="47tbZooQVum" role="1PaTwD">
+          <property role="3oM_SC" value="no" />
+        </node>
+        <node concept="3oM_SD" id="47tbZooQVuC" role="1PaTwD">
+          <property role="3oM_SC" value="cycle" />
+        </node>
+        <node concept="3oM_SD" id="47tbZooQVtP" role="1PaTwD">
+          <property role="3oM_SC" value="is" />
+        </node>
+        <node concept="3oM_SD" id="47tbZooQVyA" role="1PaTwD">
+          <property role="3oM_SC" value="allowed" />
+        </node>
+      </node>
+    </node>
+    <node concept="1MIXq2" id="4aEqBbb$5L8" role="14J5yK">
+      <node concept="3clFbS" id="4aEqBbb$5L9" role="2VODD2">
+        <node concept="3cpWs8" id="4aEqBbb$5La" role="3cqZAp">
+          <node concept="3cpWsn" id="4aEqBbb$5Lb" role="3cpWs9">
+            <property role="TrG5h" value="res" />
+            <node concept="_YKpA" id="4aEqBbb$5Lc" role="1tU5fm">
+              <node concept="17QB3L" id="4aEqBbb$5Ld" role="_ZDj9" />
+            </node>
+            <node concept="2ShNRf" id="4aEqBbb$5Le" role="33vP2m">
+              <node concept="Tc6Ow" id="4aEqBbb$5Lf" role="2ShVmc">
+                <node concept="17QB3L" id="4aEqBbb$5Lg" role="HW$YZ" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="4aEqBbb$5Lh" role="3cqZAp" />
+        <node concept="L3pyB" id="4aEqBbb$5Li" role="3cqZAp">
+          <node concept="3clFbS" id="4aEqBbb$5Lj" role="L3pyw">
+            <node concept="3clFbF" id="13En2FwdDQK" role="3cqZAp">
+              <node concept="2OqwBi" id="13En2FwdNsN" role="3clFbG">
+                <node concept="2YIFZM" id="13En2FwdLog" role="2Oq$k0">
+                  <ref role="37wK5l" node="13En2FvVD7A" resolve="getDependenciesHelper" />
+                  <ref role="1Pybhc" node="4aEqBbbBtjF" resolve="CyclicModelDependenciesHelper" />
+                  <node concept="2OqwBi" id="13En2FwdMr1" role="37wK5m">
+                    <node concept="1MG55F" id="13En2FwdLGU" role="2Oq$k0" />
+                    <node concept="liA8E" id="13En2FwdNel" role="2OqNvi">
+                      <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="liA8E" id="13En2FwdO1d" role="2OqNvi">
+                  <ref role="37wK5l" to="wpu7:13En2Fvu8h0" resolve="computeTooLargeCycles" />
+                  <node concept="2OqwBi" id="13En2FwdSfR" role="37wK5m">
+                    <node concept="2OqwBi" id="13En2FwdPLy" role="2Oq$k0">
+                      <node concept="EZOir" id="13En2Fwosd6" role="2Oq$k0" />
+                      <node concept="3$u5V9" id="13En2FwdQ$b" role="2OqNvi">
+                        <node concept="1bVj0M" id="13En2FwdQ$d" role="23t8la">
+                          <node concept="3clFbS" id="13En2FwdQ$e" role="1bW5cS">
+                            <node concept="3clFbF" id="13En2FwdQVH" role="3cqZAp">
+                              <node concept="2OqwBi" id="13En2FwosZv" role="3clFbG">
+                                <node concept="2JrnkZ" id="13En2FwosIB" role="2Oq$k0">
+                                  <node concept="37vLTw" id="13En2FwdQVG" role="2JrQYb">
+                                    <ref role="3cqZAo" node="13En2FwdQ$f" resolve="it" />
+                                  </node>
+                                </node>
+                                <node concept="liA8E" id="13En2Fwotrx" role="2OqNvi">
+                                  <ref role="37wK5l" to="mhbf:~SModel.getReference()" resolve="getReference" />
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                          <node concept="gl6BB" id="13En2FwdQ$f" role="1bW2Oz">
+                            <property role="TrG5h" value="it" />
+                            <node concept="2jxLKc" id="13En2FwdQ$g" role="1tU5fm" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="ANE8D" id="13En2FwdTdT" role="2OqNvi" />
+                  </node>
+                  <node concept="37vLTw" id="13En2FwdTJg" role="37wK5m">
+                    <ref role="3cqZAo" node="4aEqBbb$5Lb" resolve="res" />
+                  </node>
+                  <node concept="2j1LYi" id="13En2FwdU6k" role="37wK5m">
+                    <ref role="2j1LYj" node="47tbZooQUks" resolve="cycleLength" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="1MG55F" id="4aEqBbb$5Mf" role="L3pyr" />
+        </node>
+        <node concept="3clFbH" id="7XOuq5gap26" role="3cqZAp" />
+        <node concept="3clFbJ" id="7XOuq5gg_Ri" role="3cqZAp">
+          <node concept="3clFbS" id="7XOuq5gg_Rk" role="3clFbx">
+            <node concept="3cpWs8" id="7XOuq5ggDmI" role="3cqZAp">
+              <node concept="3cpWsn" id="7XOuq5ggDmL" role="3cpWs9">
+                <property role="TrG5h" value="msg" />
+                <node concept="17QB3L" id="7XOuq5ggDmG" role="1tU5fm" />
+                <node concept="3cpWs3" id="7XOuq5ggF91" role="33vP2m">
+                  <node concept="2OqwBi" id="7XOuq5ggF_3" role="3uHU7w">
+                    <node concept="37vLTw" id="7XOuq5ggFbO" role="2Oq$k0">
+                      <ref role="3cqZAo" node="4aEqBbb$5Lb" resolve="res" />
+                    </node>
+                    <node concept="34oBXx" id="7XOuq5ggGar" role="2OqNvi" />
+                  </node>
+                  <node concept="3cpWs3" id="7XOuq5ggEQm" role="3uHU7B">
+                    <node concept="3cpWs3" id="7XOuq5ggEcZ" role="3uHU7B">
+                      <node concept="Xl_RD" id="7XOuq5ggDqX" role="3uHU7B">
+                        <property role="Xl_RC" value="Too many cyclic dependencies with length " />
+                      </node>
+                      <node concept="2j1LYi" id="7XOuq5ggEtO" role="3uHU7w">
+                        <ref role="2j1LYj" node="47tbZooQUks" resolve="cycleLength" />
+                      </node>
+                    </node>
+                    <node concept="Xl_RD" id="7XOuq5ggET1" role="3uHU7w">
+                      <property role="Xl_RC" value=" found: " />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbF" id="7XOuq5ggGcO" role="3cqZAp">
+              <node concept="2OqwBi" id="7XOuq5ggGwF" role="3clFbG">
+                <node concept="37vLTw" id="7XOuq5ggGcM" role="2Oq$k0">
+                  <ref role="3cqZAo" node="4aEqBbb$5Lb" resolve="res" />
+                </node>
+                <node concept="2Kehj3" id="7XOuq5ggGSb" role="2OqNvi" />
+              </node>
+            </node>
+            <node concept="3clFbF" id="7XOuq5ggGYi" role="3cqZAp">
+              <node concept="2OqwBi" id="7XOuq5ggI0Z" role="3clFbG">
+                <node concept="37vLTw" id="7XOuq5ggGYg" role="2Oq$k0">
+                  <ref role="3cqZAo" node="4aEqBbb$5Lb" resolve="res" />
+                </node>
+                <node concept="TSZUe" id="7XOuq5ggIHP" role="2OqNvi">
+                  <node concept="37vLTw" id="7XOuq5ggIJo" role="25WWJ7">
+                    <ref role="3cqZAo" node="7XOuq5ggDmL" resolve="msg" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3eOSWO" id="7XOuq5ggDi8" role="3clFbw">
+            <node concept="3cmrfG" id="7XOuq5ggDkj" role="3uHU7w">
+              <property role="3cmrfH" value="10000" />
+            </node>
+            <node concept="2OqwBi" id="7XOuq5ggBlU" role="3uHU7B">
+              <node concept="37vLTw" id="7XOuq5gg_Tx" role="2Oq$k0">
+                <ref role="3cqZAo" node="4aEqBbb$5Lb" resolve="res" />
+              </node>
+              <node concept="34oBXx" id="7XOuq5ggCbl" role="2OqNvi" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="7XOuq5gh6H4" role="3cqZAp" />
+        <node concept="3clFbF" id="7XOuq5gh76d" role="3cqZAp">
+          <node concept="37vLTw" id="7XOuq5gh76b" role="3clFbG">
+            <ref role="3cqZAo" node="4aEqBbb$5Lb" resolve="res" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2j1LYv" id="47tbZooQV4a" role="2j1YRv">
+      <node concept="2j1LYi" id="47tbZooQV4b" role="2j1YQj">
+        <ref role="2j1LYj" node="47tbZooQUks" resolve="cycleLength" />
+      </node>
+      <node concept="3cmrfG" id="47tbZooQVk0" role="2j1LYg">
+        <property role="3cmrfH" value="1" />
+      </node>
+    </node>
+  </node>
+  <node concept="1MIHA_" id="1Yf9e2l9xfC">
+    <property role="TrG5h" value="cyclic_model_dependencies_with_fixed_size" />
+    <property role="3miQiw" value="true" />
+    <node concept="2j1K4_" id="1Yf9e2l9xfD" role="2j1K4A">
+      <property role="TrG5h" value="cycleLength" />
+      <node concept="10Oyi0" id="1Yf9e2l9xfE" role="2j1LY4" />
+    </node>
+    <node concept="1Pa9Pv" id="1Yf9e2l9xfF" role="1MIJl8">
+      <node concept="1PaTwC" id="1Yf9e2l9xfG" role="1PaQFQ">
+        <node concept="3oM_SD" id="1Yf9e2l9xfH" role="1PaTwD">
+          <property role="3oM_SC" value="Identifies" />
+        </node>
+        <node concept="3oM_SD" id="1Yf9e2l9xfI" role="1PaTwD">
+          <property role="3oM_SC" value="models" />
+        </node>
+        <node concept="3oM_SD" id="1Yf9e2l9xfJ" role="1PaTwD">
+          <property role="3oM_SC" value="from" />
+        </node>
+        <node concept="3oM_SD" id="1Yf9e2l9xfK" role="1PaTwD">
+          <property role="3oM_SC" value="the" />
+        </node>
+        <node concept="3oM_SD" id="1Yf9e2l9xfL" role="1PaTwD">
+          <property role="3oM_SC" value="current" />
+        </node>
+        <node concept="3oM_SD" id="1Yf9e2l9xfM" role="1PaTwD">
+          <property role="3oM_SC" value="project" />
+        </node>
+        <node concept="3oM_SD" id="1Yf9e2l9xfN" role="1PaTwD">
+          <property role="3oM_SC" value="which" />
+        </node>
+        <node concept="3oM_SD" id="1Yf9e2l9xfO" role="1PaTwD">
+          <property role="3oM_SC" value="form" />
+        </node>
+        <node concept="3oM_SD" id="1Yf9e2l9ymE" role="1PaTwD">
+          <property role="3oM_SC" value="a" />
+        </node>
+        <node concept="3oM_SD" id="1Yf9e2l9ymU" role="1PaTwD">
+          <property role="3oM_SC" value="cyclic" />
+        </node>
+        <node concept="3oM_SD" id="1Yf9e2l9ynb" role="1PaTwD">
+          <property role="3oM_SC" value="dependency" />
+        </node>
+        <node concept="3oM_SD" id="1Yf9e2l9ynt" role="1PaTwD">
+          <property role="3oM_SC" value="with" />
+        </node>
+        <node concept="3oM_SD" id="1Yf9e2l9ynK" role="1PaTwD">
+          <property role="3oM_SC" value="a" />
+        </node>
+        <node concept="3oM_SD" id="1Yf9e2l9yrR" role="1PaTwD">
+          <property role="3oM_SC" value="certain" />
+        </node>
+        <node concept="3oM_SD" id="1Yf9e2l9yso" role="1PaTwD">
+          <property role="3oM_SC" value="size." />
+        </node>
+      </node>
+      <node concept="1PaTwC" id="1Yf9e2l9xg1" role="1PaQFQ">
+        <node concept="3oM_SD" id="1Yf9e2l9xg2" role="1PaTwD">
+          <property role="3oM_SC" value="" />
+        </node>
+      </node>
+      <node concept="1PaTwC" id="1Yf9e2l9xg3" role="1PaQFQ">
+        <node concept="3oM_SD" id="1Yf9e2l9xg4" role="1PaTwD">
+          <property role="3oM_SC" value="Cyclic" />
+        </node>
+        <node concept="3oM_SD" id="1Yf9e2l9xg5" role="1PaTwD">
+          <property role="3oM_SC" value="dependencies" />
+        </node>
+        <node concept="3oM_SD" id="1Yf9e2l9xg6" role="1PaTwD">
+          <property role="3oM_SC" value="are" />
+        </node>
+        <node concept="3oM_SD" id="1Yf9e2l9xg7" role="1PaTwD">
+          <property role="3oM_SC" value="not" />
+        </node>
+        <node concept="3oM_SD" id="1Yf9e2l9xg8" role="1PaTwD">
+          <property role="3oM_SC" value="wanted" />
+        </node>
+        <node concept="3oM_SD" id="1Yf9e2l9xg9" role="1PaTwD">
+          <property role="3oM_SC" value="since" />
+        </node>
+        <node concept="3oM_SD" id="1Yf9e2l9xga" role="1PaTwD">
+          <property role="3oM_SC" value="they" />
+        </node>
+        <node concept="3oM_SD" id="1Yf9e2l9xgb" role="1PaTwD">
+          <property role="3oM_SC" value="break" />
+        </node>
+        <node concept="3oM_SD" id="1Yf9e2l9xgc" role="1PaTwD">
+          <property role="3oM_SC" value="layered" />
+        </node>
+        <node concept="3oM_SD" id="1Yf9e2l9xgd" role="1PaTwD">
+          <property role="3oM_SC" value="architectures" />
+        </node>
+        <node concept="3oM_SD" id="1Yf9e2l9xge" role="1PaTwD">
+          <property role="3oM_SC" value="and" />
+        </node>
+        <node concept="3oM_SD" id="1Yf9e2l9xgf" role="1PaTwD">
+          <property role="3oM_SC" value="the" />
+        </node>
+      </node>
+      <node concept="1PaTwC" id="1Yf9e2l9xgg" role="1PaQFQ">
+        <node concept="3oM_SD" id="1Yf9e2l9xgh" role="1PaTwD">
+          <property role="3oM_SC" value="possibility" />
+        </node>
+        <node concept="3oM_SD" id="1Yf9e2l9xgi" role="1PaTwD">
+          <property role="3oM_SC" value="e.g." />
+        </node>
+        <node concept="3oM_SD" id="1Yf9e2l9xgj" role="1PaTwD">
+          <property role="3oM_SC" value="to" />
+        </node>
+        <node concept="3oM_SD" id="1Yf9e2l9xgk" role="1PaTwD">
+          <property role="3oM_SC" value="separate" />
+        </node>
+        <node concept="3oM_SD" id="1Yf9e2l9xgl" role="1PaTwD">
+          <property role="3oM_SC" value="projects" />
+        </node>
+        <node concept="3oM_SD" id="1Yf9e2l9xgm" role="1PaTwD">
+          <property role="3oM_SC" value="in" />
+        </node>
+        <node concept="3oM_SD" id="1Yf9e2l9xgn" role="1PaTwD">
+          <property role="3oM_SC" value="multiple" />
+        </node>
+        <node concept="3oM_SD" id="1Yf9e2l9xgo" role="1PaTwD">
+          <property role="3oM_SC" value="repositories." />
+        </node>
+      </node>
+      <node concept="1PaTwC" id="1Yf9e2l9xgp" role="1PaQFQ">
+        <node concept="3oM_SD" id="1Yf9e2l9xgq" role="1PaTwD">
+          <property role="3oM_SC" value="" />
+        </node>
+      </node>
+      <node concept="1PaTwC" id="1Yf9e2l9xgr" role="1PaQFQ">
+        <node concept="3oM_SD" id="1Yf9e2l9xgs" role="1PaTwD">
+          <property role="3oM_SC" value="Parameters" />
+          <property role="1X82VF" value="true" />
+        </node>
+      </node>
+      <node concept="2DRihI" id="63CQ8uYzpTi" role="1PaQFQ">
+        <node concept="3oM_SD" id="63CQ8uYzpTk" role="1PaTwD">
+          <property role="3oM_SC" value="cycleLength" />
+          <property role="1X82S1" value="true" />
+        </node>
+        <node concept="3oM_SD" id="63CQ8uYzpTl" role="1PaTwD">
+          <property role="3oM_SC" value="–" />
+        </node>
+        <node concept="3oM_SD" id="63CQ8uYzpTm" role="1PaTwD">
+          <property role="3oM_SC" value="the" />
+        </node>
+        <node concept="3oM_SD" id="63CQ8uYzpTn" role="1PaTwD">
+          <property role="3oM_SC" value="length" />
+        </node>
+        <node concept="3oM_SD" id="63CQ8uYzpTo" role="1PaTwD">
+          <property role="3oM_SC" value="of" />
+        </node>
+        <node concept="3oM_SD" id="63CQ8uYzpTp" role="1PaTwD">
+          <property role="3oM_SC" value="the" />
+        </node>
+        <node concept="3oM_SD" id="63CQ8uYzpTq" role="1PaTwD">
+          <property role="3oM_SC" value="cycle" />
+        </node>
+        <node concept="3oM_SD" id="63CQ8uYzpTr" role="1PaTwD">
+          <property role="3oM_SC" value="(e.g." />
+        </node>
+        <node concept="3oM_SD" id="63CQ8uYzpTs" role="1PaTwD">
+          <property role="3oM_SC" value="cycleLength" />
+        </node>
+        <node concept="3oM_SD" id="63CQ8uYzpTt" role="1PaTwD">
+          <property role="3oM_SC" value="==" />
+        </node>
+        <node concept="3oM_SD" id="63CQ8uYzpTu" role="1PaTwD">
+          <property role="3oM_SC" value="2" />
+        </node>
+        <node concept="3oM_SD" id="63CQ8uYzpTv" role="1PaTwD">
+          <property role="3oM_SC" value="identifies" />
+        </node>
+        <node concept="3oM_SD" id="63CQ8uYzpTw" role="1PaTwD">
+          <property role="3oM_SC" value="all" />
+        </node>
+        <node concept="3oM_SD" id="63CQ8uYzpTx" role="1PaTwD">
+          <property role="3oM_SC" value="modules" />
+        </node>
+        <node concept="3oM_SD" id="63CQ8uYzpTy" role="1PaTwD">
+          <property role="3oM_SC" value="A" />
+        </node>
+        <node concept="3oM_SD" id="63CQ8uYzpTz" role="1PaTwD">
+          <property role="3oM_SC" value="and" />
+        </node>
+        <node concept="3oM_SD" id="63CQ8uYzpT$" role="1PaTwD">
+          <property role="3oM_SC" value="B" />
+        </node>
+        <node concept="3oM_SD" id="63CQ8uYzpT_" role="1PaTwD">
+          <property role="3oM_SC" value="which" />
+        </node>
+        <node concept="3oM_SD" id="63CQ8uYzpTA" role="1PaTwD">
+          <property role="3oM_SC" value="" />
+        </node>
+        <node concept="3oM_SD" id="63CQ8uYzJ98" role="1PaTwD">
+          <property role="3oM_SC" value="" />
+        </node>
+        <node concept="3oM_SD" id="63CQ8uYzJ99" role="1PaTwD">
+          <property role="3oM_SC" value="" />
+        </node>
+        <node concept="3oM_SD" id="63CQ8uYzJ9a" role="1PaTwD">
+          <property role="3oM_SC" value="" />
+        </node>
+        <node concept="3oM_SD" id="63CQ8uYzJ9b" role="1PaTwD">
+          <property role="3oM_SC" value="" />
+        </node>
+        <node concept="3oM_SD" id="63CQ8uYzJ9c" role="1PaTwD">
+          <property role="3oM_SC" value="" />
+        </node>
+        <node concept="3oM_SD" id="63CQ8uYzJ9d" role="1PaTwD">
+          <property role="3oM_SC" value="" />
+        </node>
+        <node concept="3oM_SD" id="63CQ8uYzJ9e" role="1PaTwD">
+          <property role="3oM_SC" value="" />
+        </node>
+        <node concept="3oM_SD" id="63CQ8uYzJ9f" role="1PaTwD">
+          <property role="3oM_SC" value="" />
+        </node>
+        <node concept="3oM_SD" id="63CQ8uYzJ9g" role="1PaTwD">
+          <property role="3oM_SC" value="" />
+        </node>
+        <node concept="3oM_SD" id="63CQ8uYzJ9h" role="1PaTwD">
+          <property role="3oM_SC" value="" />
+        </node>
+        <node concept="3oM_SD" id="63CQ8uYzJ9i" role="1PaTwD">
+          <property role="3oM_SC" value="" />
+        </node>
+        <node concept="3oM_SD" id="63CQ8uYzJ9j" role="1PaTwD">
+          <property role="3oM_SC" value="" />
+        </node>
+        <node concept="3oM_SD" id="63CQ8uYzJ9k" role="1PaTwD">
+          <property role="3oM_SC" value="" />
+        </node>
+        <node concept="3oM_SD" id="63CQ8uYzJ9l" role="1PaTwD">
+          <property role="3oM_SC" value="" />
+        </node>
+        <node concept="3oM_SD" id="63CQ8uYzJ9o" role="1PaTwD">
+          <property role="3oM_SC" value="" />
+        </node>
+        <node concept="3oM_SD" id="6LT4Q$AeOQG" role="1PaTwD">
+          <property role="3oM_SC" value="" />
+        </node>
+        <node concept="3oM_SD" id="6LT4Q$AeOQH" role="1PaTwD">
+          <property role="3oM_SC" value="" />
+        </node>
+        <node concept="3oM_SD" id="6LT4Q$AeOQI" role="1PaTwD">
+          <property role="3oM_SC" value="" />
+        </node>
+        <node concept="3oM_SD" id="6LT4Q$AeOQJ" role="1PaTwD">
+          <property role="3oM_SC" value="" />
+        </node>
+        <node concept="3oM_SD" id="6LT4Q$AeOQK" role="1PaTwD">
+          <property role="3oM_SC" value="" />
+        </node>
+        <node concept="3oM_SD" id="6LT4Q$AeOQL" role="1PaTwD">
+          <property role="3oM_SC" value="" />
+        </node>
+        <node concept="3oM_SD" id="6LT4Q$AeOQM" role="1PaTwD">
+          <property role="3oM_SC" value="" />
+        </node>
+        <node concept="3oM_SD" id="6LT4Q$AeOQN" role="1PaTwD">
+          <property role="3oM_SC" value="" />
+        </node>
+        <node concept="3oM_SD" id="6LT4Q$AeOQO" role="1PaTwD">
+          <property role="3oM_SC" value="" />
+        </node>
+        <node concept="3oM_SD" id="6LT4Q$AeOQP" role="1PaTwD">
+          <property role="3oM_SC" value="" />
+        </node>
+        <node concept="3oM_SD" id="6LT4Q$AeOQS" role="1PaTwD">
+          <property role="3oM_SC" value="form" />
+        </node>
+        <node concept="3oM_SD" id="63CQ8uYzpTB" role="1PaTwD">
+          <property role="3oM_SC" value="a" />
+        </node>
+        <node concept="3oM_SD" id="63CQ8uYzpTC" role="1PaTwD">
+          <property role="3oM_SC" value="cycle" />
+        </node>
+        <node concept="3oM_SD" id="63CQ8uYzJ9_" role="1PaTwD">
+          <property role="3oM_SC" value="i.e." />
+        </node>
+        <node concept="3oM_SD" id="1Yf9e2la2no" role="1PaTwD">
+          <property role="3oM_SC" value="they" />
+        </node>
+        <node concept="3oM_SD" id="1Yf9e2la2ob" role="1PaTwD">
+          <property role="3oM_SC" value="have" />
+        </node>
+        <node concept="3oM_SD" id="1Yf9e2la2Hu" role="1PaTwD">
+          <property role="3oM_SC" value="dependencies" />
+        </node>
+        <node concept="3oM_SD" id="1Yf9e2l9ySI" role="1PaTwD">
+          <property role="3oM_SC" value="on" />
+        </node>
+        <node concept="3oM_SD" id="1Yf9e2l9yT5" role="1PaTwD">
+          <property role="3oM_SC" value="each" />
+        </node>
+        <node concept="3oM_SD" id="13En2FwnIzj" role="1PaTwD">
+          <property role="3oM_SC" value="other)" />
+        </node>
+      </node>
+    </node>
+    <node concept="1MIXq2" id="1Yf9e2l9xgY" role="14J5yK">
+      <node concept="3clFbS" id="1Yf9e2l9xgZ" role="2VODD2">
+        <node concept="3cpWs8" id="1Yf9e2l9xh0" role="3cqZAp">
+          <node concept="3cpWsn" id="1Yf9e2l9xh1" role="3cpWs9">
+            <property role="TrG5h" value="res" />
+            <node concept="_YKpA" id="1Yf9e2l9xh2" role="1tU5fm">
+              <node concept="17QB3L" id="1Yf9e2l9xh3" role="_ZDj9" />
+            </node>
+            <node concept="2ShNRf" id="1Yf9e2l9xh4" role="33vP2m">
+              <node concept="Tc6Ow" id="1Yf9e2l9xh5" role="2ShVmc">
+                <node concept="17QB3L" id="1Yf9e2l9xh6" role="HW$YZ" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="1Yf9e2l9xh7" role="3cqZAp" />
+        <node concept="L3pyB" id="1Yf9e2l9xh8" role="3cqZAp">
+          <node concept="3clFbS" id="1Yf9e2l9xh9" role="L3pyw">
+            <node concept="3clFbF" id="13En2Fwehi1" role="3cqZAp">
+              <node concept="2OqwBi" id="13En2FwejG$" role="3clFbG">
+                <node concept="2YIFZM" id="13En2FwehIy" role="2Oq$k0">
+                  <ref role="37wK5l" node="13En2FvVD7A" resolve="getDependenciesHelper" />
+                  <ref role="1Pybhc" node="4aEqBbbBtjF" resolve="CyclicModelDependenciesHelper" />
+                  <node concept="2OqwBi" id="13En2FweiGX" role="37wK5m">
+                    <node concept="1MG55F" id="13En2Fwei4S" role="2Oq$k0" />
+                    <node concept="liA8E" id="13En2Fwejv1" role="2OqNvi">
+                      <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="liA8E" id="13En2Fwekf_" role="2OqNvi">
+                  <ref role="37wK5l" to="wpu7:13En2FvuLfD" resolve="computeCyclesWithSize" />
+                  <node concept="2OqwBi" id="13En2FwenKa" role="37wK5m">
+                    <node concept="ANE8D" id="13En2FweoHt" role="2OqNvi" />
+                    <node concept="2OqwBi" id="13En2Fwov5B" role="2Oq$k0">
+                      <node concept="EZOir" id="13En2Fwov5C" role="2Oq$k0" />
+                      <node concept="3$u5V9" id="13En2Fwov5D" role="2OqNvi">
+                        <node concept="1bVj0M" id="13En2Fwov5E" role="23t8la">
+                          <node concept="3clFbS" id="13En2Fwov5F" role="1bW5cS">
+                            <node concept="3clFbF" id="13En2Fwov5G" role="3cqZAp">
+                              <node concept="2OqwBi" id="13En2Fwov5H" role="3clFbG">
+                                <node concept="2JrnkZ" id="13En2Fwov5I" role="2Oq$k0">
+                                  <node concept="37vLTw" id="13En2Fwov5J" role="2JrQYb">
+                                    <ref role="3cqZAo" node="13En2Fwov5L" resolve="it" />
+                                  </node>
+                                </node>
+                                <node concept="liA8E" id="13En2Fwov5K" role="2OqNvi">
+                                  <ref role="37wK5l" to="mhbf:~SModel.getReference()" resolve="getReference" />
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                          <node concept="gl6BB" id="13En2Fwov5L" role="1bW2Oz">
+                            <property role="TrG5h" value="it" />
+                            <node concept="2jxLKc" id="13En2Fwov5M" role="1tU5fm" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="37vLTw" id="13En2Fwepd_" role="37wK5m">
+                    <ref role="3cqZAo" node="1Yf9e2l9xh1" resolve="res" />
+                  </node>
+                  <node concept="10Nm6u" id="13En2FwovAy" role="37wK5m" />
+                  <node concept="2j1LYi" id="13En2FweqKE" role="37wK5m">
+                    <ref role="2j1LYj" node="1Yf9e2l9xfD" resolve="cycleLength" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="1MG55F" id="1Yf9e2l9xhh" role="L3pyr" />
+        </node>
+        <node concept="3cpWs6" id="1Yf9e2l9xhi" role="3cqZAp">
+          <node concept="37vLTw" id="1Yf9e2l9xhj" role="3cqZAk">
+            <ref role="3cqZAo" node="1Yf9e2l9xh1" resolve="res" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2j1LYv" id="1Yf9e2l9xhk" role="2j1YRv">
+      <node concept="2j1LYi" id="1Yf9e2l9xhl" role="2j1YQj">
+        <ref role="2j1LYj" node="1Yf9e2l9xfD" resolve="cycleLength" />
+      </node>
+      <node concept="3cmrfG" id="1Yf9e2l9yJg" role="2j1LYg">
+        <property role="3cmrfH" value="2" />
+      </node>
+    </node>
+  </node>
+  <node concept="1MIHA_" id="4Y9rGZa7XxM">
+    <property role="TrG5h" value="cyclic_models_dependencies_with_starting_point" />
+    <node concept="2j1K4_" id="4Y9rGZa7XxN" role="2j1K4A">
+      <property role="TrG5h" value="toRun" />
+      <node concept="10P_77" id="4Y9rGZa7XDr" role="2j1LY4" />
+    </node>
+    <node concept="2j1K4_" id="4Y9rGZa7XDu" role="2j1K4A">
+      <property role="TrG5h" value="startingModelRef" />
+      <node concept="1XwpNF" id="13En2Fwo$L4" role="2j1LY4" />
+    </node>
+    <node concept="1MIXq2" id="4Y9rGZa83Ot" role="14J5yK">
+      <node concept="3clFbS" id="4Y9rGZa83Ou" role="2VODD2">
+        <node concept="3cpWs8" id="4Y9rGZadqg5" role="3cqZAp">
+          <node concept="3cpWsn" id="4Y9rGZadqg6" role="3cpWs9">
+            <property role="TrG5h" value="res" />
+            <node concept="_YKpA" id="4Y9rGZadq6k" role="1tU5fm">
+              <node concept="17QB3L" id="4Y9rGZadq6n" role="_ZDj9" />
+            </node>
+            <node concept="2ShNRf" id="7MmUcJipmTu" role="33vP2m">
+              <node concept="Tc6Ow" id="7MmUcJipmTq" role="2ShVmc">
+                <node concept="17QB3L" id="7MmUcJipmTr" role="HW$YZ" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbJ" id="7MmUcJipnKe" role="3cqZAp">
+          <node concept="3clFbS" id="7MmUcJipnKg" role="3clFbx">
+            <node concept="3cpWs6" id="7MmUcJipoK8" role="3cqZAp">
+              <node concept="37vLTw" id="7MmUcJipoLo" role="3cqZAk">
+                <ref role="3cqZAo" node="4Y9rGZadqg6" resolve="res" />
+              </node>
+            </node>
+          </node>
+          <node concept="3fqX7Q" id="7MmUcJipoxn" role="3clFbw">
+            <node concept="2j1LYi" id="7MmUcJipoxp" role="3fr31v">
+              <ref role="2j1LYj" node="4Y9rGZa7XxN" resolve="toRun" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="1u5Q3uAE2oX" role="3cqZAp" />
+        <node concept="L3pyB" id="4Y9rGZadtFx" role="3cqZAp">
+          <node concept="3clFbS" id="4Y9rGZadtFz" role="L3pyw">
+            <node concept="3clFbF" id="13En2Fwi4Yw" role="3cqZAp">
+              <node concept="2OqwBi" id="13En2Fwi6Su" role="3clFbG">
+                <node concept="2YIFZM" id="13En2Fwi5f1" role="2Oq$k0">
+                  <ref role="37wK5l" node="13En2Fw73pu" resolve="getStartingPointHelper" />
+                  <ref role="1Pybhc" node="4aEqBbbBtjF" resolve="CyclicModelDependenciesHelper" />
+                  <node concept="2OqwBi" id="13En2Fwi60h" role="37wK5m">
+                    <node concept="1MG55F" id="13En2Fwi5m$" role="2Oq$k0" />
+                    <node concept="liA8E" id="13En2Fwi6Jn" role="2OqNvi">
+                      <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="liA8E" id="13En2Fwi7qP" role="2OqNvi">
+                  <ref role="37wK5l" to="wpu7:13En2FvIP8Y" resolve="computeSomeCycles" />
+                  <node concept="2OqwBi" id="13En2Fwibom" role="37wK5m">
+                    <node concept="ANE8D" id="13En2Fwicm7" role="2OqNvi" />
+                    <node concept="2OqwBi" id="13En2FwowTc" role="2Oq$k0">
+                      <node concept="EZOir" id="13En2FwowTd" role="2Oq$k0" />
+                      <node concept="3$u5V9" id="13En2FwowTe" role="2OqNvi">
+                        <node concept="1bVj0M" id="13En2FwowTf" role="23t8la">
+                          <node concept="3clFbS" id="13En2FwowTg" role="1bW5cS">
+                            <node concept="3clFbF" id="13En2FwowTh" role="3cqZAp">
+                              <node concept="2OqwBi" id="13En2FwowTi" role="3clFbG">
+                                <node concept="2JrnkZ" id="13En2FwowTj" role="2Oq$k0">
+                                  <node concept="37vLTw" id="13En2FwowTk" role="2JrQYb">
+                                    <ref role="3cqZAo" node="13En2FwowTm" resolve="it" />
+                                  </node>
+                                </node>
+                                <node concept="liA8E" id="13En2FwowTl" role="2OqNvi">
+                                  <ref role="37wK5l" to="mhbf:~SModel.getReference()" resolve="getReference" />
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                          <node concept="gl6BB" id="13En2FwowTm" role="1bW2Oz">
+                            <property role="TrG5h" value="it" />
+                            <node concept="2jxLKc" id="13En2FwowTn" role="1tU5fm" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="2j1LYi" id="13En2FwicUm" role="37wK5m">
+                    <ref role="2j1LYj" node="4Y9rGZa7XDu" resolve="startingModuleRef" />
+                  </node>
+                  <node concept="37vLTw" id="13En2FwmaTz" role="37wK5m">
+                    <ref role="3cqZAo" node="4Y9rGZadqg6" resolve="res" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="1MG55F" id="4Y9rGZaduec" role="L3pyr" />
+        </node>
+        <node concept="3clFbH" id="4Y9rGZajrfq" role="3cqZAp" />
+        <node concept="3clFbJ" id="4Y9rGZajr_g" role="3cqZAp">
+          <node concept="3clFbS" id="4Y9rGZajr_h" role="3clFbx">
+            <node concept="3cpWs8" id="4Y9rGZajr_i" role="3cqZAp">
+              <node concept="3cpWsn" id="4Y9rGZajr_j" role="3cpWs9">
+                <property role="TrG5h" value="msg" />
+                <node concept="17QB3L" id="4Y9rGZajr_k" role="1tU5fm" />
+                <node concept="3cpWs3" id="63CQ8uYzMGF" role="33vP2m">
+                  <node concept="Xl_RD" id="63CQ8uYzNbn" role="3uHU7w">
+                    <property role="Xl_RC" value=")" />
+                  </node>
+                  <node concept="3cpWs3" id="4Y9rGZajr_l" role="3uHU7B">
+                    <node concept="3cpWs3" id="4Y9rGZajtqc" role="3uHU7B">
+                      <node concept="Xl_RD" id="4Y9rGZajr_t" role="3uHU7w">
+                        <property role="Xl_RC" value=" (" />
+                      </node>
+                      <node concept="3cpWs3" id="4Y9rGZajr_p" role="3uHU7B">
+                        <node concept="Xl_RD" id="4Y9rGZajr_r" role="3uHU7B">
+                          <property role="Xl_RC" value="Too many cyclic dependencies starting from " />
+                        </node>
+                        <node concept="2OqwBi" id="4Y9rGZajtXx" role="3uHU7w">
+                          <node concept="2JrnkZ" id="13En2FwoAbr" role="2Oq$k0">
+                            <node concept="2j1LYi" id="4Y9rGZajtIA" role="2JrQYb">
+                              <ref role="2j1LYj" node="4Y9rGZa7XDu" resolve="startingModelRef" />
+                            </node>
+                          </node>
+                          <node concept="liA8E" id="4Y9rGZajuct" role="2OqNvi">
+                            <ref role="37wK5l" to="mhbf:~SModelReference.getModelName()" resolve="getModelName" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="2OqwBi" id="4Y9rGZajr_m" role="3uHU7w">
+                      <node concept="37vLTw" id="4Y9rGZajr_n" role="2Oq$k0">
+                        <ref role="3cqZAo" node="4Y9rGZadqg6" resolve="res" />
+                      </node>
+                      <node concept="34oBXx" id="4Y9rGZajr_o" role="2OqNvi" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbF" id="4Y9rGZajr_u" role="3cqZAp">
+              <node concept="2OqwBi" id="4Y9rGZajr_v" role="3clFbG">
+                <node concept="37vLTw" id="4Y9rGZajr_w" role="2Oq$k0">
+                  <ref role="3cqZAo" node="4Y9rGZadqg6" resolve="res" />
+                </node>
+                <node concept="2Kehj3" id="4Y9rGZajr_x" role="2OqNvi" />
+              </node>
+            </node>
+            <node concept="3clFbF" id="4Y9rGZajr_y" role="3cqZAp">
+              <node concept="2OqwBi" id="4Y9rGZajr_z" role="3clFbG">
+                <node concept="37vLTw" id="4Y9rGZajr_$" role="2Oq$k0">
+                  <ref role="3cqZAo" node="4Y9rGZadqg6" resolve="res" />
+                </node>
+                <node concept="TSZUe" id="4Y9rGZajr__" role="2OqNvi">
+                  <node concept="37vLTw" id="4Y9rGZajr_A" role="25WWJ7">
+                    <ref role="3cqZAo" node="4Y9rGZajr_j" resolve="msg" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3eOSWO" id="4Y9rGZajr_B" role="3clFbw">
+            <node concept="3cmrfG" id="4Y9rGZajr_C" role="3uHU7w">
+              <property role="3cmrfH" value="10000" />
+            </node>
+            <node concept="2OqwBi" id="4Y9rGZajr_D" role="3uHU7B">
+              <node concept="37vLTw" id="4Y9rGZajr_E" role="2Oq$k0">
+                <ref role="3cqZAo" node="4Y9rGZadqg6" resolve="res" />
+              </node>
+              <node concept="34oBXx" id="4Y9rGZajr_F" role="2OqNvi" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="4Y9rGZajr_G" role="3cqZAp" />
+        <node concept="3clFbF" id="4Y9rGZajr_H" role="3cqZAp">
+          <node concept="37vLTw" id="4Y9rGZajr_I" role="3clFbG">
+            <ref role="3cqZAo" node="4Y9rGZadqg6" resolve="res" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2j1LYv" id="4Y9rGZajvDW" role="2j1YRv">
+      <node concept="2j1LYi" id="4Y9rGZajvDX" role="2j1YQj">
+        <ref role="2j1LYj" node="4Y9rGZa7XxN" resolve="toRun" />
+      </node>
+      <node concept="3clFbT" id="4Y9rGZajvYc" role="2j1LYg" />
+    </node>
+    <node concept="2j1LYv" id="4Y9rGZajwnS" role="2j1YRv">
+      <node concept="2j1LYi" id="4Y9rGZajwnT" role="2j1YQj">
+        <ref role="2j1LYj" node="4Y9rGZa7XDu" resolve="startingModuleRef" />
+      </node>
+      <node concept="1Xw6AR" id="13En2FwoylN" role="2j1LYg">
+        <node concept="1dCxOl" id="13En2FwoyPa" role="1XwpL7">
+          <property role="1XweGQ" value="r:161dadb5-0fef-403d-8aac-88c1e026ee75" />
+          <node concept="1j_P7g" id="13En2FwoyPb" role="1j$8Uc">
+            <property role="1j_P7h" value="org.mpsqa.lint.generic.linters_library.models" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1Pa9Pv" id="1u5Q3uAGtsM" role="1MIJl8">
+      <node concept="1PaTwC" id="1u5Q3uAGtsN" role="1PaQFQ">
+        <node concept="3oM_SD" id="1u5Q3uAGucy" role="1PaTwD">
+          <property role="3oM_SC" value="Identifies" />
+        </node>
+        <node concept="3oM_SD" id="1u5Q3uAGuc$" role="1PaTwD">
+          <property role="3oM_SC" value="models" />
+        </node>
+        <node concept="3oM_SD" id="1u5Q3uAGucB" role="1PaTwD">
+          <property role="3oM_SC" value="that" />
+        </node>
+        <node concept="3oM_SD" id="1u5Q3uAGucF" role="1PaTwD">
+          <property role="3oM_SC" value="form" />
+        </node>
+        <node concept="3oM_SD" id="1u5Q3uAGucK" role="1PaTwD">
+          <property role="3oM_SC" value="a" />
+        </node>
+        <node concept="3oM_SD" id="1u5Q3uAGucQ" role="1PaTwD">
+          <property role="3oM_SC" value="cyclic" />
+        </node>
+        <node concept="3oM_SD" id="1u5Q3uAGucX" role="1PaTwD">
+          <property role="3oM_SC" value="dependencies" />
+        </node>
+        <node concept="3oM_SD" id="1u5Q3uAGue2" role="1PaTwD">
+          <property role="3oM_SC" value="given" />
+        </node>
+        <node concept="3oM_SD" id="1u5Q3uAGueb" role="1PaTwD">
+          <property role="3oM_SC" value="a" />
+        </node>
+        <node concept="3oM_SD" id="1u5Q3uAGuel" role="1PaTwD">
+          <property role="3oM_SC" value="starting" />
+        </node>
+        <node concept="3oM_SD" id="1u5Q3uAGuew" role="1PaTwD">
+          <property role="3oM_SC" value="model." />
+        </node>
+      </node>
+      <node concept="1PaTwC" id="1u5Q3uAGueH" role="1PaQFQ">
+        <node concept="3oM_SD" id="1u5Q3uAGueG" role="1PaTwD">
+          <property role="3oM_SC" value="" />
+        </node>
+      </node>
+      <node concept="1PaTwC" id="1u5Q3uAGufl" role="1PaQFQ">
+        <node concept="3oM_SD" id="1u5Q3uAGufk" role="1PaTwD">
+          <property role="3oM_SC" value="Cyclic" />
+        </node>
+        <node concept="3oM_SD" id="1u5Q3uAGufE" role="1PaTwD">
+          <property role="3oM_SC" value="dependencies" />
+        </node>
+        <node concept="3oM_SD" id="63CQ8uYMykr" role="1PaTwD">
+          <property role="3oM_SC" value="are" />
+        </node>
+        <node concept="3oM_SD" id="1u5Q3uAGugC" role="1PaTwD">
+          <property role="3oM_SC" value="unwanted" />
+        </node>
+        <node concept="3oM_SD" id="1u5Q3uAGugI" role="1PaTwD">
+          <property role="3oM_SC" value="since" />
+        </node>
+        <node concept="3oM_SD" id="1u5Q3uAGugP" role="1PaTwD">
+          <property role="3oM_SC" value="they" />
+        </node>
+        <node concept="3oM_SD" id="1u5Q3uAGugX" role="1PaTwD">
+          <property role="3oM_SC" value="can" />
+        </node>
+        <node concept="3oM_SD" id="1u5Q3uAGuhg" role="1PaTwD">
+          <property role="3oM_SC" value="break" />
+        </node>
+        <node concept="3oM_SD" id="1u5Q3uAGuhr" role="1PaTwD">
+          <property role="3oM_SC" value="compilation." />
+        </node>
+      </node>
+      <node concept="1PaTwC" id="1u5Q3uAGuhC" role="1PaQFQ">
+        <node concept="3oM_SD" id="1u5Q3uAGuhB" role="1PaTwD">
+          <property role="3oM_SC" value="The" />
+        </node>
+        <node concept="3oM_SD" id="1u5Q3uAGuiA" role="1PaTwD">
+          <property role="3oM_SC" value="following" />
+        </node>
+        <node concept="3oM_SD" id="1u5Q3uAGuiE" role="1PaTwD">
+          <property role="3oM_SC" value="script" />
+        </node>
+        <node concept="3oM_SD" id="1u5Q3uAGuiJ" role="1PaTwD">
+          <property role="3oM_SC" value="can" />
+        </node>
+        <node concept="3oM_SD" id="1u5Q3uAGuiP" role="1PaTwD">
+          <property role="3oM_SC" value="be" />
+        </node>
+        <node concept="3oM_SD" id="1u5Q3uAGuiW" role="1PaTwD">
+          <property role="3oM_SC" value="used" />
+        </node>
+        <node concept="3oM_SD" id="1u5Q3uAGuj4" role="1PaTwD">
+          <property role="3oM_SC" value="to" />
+        </node>
+        <node concept="3oM_SD" id="1u5Q3uAGujd" role="1PaTwD">
+          <property role="3oM_SC" value="find" />
+        </node>
+        <node concept="3oM_SD" id="1u5Q3uAGujn" role="1PaTwD">
+          <property role="3oM_SC" value="cyclic" />
+        </node>
+        <node concept="3oM_SD" id="1u5Q3uAGujy" role="1PaTwD">
+          <property role="3oM_SC" value="dependencies" />
+        </node>
+        <node concept="3oM_SD" id="1u5Q3uAGujI" role="1PaTwD">
+          <property role="3oM_SC" value="involving" />
+        </node>
+        <node concept="3oM_SD" id="1u5Q3uAGujV" role="1PaTwD">
+          <property role="3oM_SC" value="the" />
+        </node>
+        <node concept="3oM_SD" id="1u5Q3uAGuk9" role="1PaTwD">
+          <property role="3oM_SC" value="model" />
+        </node>
+        <node concept="3oM_SD" id="1u5Q3uAGuko" role="1PaTwD">
+          <property role="3oM_SC" value="passed" />
+        </node>
+        <node concept="3oM_SD" id="1u5Q3uAGukC" role="1PaTwD">
+          <property role="3oM_SC" value="as" />
+        </node>
+        <node concept="3oM_SD" id="1u5Q3uAGukT" role="1PaTwD">
+          <property role="3oM_SC" value="an" />
+        </node>
+        <node concept="3oM_SD" id="1u5Q3uAGulb" role="1PaTwD">
+          <property role="3oM_SC" value="input." />
+        </node>
+      </node>
+      <node concept="1PaTwC" id="1u5Q3uAGulv" role="1PaQFQ">
+        <node concept="3oM_SD" id="1u5Q3uAGulu" role="1PaTwD">
+          <property role="3oM_SC" value="The" />
+        </node>
+        <node concept="3oM_SD" id="1u5Q3uAGun4" role="1PaTwD">
+          <property role="3oM_SC" value="script" />
+        </node>
+        <node concept="3oM_SD" id="1u5Q3uAGun8" role="1PaTwD">
+          <property role="3oM_SC" value="finds" />
+        </node>
+        <node concept="3oM_SD" id="1u5Q3uAGund" role="1PaTwD">
+          <property role="3oM_SC" value="the" />
+        </node>
+        <node concept="3oM_SD" id="1u5Q3uAGunj" role="1PaTwD">
+          <property role="3oM_SC" value="first" />
+        </node>
+        <node concept="3oM_SD" id="1u5Q3uAGunq" role="1PaTwD">
+          <property role="3oM_SC" value="cyclic" />
+        </node>
+        <node concept="3oM_SD" id="1u5Q3uAGuny" role="1PaTwD">
+          <property role="3oM_SC" value="dependencies" />
+        </node>
+        <node concept="3oM_SD" id="1u5Q3uAGunF" role="1PaTwD">
+          <property role="3oM_SC" value="encountered" />
+        </node>
+        <node concept="3oM_SD" id="1u5Q3uAGunP" role="1PaTwD">
+          <property role="3oM_SC" value="with" />
+        </node>
+        <node concept="3oM_SD" id="1u5Q3uAGuo0" role="1PaTwD">
+          <property role="3oM_SC" value="a" />
+        </node>
+        <node concept="3oM_SD" id="1u5Q3uAGuoc" role="1PaTwD">
+          <property role="3oM_SC" value="depth-first" />
+        </node>
+        <node concept="3oM_SD" id="63CQ8uYMymU" role="1PaTwD">
+          <property role="3oM_SC" value="search" />
+        </node>
+        <node concept="3oM_SD" id="1u5Q3uAGuop" role="1PaTwD">
+          <property role="3oM_SC" value="traversal." />
+        </node>
+      </node>
+      <node concept="1PaTwC" id="1u5Q3uAGurh" role="1PaQFQ">
+        <node concept="3oM_SD" id="1u5Q3uAGurg" role="1PaTwD">
+          <property role="3oM_SC" value="After" />
+        </node>
+        <node concept="3oM_SD" id="1u5Q3uAGusF" role="1PaTwD">
+          <property role="3oM_SC" value="fixing" />
+        </node>
+        <node concept="3oM_SD" id="1u5Q3uAGusI" role="1PaTwD">
+          <property role="3oM_SC" value="a" />
+        </node>
+        <node concept="3oM_SD" id="1u5Q3uAGusM" role="1PaTwD">
+          <property role="3oM_SC" value="dependency" />
+        </node>
+        <node concept="3oM_SD" id="1u5Q3uAGusR" role="1PaTwD">
+          <property role="3oM_SC" value="cycle," />
+        </node>
+        <node concept="3oM_SD" id="1u5Q3uAGusX" role="1PaTwD">
+          <property role="3oM_SC" value="re-running" />
+        </node>
+        <node concept="3oM_SD" id="1u5Q3uAGut4" role="1PaTwD">
+          <property role="3oM_SC" value="the" />
+        </node>
+        <node concept="3oM_SD" id="1u5Q3uAGutc" role="1PaTwD">
+          <property role="3oM_SC" value="script" />
+        </node>
+        <node concept="3oM_SD" id="1u5Q3uAGutl" role="1PaTwD">
+          <property role="3oM_SC" value="may" />
+        </node>
+        <node concept="3oM_SD" id="1u5Q3uAGutv" role="1PaTwD">
+          <property role="3oM_SC" value="uncover" />
+        </node>
+        <node concept="3oM_SD" id="1u5Q3uAGutE" role="1PaTwD">
+          <property role="3oM_SC" value="new" />
+        </node>
+        <node concept="3oM_SD" id="1u5Q3uAGutQ" role="1PaTwD">
+          <property role="3oM_SC" value="cycles." />
+        </node>
+      </node>
+      <node concept="1PaTwC" id="1u5Q3uAGuoC" role="1PaQFQ">
+        <node concept="3oM_SD" id="1u5Q3uAGuoB" role="1PaTwD">
+          <property role="3oM_SC" value="" />
+        </node>
+      </node>
+      <node concept="1PaTwC" id="1u5Q3uAGuqc" role="1PaQFQ">
+        <node concept="3oM_SD" id="1u5Q3uAGuu3" role="1PaTwD">
+          <property role="3oM_SC" value="Parameters" />
+          <property role="1X82VF" value="true" />
+        </node>
+      </node>
+      <node concept="2DRihI" id="63CQ8uYzNAp" role="1PaQFQ">
+        <node concept="3oM_SD" id="63CQ8uYzNAr" role="1PaTwD">
+          <property role="3oM_SC" value="toRun" />
+          <property role="1X82S1" value="true" />
+        </node>
+        <node concept="3oM_SD" id="63CQ8uYzNAs" role="1PaTwD">
+          <property role="3oM_SC" value="–" />
+        </node>
+        <node concept="3oM_SD" id="63CQ8uYzNAt" role="1PaTwD">
+          <property role="3oM_SC" value="if" />
+        </node>
+        <node concept="3oM_SD" id="63CQ8uYzNAu" role="1PaTwD">
+          <property role="3oM_SC" value="the" />
+        </node>
+        <node concept="3oM_SD" id="63CQ8uYzNAv" role="1PaTwD">
+          <property role="3oM_SC" value="script" />
+        </node>
+        <node concept="3oM_SD" id="63CQ8uYzNAw" role="1PaTwD">
+          <property role="3oM_SC" value="should" />
+        </node>
+        <node concept="3oM_SD" id="63CQ8uYzNAx" role="1PaTwD">
+          <property role="3oM_SC" value="be" />
+        </node>
+        <node concept="3oM_SD" id="63CQ8uYzNAy" role="1PaTwD">
+          <property role="3oM_SC" value="run," />
+        </node>
+        <node concept="3oM_SD" id="63CQ8uYzNAz" role="1PaTwD">
+          <property role="3oM_SC" value="false" />
+        </node>
+        <node concept="3oM_SD" id="63CQ8uYzNA$" role="1PaTwD">
+          <property role="3oM_SC" value="by" />
+        </node>
+        <node concept="3oM_SD" id="63CQ8uYzNA_" role="1PaTwD">
+          <property role="3oM_SC" value="default" />
+        </node>
+        <node concept="3oM_SD" id="63CQ8uYzNAA" role="1PaTwD">
+          <property role="3oM_SC" value="since" />
+        </node>
+        <node concept="3oM_SD" id="63CQ8uYzNAB" role="1PaTwD">
+          <property role="3oM_SC" value="this" />
+        </node>
+        <node concept="3oM_SD" id="63CQ8uYzNAC" role="1PaTwD">
+          <property role="3oM_SC" value="should" />
+        </node>
+        <node concept="3oM_SD" id="63CQ8uYzNAD" role="1PaTwD">
+          <property role="3oM_SC" value="be" />
+        </node>
+        <node concept="3oM_SD" id="63CQ8uYzNAE" role="1PaTwD">
+          <property role="3oM_SC" value="run" />
+        </node>
+        <node concept="3oM_SD" id="63CQ8uYzNAF" role="1PaTwD">
+          <property role="3oM_SC" value="only" />
+        </node>
+        <node concept="3oM_SD" id="63CQ8uYzNAG" role="1PaTwD">
+          <property role="3oM_SC" value="when" />
+        </node>
+        <node concept="3oM_SD" id="63CQ8uYzNAH" role="1PaTwD">
+          <property role="3oM_SC" value="needed" />
+        </node>
+      </node>
+      <node concept="2DRihI" id="63CQ8uYzNAI" role="1PaQFQ">
+        <node concept="3oM_SD" id="63CQ8uYzNAK" role="1PaTwD">
+          <property role="3oM_SC" value="startingModelRef" />
+          <property role="1X82S1" value="true" />
+        </node>
+        <node concept="3oM_SD" id="63CQ8uYzNAL" role="1PaTwD">
+          <property role="3oM_SC" value="–" />
+        </node>
+        <node concept="3oM_SD" id="63CQ8uYzNAM" role="1PaTwD">
+          <property role="3oM_SC" value="the" />
+        </node>
+        <node concept="3oM_SD" id="63CQ8uYzNAN" role="1PaTwD">
+          <property role="3oM_SC" value="model" />
+        </node>
+        <node concept="3oM_SD" id="63CQ8uYzNAO" role="1PaTwD">
+          <property role="3oM_SC" value="from" />
+        </node>
+        <node concept="3oM_SD" id="63CQ8uYzNAP" role="1PaTwD">
+          <property role="3oM_SC" value="which" />
+        </node>
+        <node concept="3oM_SD" id="63CQ8uYzNAQ" role="1PaTwD">
+          <property role="3oM_SC" value="to" />
+        </node>
+        <node concept="3oM_SD" id="63CQ8uYzNAR" role="1PaTwD">
+          <property role="3oM_SC" value="start" />
+        </node>
+        <node concept="3oM_SD" id="63CQ8uYzNAS" role="1PaTwD">
+          <property role="3oM_SC" value="the" />
+        </node>
+        <node concept="3oM_SD" id="63CQ8uYzNAT" role="1PaTwD">
+          <property role="3oM_SC" value="discovery" />
+        </node>
+        <node concept="3oM_SD" id="63CQ8uYzNAU" role="1PaTwD">
+          <property role="3oM_SC" value="for" />
+        </node>
+        <node concept="3oM_SD" id="63CQ8uYzNAV" role="1PaTwD">
+          <property role="3oM_SC" value="dependency" />
+        </node>
+        <node concept="3oM_SD" id="63CQ8uYzNAW" role="1PaTwD">
+          <property role="3oM_SC" value="cycles" />
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="312cEu" id="4aEqBbbBtjF">
+    <property role="TrG5h" value="CyclicModelDependenciesHelper" />
+    <property role="3GE5qa" value="utils" />
+    <node concept="2tJIrI" id="4aEqBbbBtlf" role="jymVt" />
+    <node concept="2YIFZL" id="13En2Fw73pu" role="jymVt">
+      <property role="TrG5h" value="getStartingPointHelper" />
+      <node concept="37vLTG" id="13En2Fw7x0L" role="3clF46">
+        <property role="TrG5h" value="repository" />
+        <node concept="3uibUv" id="13En2Fw7_FB" role="1tU5fm">
+          <ref role="3uigEE" to="lui2:~SRepository" resolve="SRepository" />
+        </node>
+      </node>
+      <node concept="3clFbS" id="13En2Fw73px" role="3clF47">
+        <node concept="3clFbF" id="13En2Fw7ena" role="3cqZAp">
+          <node concept="2ShNRf" id="13En2Fw7en8" role="3clFbG">
+            <node concept="1pGfFk" id="13En2Fw7jac" role="2ShVmc">
+              <property role="373rjd" value="true" />
+              <ref role="37wK5l" to="wpu7:13En2FvQ$NN" resolve="CyclicComponentDependenciesFromStartingPointHelper" />
+              <node concept="1rXfSq" id="13En2Fw7nMo" role="37wK5m">
+                <ref role="37wK5l" node="13En2FvVD7A" resolve="getDependenciesHelper" />
+                <node concept="37vLTw" id="13En2Fw7SBc" role="37wK5m">
+                  <ref role="3cqZAo" node="13En2Fw7x0L" resolve="repository" />
+                </node>
+              </node>
+              <node concept="3uibUv" id="13En2Fwm5BA" role="1pMfVU">
+                <ref role="3uigEE" to="mhbf:~SModelReference" resolve="SModelReference" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="13En2Fw6M8f" role="1B3o_S" />
+      <node concept="3uibUv" id="13En2Fw6YUm" role="3clF45">
+        <ref role="3uigEE" to="wpu7:13En2FvI8nj" resolve="CyclicComponentDependenciesFromStartingPointHelper" />
+        <node concept="3uibUv" id="13En2Fwikfo" role="11_B2D">
+          <ref role="3uigEE" to="mhbf:~SModelReference" resolve="SModelReference" />
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="13En2Fw6BGo" role="jymVt" />
+    <node concept="2YIFZL" id="13En2FvVD7A" role="jymVt">
+      <property role="TrG5h" value="getDependenciesHelper" />
+      <node concept="3clFbS" id="13En2FvVD7D" role="3clF47">
+        <node concept="3cpWs8" id="13En2Fwb4rR" role="3cqZAp">
+          <node concept="3cpWsn" id="13En2Fwb4rS" role="3cpWs9">
+            <property role="TrG5h" value="dependencyResolver" />
+            <node concept="1ajhzC" id="13En2Fwb4rK" role="1tU5fm">
+              <node concept="_YKpA" id="13En2Fwb4rL" role="1ajw0F">
+                <node concept="3uibUv" id="13En2Fwb4rM" role="_ZDj9">
+                  <ref role="3uigEE" to="mhbf:~SModelReference" resolve="SModelReference" />
+                </node>
+              </node>
+              <node concept="3uibUv" id="13En2Fwb4rN" role="1ajw0F">
+                <ref role="3uigEE" to="mhbf:~SModelReference" resolve="SModelReference" />
+              </node>
+              <node concept="3uibUv" id="13En2Fwb4rO" role="1ajw0F">
+                <ref role="3uigEE" to="wpu7:13En2FvhV7b" resolve="CyclicGenericDependenciesHelper.Option" />
+              </node>
+              <node concept="A3Dl8" id="13En2Fwb4rP" role="1ajl9A">
+                <node concept="3uibUv" id="13En2Fwb4rQ" role="A3Ik2">
+                  <ref role="3uigEE" to="mhbf:~SModelReference" resolve="SModelReference" />
+                </node>
+              </node>
+            </node>
+            <node concept="1bVj0M" id="13En2Fwb4rT" role="33vP2m">
+              <node concept="gl6BB" id="13En2Fwb4rU" role="1bW2Oz">
+                <property role="TrG5h" value="models" />
+                <node concept="2jxLKc" id="13En2Fwb4rV" role="1tU5fm" />
+              </node>
+              <node concept="gl6BB" id="13En2Fwb4rW" role="1bW2Oz">
+                <property role="TrG5h" value="modelReference" />
+                <node concept="2jxLKc" id="13En2Fwb4rX" role="1tU5fm" />
+              </node>
+              <node concept="gl6BB" id="13En2Fwb4rY" role="1bW2Oz">
+                <property role="TrG5h" value="option" />
+                <node concept="2jxLKc" id="13En2Fwb4rZ" role="1tU5fm" />
+              </node>
+              <node concept="3clFbS" id="13En2Fwb4s0" role="1bW5cS">
+                <node concept="3cpWs8" id="13En2Fwb4s1" role="3cqZAp">
+                  <node concept="3cpWsn" id="13En2Fwb4s2" role="3cpWs9">
+                    <property role="TrG5h" value="currentDependencies" />
+                    <node concept="2hMVRd" id="13En2Fwb4s3" role="1tU5fm">
+                      <node concept="3uibUv" id="13En2Fwb4s4" role="2hN53Y">
+                        <ref role="3uigEE" to="mhbf:~SModelReference" resolve="SModelReference" />
+                      </node>
+                    </node>
+                    <node concept="2ShNRf" id="13En2Fwb4s5" role="33vP2m">
+                      <node concept="2i4dXS" id="13En2Fwb4s6" role="2ShVmc">
+                        <node concept="3uibUv" id="13En2Fwb4s7" role="HW$YZ">
+                          <ref role="3uigEE" to="mhbf:~SModelReference" resolve="SModelReference" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="3cpWs8" id="13En2Fwb4s8" role="3cqZAp">
+                  <node concept="3cpWsn" id="13En2Fwb4s9" role="3cpWs9">
+                    <property role="TrG5h" value="model" />
+                    <node concept="3uibUv" id="13En2Fwb4sa" role="1tU5fm">
+                      <ref role="3uigEE" to="mhbf:~SModel" resolve="SModel" />
+                    </node>
+                    <node concept="2OqwBi" id="13En2Fwb4sb" role="33vP2m">
+                      <node concept="37vLTw" id="13En2Fwb4sc" role="2Oq$k0">
+                        <ref role="3cqZAo" node="13En2Fwb4rW" resolve="moduleReference" />
+                      </node>
+                      <node concept="liA8E" id="13En2Fwb4sd" role="2OqNvi">
+                        <ref role="37wK5l" to="mhbf:~SModelReference.resolve(org.jetbrains.mps.openapi.module.SRepository)" resolve="resolve" />
+                        <node concept="37vLTw" id="13En2Fwb4se" role="37wK5m">
+                          <ref role="3cqZAo" node="13En2Fw00za" resolve="repository" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="3cpWs8" id="13En2Fwo6HJ" role="3cqZAp">
+                  <node concept="3cpWsn" id="13En2Fwo6HK" role="3cpWs9">
+                    <property role="TrG5h" value="imports" />
+                    <node concept="3uibUv" id="13En2Fwo6HL" role="1tU5fm">
+                      <ref role="3uigEE" to="w1kc:~ModelImports" resolve="ModelImports" />
+                    </node>
+                    <node concept="2ShNRf" id="13En2Fwo8dc" role="33vP2m">
+                      <node concept="1pGfFk" id="13En2Fwo96J" role="2ShVmc">
+                        <property role="373rjd" value="true" />
+                        <ref role="37wK5l" to="w1kc:~ModelImports.&lt;init&gt;(org.jetbrains.mps.openapi.model.SModel)" resolve="ModelImports" />
+                        <node concept="37vLTw" id="13En2Fwo9E2" role="37wK5m">
+                          <ref role="3cqZAo" node="13En2Fwb4s9" resolve="model" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="2Gpval" id="13En2Fwb4sf" role="3cqZAp">
+                  <node concept="2GrKxI" id="13En2Fwb4sg" role="2Gsz3X">
+                    <property role="TrG5h" value="dep" />
+                  </node>
+                  <node concept="3clFbS" id="13En2Fwb4sh" role="2LFqv$">
+                    <node concept="3clFbJ" id="13En2Fwb4sq" role="3cqZAp">
+                      <node concept="2OqwBi" id="13En2Fwb4ss" role="3clFbw">
+                        <node concept="37vLTw" id="13En2Fwb4st" role="2Oq$k0">
+                          <ref role="3cqZAo" node="13En2Fwb4rU" resolve="models" />
+                        </node>
+                        <node concept="3JPx81" id="13En2Fwb4su" role="2OqNvi">
+                          <node concept="2GrUjf" id="13En2Fwoecs" role="25WWJ7">
+                            <ref role="2Gs0qQ" node="13En2Fwb4sg" resolve="dep" />
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="3clFbS" id="13En2Fwb4sz" role="3clFbx">
+                        <node concept="3clFbF" id="13En2Fwb4s$" role="3cqZAp">
+                          <node concept="2OqwBi" id="13En2Fwb4s_" role="3clFbG">
+                            <node concept="37vLTw" id="13En2Fwb4sA" role="2Oq$k0">
+                              <ref role="3cqZAo" node="13En2Fwb4s2" resolve="currentDependencies" />
+                            </node>
+                            <node concept="TSZUe" id="13En2Fwb4sB" role="2OqNvi">
+                              <node concept="2GrUjf" id="13En2Fwog7f" role="25WWJ7">
+                                <ref role="2Gs0qQ" node="13En2Fwb4sg" resolve="dep" />
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="2OqwBi" id="13En2Fwb4sD" role="2GsD0m">
+                    <node concept="37vLTw" id="13En2Fwb4sE" role="2Oq$k0">
+                      <ref role="3cqZAo" node="13En2Fwo6HK" resolve="imports" />
+                    </node>
+                    <node concept="liA8E" id="13En2Fwb4sF" role="2OqNvi">
+                      <ref role="37wK5l" to="w1kc:~ModelImports.getImportedModels()" resolve="getImportedModels" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="3clFbF" id="13En2Fwb4tc" role="3cqZAp">
+                  <node concept="37vLTw" id="13En2Fwb4td" role="3clFbG">
+                    <ref role="3cqZAo" node="13En2Fwb4s2" resolve="currentDependencies" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="13En2Fwc0bh" role="3cqZAp">
+          <node concept="3cpWsn" id="13En2Fwc0bk" role="3cpWs9">
+            <property role="TrG5h" value="componentNameResolver" />
+            <node concept="1ajhzC" id="13En2Fwc0bm" role="1tU5fm">
+              <node concept="17QB3L" id="13En2Fwc0bn" role="1ajl9A" />
+              <node concept="3uibUv" id="13En2Fwc0bo" role="1ajw0F">
+                <ref role="3uigEE" to="mhbf:~SModelReference" resolve="SModelReference" />
+              </node>
+            </node>
+            <node concept="1bVj0M" id="13En2Fwch$M" role="33vP2m">
+              <node concept="3clFbS" id="13En2Fwch$O" role="1bW5cS">
+                <node concept="3clFbF" id="13En2FwcA4v" role="3cqZAp">
+                  <node concept="2OqwBi" id="13En2FwcAKy" role="3clFbG">
+                    <node concept="37vLTw" id="13En2FwcA4u" role="2Oq$k0">
+                      <ref role="3cqZAo" node="13En2FwcmFW" resolve="moduleReference" />
+                    </node>
+                    <node concept="liA8E" id="13En2FwcG3l" role="2OqNvi">
+                      <ref role="37wK5l" to="mhbf:~SModelReference.getModelName()" resolve="getModelName" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="37vLTG" id="13En2FwcmFW" role="1bW2Oz">
+                <property role="TrG5h" value="modelReference" />
+                <node concept="3uibUv" id="13En2FwcmFV" role="1tU5fm">
+                  <ref role="3uigEE" to="mhbf:~SModelReference" resolve="SModelReference" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="13En2FwbFJn" role="3cqZAp" />
+        <node concept="3clFbF" id="13En2FvW0ML" role="3cqZAp">
+          <node concept="2ShNRf" id="13En2FvW0MJ" role="3clFbG">
+            <node concept="1pGfFk" id="13En2FvW4Tb" role="2ShVmc">
+              <property role="373rjd" value="true" />
+              <ref role="37wK5l" to="wpu7:13En2FvqZ5e" />
+              <node concept="3uibUv" id="13En2FvXXuX" role="1pMfVU">
+                <ref role="3uigEE" to="mhbf:~SModelReference" resolve="SModelReference" />
+              </node>
+              <node concept="37vLTw" id="13En2Fwb4te" role="37wK5m">
+                <ref role="3cqZAo" node="13En2Fwb4rS" resolve="dependencyResolver" />
+              </node>
+              <node concept="37vLTw" id="13En2FwnONt" role="37wK5m">
+                <ref role="3cqZAo" node="1gULBtOjnwD" resolve="COMPARE_MODULE_REFS" />
+              </node>
+              <node concept="37vLTw" id="13En2FwcX1e" role="37wK5m">
+                <ref role="3cqZAo" node="13En2Fwc0bk" resolve="componentNameResolver" />
+              </node>
+              <node concept="10Nm6u" id="13En2FwomyZ" role="37wK5m" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="13En2FvVul5" role="1B3o_S" />
+      <node concept="3uibUv" id="13En2FvVLgw" role="3clF45">
+        <ref role="3uigEE" to="wpu7:13En2Fv5upa" resolve="CyclicGenericDependenciesHelper" />
+        <node concept="3uibUv" id="13En2Fw8y8Y" role="11_B2D">
+          <ref role="3uigEE" to="mhbf:~SModelReference" resolve="SModelReference" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="13En2Fw00za" role="3clF46">
+        <property role="TrG5h" value="repository" />
+        <node concept="3uibUv" id="13En2Fw05Ef" role="1tU5fm">
+          <ref role="3uigEE" to="lui2:~SRepository" resolve="SRepository" />
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="1gULBtOfCkN" role="jymVt" />
+    <node concept="Wx3nA" id="1gULBtOjnwD" role="jymVt">
+      <property role="TrG5h" value="COMPARE_MODEL_REFS" />
+      <property role="3TUv4t" value="true" />
+      <node concept="3uibUv" id="1gULBtOjnwG" role="1tU5fm">
+        <ref role="3uigEE" to="33ny:~Comparator" resolve="Comparator" />
+        <node concept="3uibUv" id="1gULBtOjnwH" role="11_B2D">
+          <ref role="3uigEE" to="mhbf:~SModelReference" resolve="SModelReference" />
+        </node>
+      </node>
+      <node concept="2ShNRf" id="1gULBtOjnwI" role="33vP2m">
+        <node concept="YeOm9" id="1gULBtOjnwJ" role="2ShVmc">
+          <node concept="1Y3b0j" id="1gULBtOjnwK" role="YeSDq">
+            <property role="2bfB8j" value="true" />
+            <property role="373rjd" value="true" />
+            <ref role="1Y3XeK" to="33ny:~Comparator" resolve="Comparator" />
+            <ref role="37wK5l" to="wyt6:~Object.&lt;init&gt;()" resolve="Object" />
+            <node concept="312cEg" id="1gULBtOjnwL" role="jymVt">
+              <property role="TrG5h" value="persistenceFacade" />
+              <property role="3TUv4t" value="true" />
+              <node concept="3Tm6S6" id="1gULBtOjnwM" role="1B3o_S" />
+              <node concept="3uibUv" id="1gULBtOjnwN" role="1tU5fm">
+                <ref role="3uigEE" to="dush:~PersistenceFacade" resolve="PersistenceFacade" />
+              </node>
+              <node concept="2YIFZM" id="1gULBtOjnwO" role="33vP2m">
+                <ref role="37wK5l" to="dush:~PersistenceFacade.getInstance()" resolve="getInstance" />
+                <ref role="1Pybhc" to="dush:~PersistenceFacade" resolve="PersistenceFacade" />
+              </node>
+            </node>
+            <node concept="2tJIrI" id="1gULBtOjnwP" role="jymVt" />
+            <node concept="3Tm1VV" id="1gULBtOjnwQ" role="1B3o_S" />
+            <node concept="3clFb_" id="1gULBtOjnwR" role="jymVt">
+              <property role="TrG5h" value="compare" />
+              <node concept="3Tm1VV" id="1gULBtOjnwS" role="1B3o_S" />
+              <node concept="10Oyi0" id="1gULBtOjnwT" role="3clF45" />
+              <node concept="37vLTG" id="1gULBtOjnwU" role="3clF46">
+                <property role="TrG5h" value="a" />
+                <node concept="3uibUv" id="1gULBtOjnwV" role="1tU5fm">
+                  <ref role="3uigEE" to="mhbf:~SModelReference" resolve="SModelReference" />
+                </node>
+              </node>
+              <node concept="37vLTG" id="1gULBtOjnwW" role="3clF46">
+                <property role="TrG5h" value="b" />
+                <node concept="3uibUv" id="1gULBtOjnwX" role="1tU5fm">
+                  <ref role="3uigEE" to="mhbf:~SModelReference" resolve="SModelReference" />
+                </node>
+              </node>
+              <node concept="3clFbS" id="1gULBtOjnwY" role="3clF47">
+                <node concept="3clFbF" id="1gULBtOjnwZ" role="3cqZAp">
+                  <node concept="2OqwBi" id="1gULBtOjnx0" role="3clFbG">
+                    <node concept="2OqwBi" id="1gULBtOjnx1" role="2Oq$k0">
+                      <node concept="37vLTw" id="1gULBtOjnx2" role="2Oq$k0">
+                        <ref role="3cqZAo" node="1gULBtOjnwL" resolve="persistenceFacade" />
+                      </node>
+                      <node concept="liA8E" id="1gULBtOjnx3" role="2OqNvi">
+                        <ref role="37wK5l" to="dush:~PersistenceFacade.asString(org.jetbrains.mps.openapi.model.SModelReference)" resolve="asString" />
+                        <node concept="37vLTw" id="1gULBtOjnx4" role="37wK5m">
+                          <ref role="3cqZAo" node="1gULBtOjnwU" resolve="a" />
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="liA8E" id="1gULBtOjnx5" role="2OqNvi">
+                      <ref role="37wK5l" to="wyt6:~String.compareTo(java.lang.String)" resolve="compareTo" />
+                      <node concept="2OqwBi" id="1gULBtOjnx6" role="37wK5m">
+                        <node concept="37vLTw" id="1gULBtOjnx7" role="2Oq$k0">
+                          <ref role="3cqZAo" node="1gULBtOjnwL" resolve="persistenceFacade" />
+                        </node>
+                        <node concept="liA8E" id="1gULBtOjnx8" role="2OqNvi">
+                          <ref role="37wK5l" to="dush:~PersistenceFacade.asString(org.jetbrains.mps.openapi.model.SModelReference)" resolve="asString" />
+                          <node concept="37vLTw" id="1gULBtOjnx9" role="37wK5m">
+                            <ref role="3cqZAo" node="1gULBtOjnwW" resolve="b" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="2AHcQZ" id="1gULBtOjnxa" role="2AJF6D">
+                <ref role="2AI5Lk" to="wyt6:~Override" resolve="Override" />
+              </node>
+            </node>
+            <node concept="3uibUv" id="1gULBtOjnxb" role="2Ghqu4">
+              <ref role="3uigEE" to="mhbf:~SModelReference" resolve="SModelReference" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm6S6" id="1gULBtOjnwF" role="1B3o_S" />
+    </node>
+    <node concept="3Tm1VV" id="4aEqBbbBtjG" role="1B3o_S" />
   </node>
 </model>
 

--- a/code/languages/org.mpsqa.lint/solutions/org.mpsqa.lint.generic.linters_library/models/org.mpsqa.lint.generic.linters_library.models.mps
+++ b/code/languages/org.mpsqa.lint/solutions/org.mpsqa.lint.generic.linters_library/models/org.mpsqa.lint.generic.linters_library.models.mps
@@ -5478,7 +5478,7 @@
                     </node>
                   </node>
                   <node concept="2j1LYi" id="13En2FwicUm" role="37wK5m">
-                    <ref role="2j1LYj" node="4Y9rGZa7XDu" resolve="startingModuleRef" />
+                    <ref role="2j1LYj" node="4Y9rGZa7XDu" resolve="startingModelRef" />
                   </node>
                   <node concept="37vLTw" id="13En2FwmaTz" role="37wK5m">
                     <ref role="3cqZAo" node="4Y9rGZadqg6" resolve="res" />
@@ -5580,7 +5580,7 @@
     </node>
     <node concept="2j1LYv" id="4Y9rGZajwnS" role="2j1YRv">
       <node concept="2j1LYi" id="4Y9rGZajwnT" role="2j1YQj">
-        <ref role="2j1LYj" node="4Y9rGZa7XDu" resolve="startingModuleRef" />
+        <ref role="2j1LYj" node="4Y9rGZa7XDu" resolve="startingModelRef" />
       </node>
       <node concept="1Xw6AR" id="13En2FwoylN" role="2j1LYg">
         <node concept="1dCxOl" id="13En2FwoyPa" role="1XwpL7">
@@ -6011,7 +6011,7 @@
                     </node>
                     <node concept="2OqwBi" id="13En2Fwb4sb" role="33vP2m">
                       <node concept="37vLTw" id="13En2Fwb4sc" role="2Oq$k0">
-                        <ref role="3cqZAo" node="13En2Fwb4rW" resolve="moduleReference" />
+                        <ref role="3cqZAo" node="13En2Fwb4rW" resolve="modelReference" />
                       </node>
                       <node concept="liA8E" id="13En2Fwb4sd" role="2OqNvi">
                         <ref role="37wK5l" to="mhbf:~SModelReference.resolve(org.jetbrains.mps.openapi.module.SRepository)" resolve="resolve" />
@@ -6103,7 +6103,7 @@
                 <node concept="3clFbF" id="13En2FwcA4v" role="3cqZAp">
                   <node concept="2OqwBi" id="13En2FwcAKy" role="3clFbG">
                     <node concept="37vLTw" id="13En2FwcA4u" role="2Oq$k0">
-                      <ref role="3cqZAo" node="13En2FwcmFW" resolve="moduleReference" />
+                      <ref role="3cqZAo" node="13En2FwcmFW" resolve="modelReference" />
                     </node>
                     <node concept="liA8E" id="13En2FwcG3l" role="2OqNvi">
                       <ref role="37wK5l" to="mhbf:~SModelReference.getModelName()" resolve="getModelName" />
@@ -6125,7 +6125,7 @@
           <node concept="2ShNRf" id="13En2FvW0MJ" role="3clFbG">
             <node concept="1pGfFk" id="13En2FvW4Tb" role="2ShVmc">
               <property role="373rjd" value="true" />
-              <ref role="37wK5l" to="wpu7:13En2FvqZ5e" />
+              <ref role="37wK5l" to="wpu7:13En2FvqZ5e" resolve="CyclicGenericDependenciesHelper" />
               <node concept="3uibUv" id="13En2FvXXuX" role="1pMfVU">
                 <ref role="3uigEE" to="mhbf:~SModelReference" resolve="SModelReference" />
               </node>
@@ -6133,7 +6133,7 @@
                 <ref role="3cqZAo" node="13En2Fwb4rS" resolve="dependencyResolver" />
               </node>
               <node concept="37vLTw" id="13En2FwnONt" role="37wK5m">
-                <ref role="3cqZAo" node="1gULBtOjnwD" resolve="COMPARE_MODULE_REFS" />
+                <ref role="3cqZAo" node="1gULBtOjnwD" resolve="COMPARE_MODEL_REFS" />
               </node>
               <node concept="37vLTw" id="13En2FwcX1e" role="37wK5m">
                 <ref role="3cqZAo" node="13En2Fwc0bk" resolve="componentNameResolver" />

--- a/code/languages/org.mpsqa.lint/solutions/org.mpsqa.lint.generic.linters_library/models/org.mpsqa.lint.generic.linters_library.modules.mps
+++ b/code/languages/org.mpsqa.lint/solutions/org.mpsqa.lint.generic.linters_library/models/org.mpsqa.lint.generic.linters_library.modules.mps
@@ -4136,12 +4136,12 @@
           <node concept="2ShNRf" id="13En2FvW0MJ" role="3clFbG">
             <node concept="1pGfFk" id="13En2FvW4Tb" role="2ShVmc">
               <property role="373rjd" value="true" />
-              <ref role="37wK5l" node="13En2FvqZ5e" />
+              <ref role="37wK5l" node="13En2FvqZ5e" resolve="CyclicGenericDependenciesHelper" />
               <node concept="3uibUv" id="13En2FvXXuX" role="1pMfVU">
                 <ref role="3uigEE" to="lui2:~SModuleReference" resolve="SModuleReference" />
               </node>
               <node concept="37vLTw" id="13En2Fwb4te" role="37wK5m">
-                <ref role="3cqZAo" node="13En2Fwb4rS" resolve="function" />
+                <ref role="3cqZAo" node="13En2Fwb4rS" resolve="dependencyResolver" />
               </node>
               <node concept="37vLTw" id="13En2FvYa6I" role="37wK5m">
                 <ref role="3cqZAo" node="1gULBtOjnwD" resolve="COMPARE_MODULE_REFS" />
@@ -6696,7 +6696,7 @@
                   <ref role="16sUi3" node="13En2FvIxxl" resolve="Component" />
                 </node>
                 <node concept="37vLTw" id="13En2FvIP98" role="HW$Y0">
-                  <ref role="3cqZAo" node="13En2FvIP9R" resolve="startingModule" />
+                  <ref role="3cqZAo" node="13En2FvIP9R" resolve="startingComponent" />
                 </node>
               </node>
             </node>
@@ -6847,7 +6847,7 @@
             </node>
             <node concept="TSZUe" id="13En2FvJE3O" role="2OqNvi">
               <node concept="37vLTw" id="13En2FvJE3P" role="25WWJ7">
-                <ref role="3cqZAo" node="13En2FvJE4v" resolve="currentModule" />
+                <ref role="3cqZAo" node="13En2FvJE4v" resolve="currentComponent" />
               </node>
             </node>
           </node>
@@ -6859,7 +6859,7 @@
             </node>
             <node concept="TSZUe" id="13En2FvJE3T" role="2OqNvi">
               <node concept="37vLTw" id="13En2FvJE3U" role="25WWJ7">
-                <ref role="3cqZAo" node="13En2FvJE4v" resolve="currentModule" />
+                <ref role="3cqZAo" node="13En2FvJE4v" resolve="currentComponent" />
               </node>
             </node>
           </node>
@@ -6870,7 +6870,7 @@
           </node>
           <node concept="3EllGN" id="13En2FvJE3X" role="2GsD0m">
             <node concept="37vLTw" id="13En2FvJE3Y" role="3ElVtu">
-              <ref role="3cqZAo" node="13En2FvJE4v" resolve="currentModule" />
+              <ref role="3cqZAo" node="13En2FvJE4v" resolve="currentComponent" />
             </node>
             <node concept="37vLTw" id="13En2FvJE3Z" role="3ElQJh">
               <ref role="3cqZAo" node="13En2FvJE4x" resolve="directDependencies" />
@@ -7128,7 +7128,7 @@
         <node concept="3clFbF" id="13En2FvM0mG" role="3cqZAp">
           <node concept="2OqwBi" id="13En2FvM0mH" role="3clFbG">
             <node concept="37vLTw" id="13En2FvM0mI" role="2Oq$k0">
-              <ref role="3cqZAo" node="13En2FvM0mW" resolve="startingModules" />
+              <ref role="3cqZAo" node="13En2FvM0mW" resolve="startingComponents" />
             </node>
             <node concept="2es0OD" id="13En2FvM0mJ" role="2OqNvi">
               <node concept="1bVj0M" id="13En2FvM0mK" role="23t8la">
@@ -7140,7 +7140,7 @@
                         <ref role="3cqZAo" node="13En2FvM0mR" resolve="startingMod" />
                       </node>
                       <node concept="37vLTw" id="13En2FvMpjR" role="37wK5m">
-                        <ref role="3cqZAo" node="13En2FvM0m$" resolve="directModuleDependencies" />
+                        <ref role="3cqZAo" node="13En2FvM0m$" resolve="directComponentDependencies" />
                       </node>
                       <node concept="37vLTw" id="13En2FvMxTX" role="37wK5m">
                         <ref role="3cqZAo" node="13En2FvM0mZ" resolve="action" />
@@ -7351,10 +7351,10 @@
           <node concept="1rXfSq" id="13En2FvNZff" role="3clFbG">
             <ref role="37wK5l" node="13En2FvM0mw" resolve="DFS" />
             <node concept="37vLTw" id="13En2FvNZfg" role="37wK5m">
-              <ref role="3cqZAo" node="13En2FvNZfm" resolve="modules" />
+              <ref role="3cqZAo" node="13En2FvNZfm" resolve="components" />
             </node>
             <node concept="37vLTw" id="13En2FvNZfh" role="37wK5m">
-              <ref role="3cqZAo" node="13En2FvNZfp" resolve="startingModules" />
+              <ref role="3cqZAo" node="13En2FvNZfp" resolve="startingComponents" />
             </node>
             <node concept="37vLTw" id="13En2FvNZfi" role="37wK5m">
               <ref role="3cqZAo" node="13En2FvNZet" resolve="addToCycles" />
@@ -8609,7 +8609,7 @@
                       <ref role="3cqZAo" node="13En2FvxEFh" resolve="alreadyVisited" />
                     </node>
                     <node concept="37vLTw" id="13En2FvCsKX" role="37wK5m">
-                      <ref role="3cqZAo" node="13En2FvxEED" resolve="modulesForWhichAllCyclesHaveBeenFound" />
+                      <ref role="3cqZAo" node="13En2FvxEED" resolve="componentsForWhichAllCyclesHaveBeenFound" />
                     </node>
                     <node concept="37vLTw" id="13En2FvC_p$" role="37wK5m">
                       <ref role="3cqZAo" node="13En2FvxEEw" resolve="allCycles" />
@@ -8639,7 +8639,7 @@
             <node concept="3clFbF" id="13En2FvxEFC" role="3cqZAp">
               <node concept="2OqwBi" id="13En2FvxEFD" role="3clFbG">
                 <node concept="37vLTw" id="13En2FvxEFE" role="2Oq$k0">
-                  <ref role="3cqZAo" node="13En2FvxEED" resolve="modulesForWhichAllCyclesHaveBeenFound" />
+                  <ref role="3cqZAo" node="13En2FvxEED" resolve="componentsForWhichAllCyclesHaveBeenFound" />
                 </node>
                 <node concept="TSZUe" id="13En2FvxEFF" role="2OqNvi">
                   <node concept="2GrUjf" id="13En2FvxEFG" role="25WWJ7">

--- a/code/languages/org.mpsqa.lint/solutions/org.mpsqa.lint.generic.linters_library/models/org.mpsqa.lint.generic.linters_library.modules.mps
+++ b/code/languages/org.mpsqa.lint/solutions/org.mpsqa.lint.generic.linters_library/models/org.mpsqa.lint.generic.linters_library.modules.mps
@@ -18,7 +18,6 @@
     <import index="lui2" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.module(MPS.OpenAPI/)" />
     <import index="3ju5" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.vfs(MPS.Core/)" />
     <import index="w1kc" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.smodel(MPS.Core/)" />
-    <import index="j8aq" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.module(MPS.Core/)" />
     <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" />
     <import index="guwi" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.io(JDK/)" />
     <import index="eoo2" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.nio.file(JDK/)" />
@@ -36,6 +35,7 @@
     <import index="mhfm" ref="3f233e7f-b8a6-46d2-a57f-795d56775243/java:org.jetbrains.annotations(Annotations/)" />
     <import index="zn9m" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.openapi.util(MPS.IDEA/)" />
     <import index="pjrh" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.smodel.adapter(MPS.Core/)" />
+    <import index="j8aq" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.module(MPS.Core/)" implicit="true" />
   </imports>
   <registry>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">

--- a/code/languages/org.mpsqa.lint/solutions/org.mpsqa.lint.generic.linters_library/models/org.mpsqa.lint.generic.linters_library.modules.mps
+++ b/code/languages/org.mpsqa.lint/solutions/org.mpsqa.lint.generic.linters_library/models/org.mpsqa.lint.generic.linters_library.modules.mps
@@ -39,80 +39,80 @@
   </imports>
   <registry>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
-      <concept id="1080223426719" name="jetbrains.mps.baseLanguage.structure.OrExpression" flags="nn" index="22lmx$" />
-      <concept id="1082485599095" name="jetbrains.mps.baseLanguage.structure.BlockStatement" flags="nn" index="9aQIb">
+      <concept id="1080223426719" name="jetbrains.mps.baseLanguage.structure.OrExpression" flags="ng" index="22lmx$" />
+      <concept id="1082485599095" name="jetbrains.mps.baseLanguage.structure.BlockStatement" flags="ng" index="9aQIb">
         <child id="1082485599096" name="statements" index="9aQI4" />
       </concept>
-      <concept id="1215693861676" name="jetbrains.mps.baseLanguage.structure.BaseAssignmentExpression" flags="nn" index="d038R">
+      <concept id="1215693861676" name="jetbrains.mps.baseLanguage.structure.BaseAssignmentExpression" flags="ng" index="d038R">
         <child id="1068498886297" name="rValue" index="37vLTx" />
         <child id="1068498886295" name="lValue" index="37vLTJ" />
       </concept>
-      <concept id="1215695189714" name="jetbrains.mps.baseLanguage.structure.PlusAssignmentExpression" flags="nn" index="d57v9" />
-      <concept id="4836112446988635817" name="jetbrains.mps.baseLanguage.structure.UndefinedType" flags="in" index="2jxLKc" />
-      <concept id="1202948039474" name="jetbrains.mps.baseLanguage.structure.InstanceMethodCallOperation" flags="nn" index="liA8E" />
+      <concept id="1215695189714" name="jetbrains.mps.baseLanguage.structure.PlusAssignmentExpression" flags="ng" index="d57v9" />
+      <concept id="4836112446988635817" name="jetbrains.mps.baseLanguage.structure.UndefinedType" flags="ig" index="2jxLKc" />
+      <concept id="1202948039474" name="jetbrains.mps.baseLanguage.structure.InstanceMethodCallOperation" flags="ng" index="liA8E" />
       <concept id="8118189177080264853" name="jetbrains.mps.baseLanguage.structure.AlternativeType" flags="ig" index="nSUau">
         <child id="8118189177080264854" name="alternative" index="nSUat" />
       </concept>
-      <concept id="1465982738277781862" name="jetbrains.mps.baseLanguage.structure.PlaceholderMember" flags="nn" index="2tJIrI" />
-      <concept id="1076505808687" name="jetbrains.mps.baseLanguage.structure.WhileStatement" flags="nn" index="2$JKZl">
+      <concept id="1465982738277781862" name="jetbrains.mps.baseLanguage.structure.PlaceholderMember" flags="ng" index="2tJIrI" />
+      <concept id="1076505808687" name="jetbrains.mps.baseLanguage.structure.WhileStatement" flags="ng" index="2$JKZl">
         <child id="1076505808688" name="condition" index="2$JKZa" />
       </concept>
-      <concept id="1239714755177" name="jetbrains.mps.baseLanguage.structure.AbstractUnaryNumberOperation" flags="nn" index="2$Kvd9">
+      <concept id="1239714755177" name="jetbrains.mps.baseLanguage.structure.AbstractUnaryNumberOperation" flags="ng" index="2$Kvd9">
         <child id="1239714902950" name="expression" index="2$L3a6" />
       </concept>
-      <concept id="1188207840427" name="jetbrains.mps.baseLanguage.structure.AnnotationInstance" flags="nn" index="2AHcQZ">
+      <concept id="1188207840427" name="jetbrains.mps.baseLanguage.structure.AnnotationInstance" flags="ng" index="2AHcQZ">
         <reference id="1188208074048" name="annotation" index="2AI5Lk" />
       </concept>
       <concept id="1188208481402" name="jetbrains.mps.baseLanguage.structure.HasAnnotation" flags="ngI" index="2AJDlI">
         <child id="1188208488637" name="annotation" index="2AJF6D" />
       </concept>
-      <concept id="2820489544401957797" name="jetbrains.mps.baseLanguage.structure.DefaultClassCreator" flags="nn" index="HV5vD">
+      <concept id="2820489544401957797" name="jetbrains.mps.baseLanguage.structure.DefaultClassCreator" flags="ng" index="HV5vD">
         <reference id="2820489544401957798" name="classifier" index="HV5vE" />
       </concept>
-      <concept id="1154032098014" name="jetbrains.mps.baseLanguage.structure.AbstractLoopStatement" flags="nn" index="2LF5Ji">
+      <concept id="1154032098014" name="jetbrains.mps.baseLanguage.structure.AbstractLoopStatement" flags="ng" index="2LF5Ji">
         <child id="1154032183016" name="body" index="2LFqv$" />
       </concept>
-      <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
+      <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="ng" index="2OqwBi">
         <child id="1197027771414" name="operand" index="2Oq$k0" />
         <child id="1197027833540" name="operation" index="2OqNvi" />
       </concept>
-      <concept id="1197029447546" name="jetbrains.mps.baseLanguage.structure.FieldReferenceOperation" flags="nn" index="2OwXpG">
+      <concept id="1197029447546" name="jetbrains.mps.baseLanguage.structure.FieldReferenceOperation" flags="ng" index="2OwXpG">
         <reference id="1197029500499" name="fieldDeclaration" index="2Oxat5" />
       </concept>
-      <concept id="1083260308424" name="jetbrains.mps.baseLanguage.structure.EnumConstantReference" flags="nn" index="Rm8GO">
+      <concept id="1083260308424" name="jetbrains.mps.baseLanguage.structure.EnumConstantReference" flags="ng" index="Rm8GO">
         <reference id="1083260308426" name="enumConstantDeclaration" index="Rm8GQ" />
         <reference id="1144432896254" name="enumClass" index="1Px2BO" />
       </concept>
-      <concept id="1145552977093" name="jetbrains.mps.baseLanguage.structure.GenericNewExpression" flags="nn" index="2ShNRf">
+      <concept id="1145552977093" name="jetbrains.mps.baseLanguage.structure.GenericNewExpression" flags="ng" index="2ShNRf">
         <child id="1145553007750" name="creator" index="2ShVmc" />
       </concept>
-      <concept id="1137021947720" name="jetbrains.mps.baseLanguage.structure.ConceptFunction" flags="in" index="2VMwT0">
+      <concept id="1137021947720" name="jetbrains.mps.baseLanguage.structure.ConceptFunction" flags="ig" index="2VMwT0">
         <child id="1137022507850" name="body" index="2VODD2" />
       </concept>
       <concept id="1070462154015" name="jetbrains.mps.baseLanguage.structure.StaticFieldDeclaration" flags="ig" index="Wx3nA" />
-      <concept id="1070475354124" name="jetbrains.mps.baseLanguage.structure.ThisExpression" flags="nn" index="Xjq3P" />
-      <concept id="1070475926800" name="jetbrains.mps.baseLanguage.structure.StringLiteral" flags="nn" index="Xl_RD">
+      <concept id="1070475354124" name="jetbrains.mps.baseLanguage.structure.ThisExpression" flags="ng" index="Xjq3P" />
+      <concept id="1070475926800" name="jetbrains.mps.baseLanguage.structure.StringLiteral" flags="ng" index="Xl_RD">
         <property id="1070475926801" name="value" index="Xl_RC" />
       </concept>
       <concept id="4952749571008284462" name="jetbrains.mps.baseLanguage.structure.CatchVariable" flags="ng" index="XOnhg" />
-      <concept id="1182160077978" name="jetbrains.mps.baseLanguage.structure.AnonymousClassCreator" flags="nn" index="YeOm9">
+      <concept id="1182160077978" name="jetbrains.mps.baseLanguage.structure.AnonymousClassCreator" flags="ng" index="YeOm9">
         <child id="1182160096073" name="cls" index="YeSDq" />
       </concept>
       <concept id="1081236700938" name="jetbrains.mps.baseLanguage.structure.StaticMethodDeclaration" flags="ig" index="2YIFZL" />
-      <concept id="1081236700937" name="jetbrains.mps.baseLanguage.structure.StaticMethodCall" flags="nn" index="2YIFZM">
+      <concept id="1081236700937" name="jetbrains.mps.baseLanguage.structure.StaticMethodCall" flags="ng" index="2YIFZM">
         <reference id="1144433194310" name="classConcept" index="1Pybhc" />
       </concept>
-      <concept id="1081256982272" name="jetbrains.mps.baseLanguage.structure.InstanceOfExpression" flags="nn" index="2ZW3vV">
+      <concept id="1081256982272" name="jetbrains.mps.baseLanguage.structure.InstanceOfExpression" flags="ng" index="2ZW3vV">
         <child id="1081256993305" name="classType" index="2ZW6by" />
         <child id="1081256993304" name="leftExpression" index="2ZW6bz" />
       </concept>
-      <concept id="1070533707846" name="jetbrains.mps.baseLanguage.structure.StaticFieldReference" flags="nn" index="10M0yZ">
+      <concept id="1070533707846" name="jetbrains.mps.baseLanguage.structure.StaticFieldReference" flags="ng" index="10M0yZ">
         <reference id="1144433057691" name="classifier" index="1PxDUh" />
       </concept>
-      <concept id="1070534058343" name="jetbrains.mps.baseLanguage.structure.NullLiteral" flags="nn" index="10Nm6u" />
-      <concept id="1070534370425" name="jetbrains.mps.baseLanguage.structure.IntegerType" flags="in" index="10Oyi0" />
-      <concept id="1070534644030" name="jetbrains.mps.baseLanguage.structure.BooleanType" flags="in" index="10P_77" />
-      <concept id="1070534934090" name="jetbrains.mps.baseLanguage.structure.CastExpression" flags="nn" index="10QFUN">
+      <concept id="1070534058343" name="jetbrains.mps.baseLanguage.structure.NullLiteral" flags="ng" index="10Nm6u" />
+      <concept id="1070534370425" name="jetbrains.mps.baseLanguage.structure.IntegerType" flags="ig" index="10Oyi0" />
+      <concept id="1070534644030" name="jetbrains.mps.baseLanguage.structure.BooleanType" flags="ig" index="10P_77" />
+      <concept id="1070534934090" name="jetbrains.mps.baseLanguage.structure.CastExpression" flags="ng" index="10QFUN">
         <child id="1070534934091" name="type" index="10QFUM" />
         <child id="1070534934092" name="expression" index="10QFUP" />
       </concept>
@@ -129,16 +129,16 @@
       <concept id="1109279851642" name="jetbrains.mps.baseLanguage.structure.GenericDeclaration" flags="ng" index="16eOlS">
         <child id="1109279881614" name="typeVariableDeclaration" index="16eVyc" />
       </concept>
-      <concept id="1109283449304" name="jetbrains.mps.baseLanguage.structure.TypeVariableReference" flags="in" index="16syzq">
+      <concept id="1109283449304" name="jetbrains.mps.baseLanguage.structure.TypeVariableReference" flags="ig" index="16syzq">
         <reference id="1109283546497" name="typeVariableDeclaration" index="16sUi3" />
       </concept>
-      <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
+      <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="ng" index="37vLTw">
         <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
       </concept>
       <concept id="1068498886292" name="jetbrains.mps.baseLanguage.structure.ParameterDeclaration" flags="ir" index="37vLTG" />
-      <concept id="1068498886294" name="jetbrains.mps.baseLanguage.structure.AssignmentExpression" flags="nn" index="37vLTI" />
-      <concept id="1225271177708" name="jetbrains.mps.baseLanguage.structure.StringType" flags="in" index="17QB3L" />
-      <concept id="1225271283259" name="jetbrains.mps.baseLanguage.structure.NPEEqualsExpression" flags="nn" index="17R0WA" />
+      <concept id="1068498886294" name="jetbrains.mps.baseLanguage.structure.AssignmentExpression" flags="ng" index="37vLTI" />
+      <concept id="1225271177708" name="jetbrains.mps.baseLanguage.structure.StringType" flags="ig" index="17QB3L" />
+      <concept id="1225271283259" name="jetbrains.mps.baseLanguage.structure.NPEEqualsExpression" flags="ng" index="17R0WA" />
       <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
         <child id="5680397130376446158" name="type" index="1tU5fm" />
       </concept>
@@ -149,110 +149,110 @@
         <child id="1068580123135" name="body" index="3clF47" />
       </concept>
       <concept id="1068580123165" name="jetbrains.mps.baseLanguage.structure.InstanceMethodDeclaration" flags="ig" index="3clFb_" />
-      <concept id="1068580123152" name="jetbrains.mps.baseLanguage.structure.EqualsExpression" flags="nn" index="3clFbC" />
-      <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
+      <concept id="1068580123152" name="jetbrains.mps.baseLanguage.structure.EqualsExpression" flags="ng" index="3clFbC" />
+      <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="ng" index="3clFbF">
         <child id="1068580123156" name="expression" index="3clFbG" />
       </concept>
-      <concept id="1068580123157" name="jetbrains.mps.baseLanguage.structure.Statement" flags="nn" index="3clFbH" />
-      <concept id="1068580123159" name="jetbrains.mps.baseLanguage.structure.IfStatement" flags="nn" index="3clFbJ">
+      <concept id="1068580123157" name="jetbrains.mps.baseLanguage.structure.Statement" flags="ng" index="3clFbH" />
+      <concept id="1068580123159" name="jetbrains.mps.baseLanguage.structure.IfStatement" flags="ng" index="3clFbJ">
         <child id="1082485599094" name="ifFalseStatement" index="9aQIa" />
         <child id="1068580123160" name="condition" index="3clFbw" />
         <child id="1068580123161" name="ifTrue" index="3clFbx" />
       </concept>
-      <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
+      <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sg" stub="5293379017992965193" index="3clFbS">
         <child id="1068581517665" name="statement" index="3cqZAp" />
       </concept>
-      <concept id="1068580123137" name="jetbrains.mps.baseLanguage.structure.BooleanConstant" flags="nn" index="3clFbT">
+      <concept id="1068580123137" name="jetbrains.mps.baseLanguage.structure.BooleanConstant" flags="ng" index="3clFbT">
         <property id="1068580123138" name="value" index="3clFbU" />
       </concept>
       <concept id="1068580123140" name="jetbrains.mps.baseLanguage.structure.ConstructorDeclaration" flags="ig" index="3clFbW" />
-      <concept id="1068580320020" name="jetbrains.mps.baseLanguage.structure.IntegerConstant" flags="nn" index="3cmrfG">
+      <concept id="1068580320020" name="jetbrains.mps.baseLanguage.structure.IntegerConstant" flags="ng" index="3cmrfG">
         <property id="1068580320021" name="value" index="3cmrfH" />
       </concept>
-      <concept id="1068581242875" name="jetbrains.mps.baseLanguage.structure.PlusExpression" flags="nn" index="3cpWs3" />
-      <concept id="1068581242878" name="jetbrains.mps.baseLanguage.structure.ReturnStatement" flags="nn" index="3cpWs6">
+      <concept id="1068581242875" name="jetbrains.mps.baseLanguage.structure.PlusExpression" flags="ng" index="3cpWs3" />
+      <concept id="1068581242878" name="jetbrains.mps.baseLanguage.structure.ReturnStatement" flags="ng" index="3cpWs6">
         <child id="1068581517676" name="expression" index="3cqZAk" />
       </concept>
-      <concept id="1068581242864" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclarationStatement" flags="nn" index="3cpWs8">
+      <concept id="1068581242864" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclarationStatement" flags="ng" index="3cpWs8">
         <child id="1068581242865" name="localVariableDeclaration" index="3cpWs9" />
       </concept>
       <concept id="1068581242863" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclaration" flags="nr" index="3cpWsn" />
-      <concept id="1068581517677" name="jetbrains.mps.baseLanguage.structure.VoidType" flags="in" index="3cqZAl" />
-      <concept id="1079359253375" name="jetbrains.mps.baseLanguage.structure.ParenthesizedExpression" flags="nn" index="1eOMI4">
+      <concept id="1068581517677" name="jetbrains.mps.baseLanguage.structure.VoidType" flags="ig" index="3cqZAl" />
+      <concept id="1079359253375" name="jetbrains.mps.baseLanguage.structure.ParenthesizedExpression" flags="ng" index="1eOMI4">
         <child id="1079359253376" name="expression" index="1eOMHV" />
       </concept>
-      <concept id="1081506762703" name="jetbrains.mps.baseLanguage.structure.GreaterThanExpression" flags="nn" index="3eOSWO" />
-      <concept id="1081506773034" name="jetbrains.mps.baseLanguage.structure.LessThanExpression" flags="nn" index="3eOVzh" />
-      <concept id="1081516740877" name="jetbrains.mps.baseLanguage.structure.NotExpression" flags="nn" index="3fqX7Q">
+      <concept id="1081506762703" name="jetbrains.mps.baseLanguage.structure.GreaterThanExpression" flags="ng" index="3eOSWO" />
+      <concept id="1081506773034" name="jetbrains.mps.baseLanguage.structure.LessThanExpression" flags="ng" index="3eOVzh" />
+      <concept id="1081516740877" name="jetbrains.mps.baseLanguage.structure.NotExpression" flags="ng" index="3fqX7Q">
         <child id="1081516765348" name="expression" index="3fr31v" />
       </concept>
-      <concept id="1160998861373" name="jetbrains.mps.baseLanguage.structure.AssertStatement" flags="nn" index="1gVbGN">
+      <concept id="1160998861373" name="jetbrains.mps.baseLanguage.structure.AssertStatement" flags="ng" index="1gVbGN">
         <child id="1160998896846" name="condition" index="1gVkn0" />
       </concept>
       <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ngI" index="1ndlxa">
         <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
         <child id="1068499141038" name="actualArgument" index="37wK5m" />
       </concept>
-      <concept id="1073063089578" name="jetbrains.mps.baseLanguage.structure.SuperMethodCall" flags="nn" index="3nyPlj" />
-      <concept id="1212685548494" name="jetbrains.mps.baseLanguage.structure.ClassCreator" flags="nn" index="1pGfFk">
+      <concept id="1073063089578" name="jetbrains.mps.baseLanguage.structure.SuperMethodCall" flags="ng" index="3nyPlj" />
+      <concept id="1212685548494" name="jetbrains.mps.baseLanguage.structure.ClassCreator" flags="ng" index="1pGfFk">
         <child id="1212687122400" name="typeParameter" index="1pMfVU" />
       </concept>
       <concept id="1107461130800" name="jetbrains.mps.baseLanguage.structure.Classifier" flags="ng" index="3pOWGL">
         <property id="521412098689998745" name="nonStatic" index="2bfB8j" />
         <child id="5375687026011219971" name="member" index="jymVt" unordered="true" />
       </concept>
-      <concept id="7812454656619025412" name="jetbrains.mps.baseLanguage.structure.LocalMethodCall" flags="nn" index="1rXfSq" />
-      <concept id="1107535904670" name="jetbrains.mps.baseLanguage.structure.ClassifierType" flags="in" index="3uibUv">
+      <concept id="7812454656619025412" name="jetbrains.mps.baseLanguage.structure.LocalMethodCall" flags="ng" index="1rXfSq" />
+      <concept id="1107535904670" name="jetbrains.mps.baseLanguage.structure.ClassifierType" flags="ig" index="3uibUv">
         <reference id="1107535924139" name="classifier" index="3uigEE" />
         <child id="1109201940907" name="parameter" index="11_B2D" />
       </concept>
-      <concept id="1081773326031" name="jetbrains.mps.baseLanguage.structure.BinaryOperation" flags="nn" index="3uHJSO">
+      <concept id="1081773326031" name="jetbrains.mps.baseLanguage.structure.BinaryOperation" flags="ng" index="3uHJSO">
         <child id="1081773367579" name="rightExpression" index="3uHU7w" />
         <child id="1081773367580" name="leftExpression" index="3uHU7B" />
       </concept>
-      <concept id="1214918800624" name="jetbrains.mps.baseLanguage.structure.PostfixIncrementExpression" flags="nn" index="3uNrnE" />
+      <concept id="1214918800624" name="jetbrains.mps.baseLanguage.structure.PostfixIncrementExpression" flags="ng" index="3uNrnE" />
       <concept id="3093926081414150598" name="jetbrains.mps.baseLanguage.structure.MultipleCatchClause" flags="ng" index="3uVAMA">
         <child id="8276990574895933173" name="catchBody" index="1zc67A" />
         <child id="8276990574895933172" name="throwable" index="1zc67B" />
       </concept>
-      <concept id="1073239437375" name="jetbrains.mps.baseLanguage.structure.NotEqualsExpression" flags="nn" index="3y3z36" />
-      <concept id="1081855346303" name="jetbrains.mps.baseLanguage.structure.BreakStatement" flags="nn" index="3zACq4" />
+      <concept id="1073239437375" name="jetbrains.mps.baseLanguage.structure.NotEqualsExpression" flags="ng" index="3y3z36" />
+      <concept id="1081855346303" name="jetbrains.mps.baseLanguage.structure.BreakStatement" flags="ng" index="3zACq4" />
       <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ngI" index="1B3ioH">
         <child id="1178549979242" name="visibility" index="1B3o_S" />
       </concept>
-      <concept id="1144226303539" name="jetbrains.mps.baseLanguage.structure.ForeachStatement" flags="nn" index="1DcWWT">
+      <concept id="1144226303539" name="jetbrains.mps.baseLanguage.structure.ForeachStatement" flags="ng" index="1DcWWT">
         <child id="1144226360166" name="iterable" index="1DdaDG" />
       </concept>
-      <concept id="1144230876926" name="jetbrains.mps.baseLanguage.structure.AbstractForStatement" flags="nn" index="1DupvO">
+      <concept id="1144230876926" name="jetbrains.mps.baseLanguage.structure.AbstractForStatement" flags="ng" index="1DupvO">
         <child id="1144230900587" name="variable" index="1Duv9x" />
       </concept>
-      <concept id="1144231330558" name="jetbrains.mps.baseLanguage.structure.ForStatement" flags="nn" index="1Dw8fO">
+      <concept id="1144231330558" name="jetbrains.mps.baseLanguage.structure.ForStatement" flags="ng" index="1Dw8fO">
         <child id="1144231399730" name="condition" index="1Dwp0S" />
         <child id="1144231408325" name="iteration" index="1Dwrff" />
       </concept>
-      <concept id="5351203823916750322" name="jetbrains.mps.baseLanguage.structure.TryUniversalStatement" flags="nn" index="3J1_TO">
+      <concept id="5351203823916750322" name="jetbrains.mps.baseLanguage.structure.TryUniversalStatement" flags="ng" index="3J1_TO">
         <child id="8276990574886367510" name="catchClause" index="1zxBo5" />
         <child id="8276990574886367508" name="body" index="1zxBo7" />
       </concept>
-      <concept id="1163668896201" name="jetbrains.mps.baseLanguage.structure.TernaryOperatorExpression" flags="nn" index="3K4zz7">
+      <concept id="1163668896201" name="jetbrains.mps.baseLanguage.structure.TernaryOperatorExpression" flags="ng" index="3K4zz7">
         <child id="1163668914799" name="condition" index="3K4Cdx" />
         <child id="1163668922816" name="ifTrue" index="3K4E3e" />
         <child id="1163668934364" name="ifFalse" index="3K4GZi" />
       </concept>
-      <concept id="1082113931046" name="jetbrains.mps.baseLanguage.structure.ContinueStatement" flags="nn" index="3N13vt" />
-      <concept id="6329021646629104954" name="jetbrains.mps.baseLanguage.structure.SingleLineComment" flags="nn" index="3SKdUt">
+      <concept id="1082113931046" name="jetbrains.mps.baseLanguage.structure.ContinueStatement" flags="ng" index="3N13vt" />
+      <concept id="6329021646629104954" name="jetbrains.mps.baseLanguage.structure.SingleLineComment" flags="ng" index="3SKdUt">
         <child id="8356039341262087992" name="line" index="1aUNEU" />
       </concept>
-      <concept id="1146644602865" name="jetbrains.mps.baseLanguage.structure.PublicVisibility" flags="nn" index="3Tm1VV" />
-      <concept id="1146644623116" name="jetbrains.mps.baseLanguage.structure.PrivateVisibility" flags="nn" index="3Tm6S6" />
-      <concept id="1080120340718" name="jetbrains.mps.baseLanguage.structure.AndExpression" flags="nn" index="1Wc70l" />
+      <concept id="1146644602865" name="jetbrains.mps.baseLanguage.structure.PublicVisibility" flags="ng" index="3Tm1VV" />
+      <concept id="1146644623116" name="jetbrains.mps.baseLanguage.structure.PrivateVisibility" flags="ng" index="3Tm6S6" />
+      <concept id="1080120340718" name="jetbrains.mps.baseLanguage.structure.AndExpression" flags="ng" index="1Wc70l" />
       <concept id="1170345865475" name="jetbrains.mps.baseLanguage.structure.AnonymousClass" flags="ig" index="1Y3b0j">
         <reference id="1170346070688" name="classifier" index="1Y3XeK" />
         <child id="1201186121363" name="typeParameter" index="2Ghqu4" />
       </concept>
     </language>
     <language id="774bf8a0-62e5-41e1-af63-f4812e60e48b" name="jetbrains.mps.baseLanguage.checkedDots">
-      <concept id="4079382982702596667" name="jetbrains.mps.baseLanguage.checkedDots.structure.CheckedDotExpression" flags="nn" index="2EnYce" />
+      <concept id="4079382982702596667" name="jetbrains.mps.baseLanguage.checkedDots.structure.CheckedDotExpression" flags="ng" index="2EnYce" />
     </language>
     <language id="40ab19e9-751a-4433-b645-0e65160e58a0" name="org.mpsqa.lint.generic">
       <concept id="7741759128795038157" name="org.mpsqa.lint.generic.structure.CheckableScriptParameter" flags="ng" index="2j1K4_">
@@ -268,7 +268,7 @@
         <child id="7741759128795045752" name="exp" index="2j1LYg" />
         <child id="7741759128795065723" name="paramRef" index="2j1YQj" />
       </concept>
-      <concept id="1209559114970" name="org.mpsqa.lint.generic.structure.ConceptFunctionParameter_Module" flags="nn" index="2vlQn3" />
+      <concept id="1209559114970" name="org.mpsqa.lint.generic.structure.ConceptFunctionParameter_Module" flags="ng" index="2vlQn3" />
       <concept id="7679435328618353697" name="org.mpsqa.lint.generic.structure.FormatException" flags="ng" index="vsK6v">
         <child id="7679435328618377120" name="exception" index="vsfCu" />
       </concept>
@@ -287,19 +287,19 @@
     </language>
     <language id="fd392034-7849-419d-9071-12563d152375" name="jetbrains.mps.baseLanguage.closures">
       <concept id="2524418899405758586" name="jetbrains.mps.baseLanguage.closures.structure.InferredClosureParameterDeclaration" flags="ig" index="gl6BB" />
-      <concept id="1235746970280" name="jetbrains.mps.baseLanguage.closures.structure.CompactInvokeFunctionExpression" flags="nn" index="2Sg_IR">
+      <concept id="1235746970280" name="jetbrains.mps.baseLanguage.closures.structure.CompactInvokeFunctionExpression" flags="ng" index="2Sg_IR">
         <child id="1235746996653" name="function" index="2SgG2M" />
         <child id="1235747002942" name="parameter" index="2SgHGx" />
       </concept>
-      <concept id="1199542442495" name="jetbrains.mps.baseLanguage.closures.structure.FunctionType" flags="in" index="1ajhzC">
+      <concept id="1199542442495" name="jetbrains.mps.baseLanguage.closures.structure.FunctionType" flags="ig" index="1ajhzC">
         <child id="1199542457201" name="resultType" index="1ajl9A" />
         <child id="1199542501692" name="parameterType" index="1ajw0F" />
       </concept>
-      <concept id="1199569711397" name="jetbrains.mps.baseLanguage.closures.structure.ClosureLiteral" flags="nn" index="1bVj0M">
+      <concept id="1199569711397" name="jetbrains.mps.baseLanguage.closures.structure.ClosureLiteral" flags="ng" index="1bVj0M">
         <child id="1199569906740" name="parameter" index="1bW2Oz" />
         <child id="1199569916463" name="body" index="1bW5cS" />
       </concept>
-      <concept id="1225797177491" name="jetbrains.mps.baseLanguage.closures.structure.InvokeFunctionOperation" flags="nn" index="1Bd96e">
+      <concept id="1225797177491" name="jetbrains.mps.baseLanguage.closures.structure.InvokeFunctionOperation" flags="ng" index="1Bd96e">
         <child id="1225797361612" name="parameter" index="1BdPVh" />
       </concept>
     </language>
@@ -340,8 +340,8 @@
       </concept>
     </language>
     <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
-      <concept id="1143226024141" name="jetbrains.mps.lang.smodel.structure.SModelType" flags="in" index="H_c77" />
-      <concept id="1171323947159" name="jetbrains.mps.lang.smodel.structure.Model_NodesOperation" flags="nn" index="2SmgA7" />
+      <concept id="1143226024141" name="jetbrains.mps.lang.smodel.structure.SModelType" flags="ig" index="H_c77" />
+      <concept id="1171323947159" name="jetbrains.mps.lang.smodel.structure.Model_NodesOperation" flags="ng" index="2SmgA7" />
       <concept id="1678062499342629858" name="jetbrains.mps.lang.smodel.structure.ModuleRefExpression" flags="ng" index="37shsh">
         <child id="1678062499342629861" name="moduleId" index="37shsm" />
       </concept>
@@ -360,16 +360,16 @@
       <concept id="5106752179536586436" name="jetbrains.mps.lang.text.structure.IndentedPoint" flags="ngI" index="2RT3b8">
         <property id="5106752179536586491" name="indentation" index="2RT3bR" />
       </concept>
-      <concept id="155656958578482948" name="jetbrains.mps.lang.text.structure.Word" flags="nn" index="3oM_SD">
+      <concept id="155656958578482948" name="jetbrains.mps.lang.text.structure.Word" flags="ng" index="3oM_SD">
         <property id="155656958578482949" name="value" index="3oM_SC" />
         <property id="6328114375520539774" name="bold" index="1X82S1" />
         <property id="6328114375520539796" name="underlined" index="1X82VF" />
         <property id="6328114375520539777" name="italic" index="1X82VY" />
       </concept>
-      <concept id="2535923850359206929" name="jetbrains.mps.lang.text.structure.Text" flags="nn" index="1Pa9Pv">
+      <concept id="2535923850359206929" name="jetbrains.mps.lang.text.structure.Text" flags="ng" index="1Pa9Pv">
         <child id="2535923850359210936" name="lines" index="1PaQFQ" />
       </concept>
-      <concept id="2535923850359271782" name="jetbrains.mps.lang.text.structure.Line" flags="nn" index="1PaTwC">
+      <concept id="2535923850359271782" name="jetbrains.mps.lang.text.structure.Line" flags="ng" index="1PaTwC">
         <child id="2535923850359271783" name="elements" index="1PaTwD" />
       </concept>
     </language>
@@ -381,88 +381,88 @@
       </concept>
     </language>
     <language id="83888646-71ce-4f1c-9c53-c54016f6ad4f" name="jetbrains.mps.baseLanguage.collections">
-      <concept id="1204796164442" name="jetbrains.mps.baseLanguage.collections.structure.InternalSequenceOperation" flags="nn" index="23sCx2">
+      <concept id="1204796164442" name="jetbrains.mps.baseLanguage.collections.structure.InternalSequenceOperation" flags="ng" index="23sCx2">
         <child id="1204796294226" name="closure" index="23t8la" />
       </concept>
-      <concept id="1176906603202" name="jetbrains.mps.baseLanguage.collections.structure.BinaryOperation" flags="nn" index="56pJg">
+      <concept id="1176906603202" name="jetbrains.mps.baseLanguage.collections.structure.BinaryOperation" flags="ng" index="56pJg">
         <child id="1176906787974" name="rightExpression" index="576Qk" />
       </concept>
-      <concept id="540871147943773365" name="jetbrains.mps.baseLanguage.collections.structure.SingleArgumentSequenceOperation" flags="nn" index="25WWJ4">
+      <concept id="540871147943773365" name="jetbrains.mps.baseLanguage.collections.structure.SingleArgumentSequenceOperation" flags="ng" index="25WWJ4">
         <child id="540871147943773366" name="argument" index="25WWJ7" />
       </concept>
-      <concept id="1176923520476" name="jetbrains.mps.baseLanguage.collections.structure.ExcludeOperation" flags="nn" index="66VNe" />
-      <concept id="1204980550705" name="jetbrains.mps.baseLanguage.collections.structure.VisitAllOperation" flags="nn" index="2es0OD" />
-      <concept id="1226511727824" name="jetbrains.mps.baseLanguage.collections.structure.SetType" flags="in" index="2hMVRd">
+      <concept id="1176923520476" name="jetbrains.mps.baseLanguage.collections.structure.ExcludeOperation" flags="ng" index="66VNe" />
+      <concept id="1204980550705" name="jetbrains.mps.baseLanguage.collections.structure.VisitAllOperation" flags="ng" index="2es0OD" />
+      <concept id="1226511727824" name="jetbrains.mps.baseLanguage.collections.structure.SetType" flags="ig" index="2hMVRd">
         <child id="1226511765987" name="elementType" index="2hN53Y" />
       </concept>
-      <concept id="1226516258405" name="jetbrains.mps.baseLanguage.collections.structure.HashSetCreator" flags="nn" index="2i4dXS" />
-      <concept id="1151688443754" name="jetbrains.mps.baseLanguage.collections.structure.ListType" flags="in" index="_YKpA">
+      <concept id="1226516258405" name="jetbrains.mps.baseLanguage.collections.structure.HashSetCreator" flags="ng" index="2i4dXS" />
+      <concept id="1151688443754" name="jetbrains.mps.baseLanguage.collections.structure.ListType" flags="ig" index="_YKpA">
         <child id="1151688676805" name="elementType" index="_ZDj9" />
       </concept>
-      <concept id="1151689724996" name="jetbrains.mps.baseLanguage.collections.structure.SequenceType" flags="in" index="A3Dl8">
+      <concept id="1151689724996" name="jetbrains.mps.baseLanguage.collections.structure.SequenceType" flags="ig" index="A3Dl8">
         <child id="1151689745422" name="elementType" index="A3Ik2" />
       </concept>
-      <concept id="1151702311717" name="jetbrains.mps.baseLanguage.collections.structure.ToListOperation" flags="nn" index="ANE8D" />
-      <concept id="1209727891789" name="jetbrains.mps.baseLanguage.collections.structure.ComparatorSortOperation" flags="nn" index="2DpFxk">
+      <concept id="1151702311717" name="jetbrains.mps.baseLanguage.collections.structure.ToListOperation" flags="ng" index="ANE8D" />
+      <concept id="1209727891789" name="jetbrains.mps.baseLanguage.collections.structure.ComparatorSortOperation" flags="ng" index="2DpFxk">
         <child id="1209727996925" name="ascending" index="2Dq5b$" />
       </concept>
-      <concept id="1153943597977" name="jetbrains.mps.baseLanguage.collections.structure.ForEachStatement" flags="nn" index="2Gpval">
+      <concept id="1153943597977" name="jetbrains.mps.baseLanguage.collections.structure.ForEachStatement" flags="ng" index="2Gpval">
         <child id="1153944400369" name="variable" index="2Gsz3X" />
         <child id="1153944424730" name="inputSequence" index="2GsD0m" />
       </concept>
       <concept id="1153944193378" name="jetbrains.mps.baseLanguage.collections.structure.ForEachVariable" flags="nr" index="2GrKxI" />
-      <concept id="1153944233411" name="jetbrains.mps.baseLanguage.collections.structure.ForEachVariableReference" flags="nn" index="2GrUjf">
+      <concept id="1153944233411" name="jetbrains.mps.baseLanguage.collections.structure.ForEachVariableReference" flags="ng" index="2GrUjf">
         <reference id="1153944258490" name="variable" index="2Gs0qQ" />
       </concept>
-      <concept id="1235573135402" name="jetbrains.mps.baseLanguage.collections.structure.SingletonSequenceCreator" flags="nn" index="2HTt$P">
+      <concept id="1235573135402" name="jetbrains.mps.baseLanguage.collections.structure.SingletonSequenceCreator" flags="ng" index="2HTt$P">
         <child id="1235573175711" name="elementType" index="2HTBi0" />
         <child id="1235573187520" name="singletonValue" index="2HTEbv" />
       </concept>
-      <concept id="1237721394592" name="jetbrains.mps.baseLanguage.collections.structure.AbstractContainerCreator" flags="nn" index="HWqM0">
+      <concept id="1237721394592" name="jetbrains.mps.baseLanguage.collections.structure.AbstractContainerCreator" flags="ng" index="HWqM0">
         <child id="1237721435808" name="initValue" index="HW$Y0" />
         <child id="1237721435807" name="elementType" index="HW$YZ" />
         <child id="1237731803878" name="copyFrom" index="I$8f6" />
       </concept>
-      <concept id="1227008614712" name="jetbrains.mps.baseLanguage.collections.structure.LinkedListCreator" flags="nn" index="2Jqq0_" />
-      <concept id="1227022210526" name="jetbrains.mps.baseLanguage.collections.structure.ClearAllElementsOperation" flags="nn" index="2Kehj3" />
-      <concept id="1205679737078" name="jetbrains.mps.baseLanguage.collections.structure.SortOperation" flags="nn" index="2S7cBI">
+      <concept id="1227008614712" name="jetbrains.mps.baseLanguage.collections.structure.LinkedListCreator" flags="ng" index="2Jqq0_" />
+      <concept id="1227022210526" name="jetbrains.mps.baseLanguage.collections.structure.ClearAllElementsOperation" flags="ng" index="2Kehj3" />
+      <concept id="1205679737078" name="jetbrains.mps.baseLanguage.collections.structure.SortOperation" flags="ng" index="2S7cBI">
         <child id="1205679832066" name="ascending" index="2S7zOq" />
       </concept>
-      <concept id="1160600644654" name="jetbrains.mps.baseLanguage.collections.structure.ListCreatorWithInit" flags="nn" index="Tc6Ow" />
-      <concept id="1160612413312" name="jetbrains.mps.baseLanguage.collections.structure.AddElementOperation" flags="nn" index="TSZUe" />
-      <concept id="1160666733551" name="jetbrains.mps.baseLanguage.collections.structure.AddAllElementsOperation" flags="nn" index="X8dFx" />
-      <concept id="1162934736510" name="jetbrains.mps.baseLanguage.collections.structure.GetElementOperation" flags="nn" index="34jXtK" />
-      <concept id="1162935959151" name="jetbrains.mps.baseLanguage.collections.structure.GetSizeOperation" flags="nn" index="34oBXx" />
-      <concept id="1167380149909" name="jetbrains.mps.baseLanguage.collections.structure.RemoveElementOperation" flags="nn" index="3dhRuq" />
-      <concept id="1201872418428" name="jetbrains.mps.baseLanguage.collections.structure.GetKeysOperation" flags="nn" index="3lbrtF" />
-      <concept id="1178286324487" name="jetbrains.mps.baseLanguage.collections.structure.SortDirection" flags="nn" index="1nlBCl" />
-      <concept id="1197683403723" name="jetbrains.mps.baseLanguage.collections.structure.MapType" flags="in" index="3rvAFt">
+      <concept id="1160600644654" name="jetbrains.mps.baseLanguage.collections.structure.ListCreatorWithInit" flags="ng" index="Tc6Ow" />
+      <concept id="1160612413312" name="jetbrains.mps.baseLanguage.collections.structure.AddElementOperation" flags="ng" index="TSZUe" />
+      <concept id="1160666733551" name="jetbrains.mps.baseLanguage.collections.structure.AddAllElementsOperation" flags="ng" index="X8dFx" />
+      <concept id="1162934736510" name="jetbrains.mps.baseLanguage.collections.structure.GetElementOperation" flags="ng" index="34jXtK" />
+      <concept id="1162935959151" name="jetbrains.mps.baseLanguage.collections.structure.GetSizeOperation" flags="ng" index="34oBXx" />
+      <concept id="1167380149909" name="jetbrains.mps.baseLanguage.collections.structure.RemoveElementOperation" flags="ng" index="3dhRuq" />
+      <concept id="1201872418428" name="jetbrains.mps.baseLanguage.collections.structure.GetKeysOperation" flags="ng" index="3lbrtF" />
+      <concept id="1178286324487" name="jetbrains.mps.baseLanguage.collections.structure.SortDirection" flags="ng" index="1nlBCl" />
+      <concept id="1197683403723" name="jetbrains.mps.baseLanguage.collections.structure.MapType" flags="ig" index="3rvAFt">
         <child id="1197683466920" name="keyType" index="3rvQeY" />
         <child id="1197683475734" name="valueType" index="3rvSg0" />
       </concept>
-      <concept id="1197686869805" name="jetbrains.mps.baseLanguage.collections.structure.HashMapCreator" flags="nn" index="3rGOSV">
+      <concept id="1197686869805" name="jetbrains.mps.baseLanguage.collections.structure.HashMapCreator" flags="ng" index="3rGOSV">
         <child id="1197687026896" name="keyType" index="3rHrn6" />
         <child id="1197687035757" name="valueType" index="3rHtpV" />
       </concept>
-      <concept id="1165525191778" name="jetbrains.mps.baseLanguage.collections.structure.GetFirstOperation" flags="nn" index="1uHKPH" />
-      <concept id="1240687580870" name="jetbrains.mps.baseLanguage.collections.structure.JoinOperation" flags="nn" index="3uJxvA">
+      <concept id="1165525191778" name="jetbrains.mps.baseLanguage.collections.structure.GetFirstOperation" flags="ng" index="1uHKPH" />
+      <concept id="1240687580870" name="jetbrains.mps.baseLanguage.collections.structure.JoinOperation" flags="ng" index="3uJxvA">
         <child id="1240687658305" name="delimiter" index="3uJOhx" />
       </concept>
-      <concept id="1202120902084" name="jetbrains.mps.baseLanguage.collections.structure.WhereOperation" flags="nn" index="3zZkjj" />
-      <concept id="1202128969694" name="jetbrains.mps.baseLanguage.collections.structure.SelectOperation" flags="nn" index="3$u5V9" />
-      <concept id="1240824834947" name="jetbrains.mps.baseLanguage.collections.structure.ValueAccessOperation" flags="nn" index="3AV6Ez" />
-      <concept id="1240825616499" name="jetbrains.mps.baseLanguage.collections.structure.KeyAccessOperation" flags="nn" index="3AY5_j" />
-      <concept id="1197932370469" name="jetbrains.mps.baseLanguage.collections.structure.MapElement" flags="nn" index="3EllGN">
+      <concept id="1202120902084" name="jetbrains.mps.baseLanguage.collections.structure.WhereOperation" flags="ng" index="3zZkjj" />
+      <concept id="1202128969694" name="jetbrains.mps.baseLanguage.collections.structure.SelectOperation" flags="ng" index="3$u5V9" />
+      <concept id="1240824834947" name="jetbrains.mps.baseLanguage.collections.structure.ValueAccessOperation" flags="ng" index="3AV6Ez" />
+      <concept id="1240825616499" name="jetbrains.mps.baseLanguage.collections.structure.KeyAccessOperation" flags="ng" index="3AY5_j" />
+      <concept id="1197932370469" name="jetbrains.mps.baseLanguage.collections.structure.MapElement" flags="ng" index="3EllGN">
         <child id="1197932505799" name="map" index="3ElQJh" />
         <child id="1197932525128" name="key" index="3ElVtu" />
       </concept>
-      <concept id="1176501494711" name="jetbrains.mps.baseLanguage.collections.structure.IsNotEmptyOperation" flags="nn" index="3GX2aA" />
-      <concept id="1172254888721" name="jetbrains.mps.baseLanguage.collections.structure.ContainsOperation" flags="nn" index="3JPx81" />
-      <concept id="1180964022718" name="jetbrains.mps.baseLanguage.collections.structure.ConcatOperation" flags="nn" index="3QWeyG" />
-      <concept id="1228228912534" name="jetbrains.mps.baseLanguage.collections.structure.DowncastExpression" flags="nn" index="3S9uib">
+      <concept id="1176501494711" name="jetbrains.mps.baseLanguage.collections.structure.IsNotEmptyOperation" flags="ng" index="3GX2aA" />
+      <concept id="1172254888721" name="jetbrains.mps.baseLanguage.collections.structure.ContainsOperation" flags="ng" index="3JPx81" />
+      <concept id="1180964022718" name="jetbrains.mps.baseLanguage.collections.structure.ConcatOperation" flags="ng" index="3QWeyG" />
+      <concept id="1228228912534" name="jetbrains.mps.baseLanguage.collections.structure.DowncastExpression" flags="ng" index="3S9uib">
         <child id="1228228959951" name="expression" index="3S9DZi" />
       </concept>
-      <concept id="1178894719932" name="jetbrains.mps.baseLanguage.collections.structure.DistinctOperation" flags="nn" index="1VAtEI" />
+      <concept id="1178894719932" name="jetbrains.mps.baseLanguage.collections.structure.DistinctOperation" flags="ng" index="1VAtEI" />
     </language>
   </registry>
   <node concept="1MIHA_" id="2dSiT1hKT_t">
@@ -8323,12 +8323,12 @@
                 <node concept="1bVj0M" id="13En2FvvjPG" role="23t8la">
                   <node concept="3clFbS" id="13En2FvvjPH" role="1bW5cS">
                     <node concept="3clFbF" id="13En2FvvjPI" role="3cqZAp">
-                      <node concept="2OqwBi" id="13En2FvvjPJ" role="3clFbG">
-                        <node concept="37vLTw" id="13En2FvvjPK" role="2Oq$k0">
-                          <ref role="3cqZAo" node="13En2FvvjPM" resolve="it" />
+                      <node concept="2Sg_IR" id="13En2FwrpxX" role="3clFbG">
+                        <node concept="37vLTw" id="13En2FwrpxY" role="2SgG2M">
+                          <ref role="3cqZAo" node="13En2Fw8U7C" resolve="componentNameResolver" />
                         </node>
-                        <node concept="liA8E" id="13En2FvvjPL" role="2OqNvi">
-                          <ref role="37wK5l" to="wyt6:~Object.toString()" resolve="toString" />
+                        <node concept="37vLTw" id="13En2FwrwIO" role="2SgHGx">
+                          <ref role="3cqZAo" node="13En2FvvjPM" resolve="it" />
                         </node>
                       </node>
                     </node>

--- a/code/languages/org.mpsqa.lint/solutions/org.mpsqa.lint.generic.linters_library/models/org.mpsqa.lint.generic.linters_library.modules.mps
+++ b/code/languages/org.mpsqa.lint/solutions/org.mpsqa.lint.generic.linters_library/models/org.mpsqa.lint.generic.linters_library.modules.mps
@@ -4111,13 +4111,71 @@
             </node>
             <node concept="1bVj0M" id="13En2Fwch$M" role="33vP2m">
               <node concept="3clFbS" id="13En2Fwch$O" role="1bW5cS">
-                <node concept="3clFbF" id="13En2FwcA4v" role="3cqZAp">
-                  <node concept="2OqwBi" id="13En2FwcAKy" role="3clFbG">
-                    <node concept="37vLTw" id="13En2FwcA4u" role="2Oq$k0">
-                      <ref role="3cqZAo" node="13En2FwcmFW" resolve="moduleReference" />
+                <node concept="3cpWs8" id="3OtVAWnTxCA" role="3cqZAp">
+                  <node concept="3cpWsn" id="3OtVAWnTxCB" role="3cpWs9">
+                    <property role="TrG5h" value="module" />
+                    <node concept="3uibUv" id="3OtVAWnTxnt" role="1tU5fm">
+                      <ref role="3uigEE" to="lui2:~SModule" resolve="SModule" />
                     </node>
-                    <node concept="liA8E" id="13En2FwcG3l" role="2OqNvi">
-                      <ref role="37wK5l" to="lui2:~SModuleReference.getModuleName()" resolve="getModuleName" />
+                    <node concept="2OqwBi" id="3OtVAWnTxCC" role="33vP2m">
+                      <node concept="37vLTw" id="3OtVAWnTxCD" role="2Oq$k0">
+                        <ref role="3cqZAo" node="13En2FwcmFW" resolve="moduleReference" />
+                      </node>
+                      <node concept="liA8E" id="3OtVAWnTxCE" role="2OqNvi">
+                        <ref role="37wK5l" to="lui2:~SModuleReference.resolve(org.jetbrains.mps.openapi.module.SRepository)" resolve="resolve" />
+                        <node concept="37vLTw" id="3OtVAWnTxCF" role="37wK5m">
+                          <ref role="3cqZAo" node="13En2Fw00za" resolve="repository" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="3cpWs8" id="3OtVAWnTnpy" role="3cqZAp">
+                  <node concept="3cpWsn" id="3OtVAWnTnp_" role="3cpWs9">
+                    <property role="TrG5h" value="moduleType" />
+                    <node concept="17QB3L" id="3OtVAWnTnpw" role="1tU5fm" />
+                    <node concept="3cpWs3" id="3OtVAWnUfNK" role="33vP2m">
+                      <node concept="Xl_RD" id="3OtVAWnUguO" role="3uHU7w">
+                        <property role="Xl_RC" value="]" />
+                      </node>
+                      <node concept="3cpWs3" id="3OtVAWnU6Lc" role="3uHU7B">
+                        <node concept="Xl_RD" id="3OtVAWnTtgk" role="3uHU7B">
+                          <property role="Xl_RC" value=" [" />
+                        </node>
+                        <node concept="2OqwBi" id="3OtVAWnVt$d" role="3uHU7w">
+                          <node concept="2OqwBi" id="3OtVAWnUb2e" role="2Oq$k0">
+                            <node concept="2OqwBi" id="3OtVAWnU8VJ" role="2Oq$k0">
+                              <node concept="37vLTw" id="3OtVAWnU7m7" role="2Oq$k0">
+                                <ref role="3cqZAo" node="3OtVAWnTxCB" resolve="module" />
+                              </node>
+                              <node concept="liA8E" id="3OtVAWnU9HL" role="2OqNvi">
+                                <ref role="37wK5l" to="wyt6:~Object.getClass()" resolve="getClass" />
+                              </node>
+                            </node>
+                            <node concept="liA8E" id="3OtVAWnUe6W" role="2OqNvi">
+                              <ref role="37wK5l" to="wyt6:~Class.getSimpleName()" resolve="getSimpleName" />
+                            </node>
+                          </node>
+                          <node concept="liA8E" id="3OtVAWnVw0v" role="2OqNvi">
+                            <ref role="37wK5l" to="wyt6:~String.toLowerCase()" resolve="toLowerCase" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="3clFbF" id="13En2FwcA4v" role="3cqZAp">
+                  <node concept="3cpWs3" id="3OtVAWnK9QM" role="3clFbG">
+                    <node concept="37vLTw" id="3OtVAWnUjtt" role="3uHU7w">
+                      <ref role="3cqZAo" node="3OtVAWnTnp_" resolve="moduleType" />
+                    </node>
+                    <node concept="2OqwBi" id="13En2FwcAKy" role="3uHU7B">
+                      <node concept="37vLTw" id="13En2FwcA4u" role="2Oq$k0">
+                        <ref role="3cqZAo" node="3OtVAWnTxCB" resolve="module" />
+                      </node>
+                      <node concept="liA8E" id="13En2FwcG3l" role="2OqNvi">
+                        <ref role="37wK5l" to="lui2:~SModule.getModuleName()" resolve="getModuleName" />
+                      </node>
                     </node>
                   </node>
                 </node>
@@ -5805,86 +5863,8 @@
         <node concept="3oM_SD" id="63CQ8uYzpT$" role="1PaTwD">
           <property role="3oM_SC" value="B" />
         </node>
-        <node concept="3oM_SD" id="63CQ8uYzpT_" role="1PaTwD">
+        <node concept="3oM_SD" id="3OtVAWnJz6D" role="1PaTwD">
           <property role="3oM_SC" value="which" />
-        </node>
-        <node concept="3oM_SD" id="63CQ8uYzpTA" role="1PaTwD">
-          <property role="3oM_SC" value="" />
-        </node>
-        <node concept="3oM_SD" id="63CQ8uYzJ98" role="1PaTwD">
-          <property role="3oM_SC" value="" />
-        </node>
-        <node concept="3oM_SD" id="63CQ8uYzJ99" role="1PaTwD">
-          <property role="3oM_SC" value="" />
-        </node>
-        <node concept="3oM_SD" id="63CQ8uYzJ9a" role="1PaTwD">
-          <property role="3oM_SC" value="" />
-        </node>
-        <node concept="3oM_SD" id="63CQ8uYzJ9b" role="1PaTwD">
-          <property role="3oM_SC" value="" />
-        </node>
-        <node concept="3oM_SD" id="63CQ8uYzJ9c" role="1PaTwD">
-          <property role="3oM_SC" value="" />
-        </node>
-        <node concept="3oM_SD" id="63CQ8uYzJ9d" role="1PaTwD">
-          <property role="3oM_SC" value="" />
-        </node>
-        <node concept="3oM_SD" id="63CQ8uYzJ9e" role="1PaTwD">
-          <property role="3oM_SC" value="" />
-        </node>
-        <node concept="3oM_SD" id="63CQ8uYzJ9f" role="1PaTwD">
-          <property role="3oM_SC" value="" />
-        </node>
-        <node concept="3oM_SD" id="63CQ8uYzJ9g" role="1PaTwD">
-          <property role="3oM_SC" value="" />
-        </node>
-        <node concept="3oM_SD" id="63CQ8uYzJ9h" role="1PaTwD">
-          <property role="3oM_SC" value="" />
-        </node>
-        <node concept="3oM_SD" id="63CQ8uYzJ9i" role="1PaTwD">
-          <property role="3oM_SC" value="" />
-        </node>
-        <node concept="3oM_SD" id="63CQ8uYzJ9j" role="1PaTwD">
-          <property role="3oM_SC" value="" />
-        </node>
-        <node concept="3oM_SD" id="63CQ8uYzJ9k" role="1PaTwD">
-          <property role="3oM_SC" value="" />
-        </node>
-        <node concept="3oM_SD" id="63CQ8uYzJ9l" role="1PaTwD">
-          <property role="3oM_SC" value="" />
-        </node>
-        <node concept="3oM_SD" id="63CQ8uYzJ9o" role="1PaTwD">
-          <property role="3oM_SC" value="" />
-        </node>
-        <node concept="3oM_SD" id="6LT4Q$AeOQG" role="1PaTwD">
-          <property role="3oM_SC" value="" />
-        </node>
-        <node concept="3oM_SD" id="6LT4Q$AeOQH" role="1PaTwD">
-          <property role="3oM_SC" value="" />
-        </node>
-        <node concept="3oM_SD" id="6LT4Q$AeOQI" role="1PaTwD">
-          <property role="3oM_SC" value="" />
-        </node>
-        <node concept="3oM_SD" id="6LT4Q$AeOQJ" role="1PaTwD">
-          <property role="3oM_SC" value="" />
-        </node>
-        <node concept="3oM_SD" id="6LT4Q$AeOQK" role="1PaTwD">
-          <property role="3oM_SC" value="" />
-        </node>
-        <node concept="3oM_SD" id="6LT4Q$AeOQL" role="1PaTwD">
-          <property role="3oM_SC" value="" />
-        </node>
-        <node concept="3oM_SD" id="6LT4Q$AeOQM" role="1PaTwD">
-          <property role="3oM_SC" value="" />
-        </node>
-        <node concept="3oM_SD" id="6LT4Q$AeOQN" role="1PaTwD">
-          <property role="3oM_SC" value="" />
-        </node>
-        <node concept="3oM_SD" id="6LT4Q$AeOQO" role="1PaTwD">
-          <property role="3oM_SC" value="" />
-        </node>
-        <node concept="3oM_SD" id="6LT4Q$AeOQP" role="1PaTwD">
-          <property role="3oM_SC" value="" />
         </node>
         <node concept="3oM_SD" id="6LT4Q$AeOQS" role="1PaTwD">
           <property role="3oM_SC" value="form" />
@@ -6635,777 +6615,6 @@
       </node>
     </node>
   </node>
-  <node concept="312cEu" id="13En2FvI8nj">
-    <property role="3GE5qa" value="helpers" />
-    <property role="TrG5h" value="CyclicComponentDependenciesFromStartingPointHelper" />
-    <node concept="3Tm1VV" id="13En2FvI8nk" role="1B3o_S" />
-    <node concept="312cEg" id="13En2FvQ26l" role="jymVt">
-      <property role="TrG5h" value="dependenciesHelper" />
-      <node concept="3uibUv" id="13En2FvPXiL" role="1tU5fm">
-        <ref role="3uigEE" node="13En2Fv5upa" resolve="CyclicGenericDependenciesHelper" />
-        <node concept="16syzq" id="13En2FvSp0p" role="11_B2D">
-          <ref role="16sUi3" node="13En2FvIxxl" resolve="Component" />
-        </node>
-      </node>
-    </node>
-    <node concept="2tJIrI" id="13En2FvI8nl" role="jymVt" />
-    <node concept="3clFbW" id="13En2FvQ$NN" role="jymVt">
-      <node concept="3cqZAl" id="13En2FvQ$NO" role="3clF45" />
-      <node concept="3clFbS" id="13En2FvQ$NQ" role="3clF47">
-        <node concept="3clFbF" id="13En2FvRARK" role="3cqZAp">
-          <node concept="37vLTI" id="13En2FvRJo8" role="3clFbG">
-            <node concept="2OqwBi" id="13En2FvRB0U" role="37vLTJ">
-              <node concept="Xjq3P" id="13En2FvRARJ" role="2Oq$k0" />
-              <node concept="2OwXpG" id="13En2FvRF7Z" role="2OqNvi">
-                <ref role="2Oxat5" node="13En2FvQ26l" resolve="dependenciesHelper" />
-              </node>
-            </node>
-            <node concept="37vLTw" id="13En2Fw5E5s" role="37vLTx">
-              <ref role="3cqZAo" node="13En2Fw5uPk" resolve="dependenciesHelper" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="3Tm1VV" id="13En2FvQ$NR" role="1B3o_S" />
-      <node concept="37vLTG" id="13En2Fw5uPk" role="3clF46">
-        <property role="TrG5h" value="dependenciesHelper" />
-        <node concept="3uibUv" id="13En2Fw5uPj" role="1tU5fm">
-          <ref role="3uigEE" node="13En2Fv5upa" resolve="CyclicGenericDependenciesHelper" />
-          <node concept="16syzq" id="13En2Fw5yx4" role="11_B2D">
-            <ref role="16sUi3" node="13En2FvIxxl" resolve="Component" />
-          </node>
-        </node>
-      </node>
-    </node>
-    <node concept="2tJIrI" id="13En2FvQm9f" role="jymVt" />
-    <node concept="2tJIrI" id="13En2FvPSu_" role="jymVt" />
-    <node concept="3clFb_" id="13En2FvIP8Y" role="jymVt">
-      <property role="TrG5h" value="computeSomeCycles" />
-      <node concept="3clFbS" id="13En2FvIP90" role="3clF47">
-        <node concept="3cpWs8" id="13En2FvIP91" role="3cqZAp">
-          <node concept="3cpWsn" id="13En2FvIP92" role="3cpWs9">
-            <property role="TrG5h" value="startingComponents" />
-            <node concept="_YKpA" id="13En2FvIP93" role="1tU5fm">
-              <node concept="16syzq" id="13En2FvJ7qY" role="_ZDj9">
-                <ref role="16sUi3" node="13En2FvIxxl" resolve="Component" />
-              </node>
-            </node>
-            <node concept="2ShNRf" id="13En2FvIP95" role="33vP2m">
-              <node concept="Tc6Ow" id="13En2FvIP96" role="2ShVmc">
-                <node concept="16syzq" id="13En2FvJm4a" role="HW$YZ">
-                  <ref role="16sUi3" node="13En2FvIxxl" resolve="Component" />
-                </node>
-                <node concept="37vLTw" id="13En2FvIP98" role="HW$Y0">
-                  <ref role="3cqZAo" node="13En2FvIP9R" resolve="startingComponent" />
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3cpWs8" id="13En2FvIP99" role="3cqZAp">
-          <node concept="3cpWsn" id="13En2FvIP9a" role="3cpWs9">
-            <property role="TrG5h" value="someCyclesStartingFrom" />
-            <node concept="A3Dl8" id="13En2FvIP9f" role="1tU5fm">
-              <node concept="_YKpA" id="13En2FvIP9g" role="A3Ik2">
-                <node concept="16syzq" id="13En2FvJp__" role="_ZDj9">
-                  <ref role="16sUi3" node="13En2FvIxxl" resolve="Component" />
-                </node>
-              </node>
-            </node>
-            <node concept="1rXfSq" id="13En2FvSz3i" role="33vP2m">
-              <ref role="37wK5l" node="13En2FvNZeg" resolve="findSomeCyclesStartingFrom" />
-              <node concept="37vLTw" id="13En2FvSGXh" role="37wK5m">
-                <ref role="3cqZAo" node="13En2FvIP9O" resolve="components" />
-              </node>
-              <node concept="37vLTw" id="13En2FvST$f" role="37wK5m">
-                <ref role="3cqZAo" node="13En2FvIP92" resolve="startingComponents" />
-              </node>
-              <node concept="2OqwBi" id="13En2FwiIqm" role="37wK5m">
-                <node concept="2OqwBi" id="13En2FwiCoY" role="2Oq$k0">
-                  <node concept="Xjq3P" id="13En2FwiAPT" role="2Oq$k0" />
-                  <node concept="2OwXpG" id="13En2FwiH9d" role="2OqNvi">
-                    <ref role="2Oxat5" node="13En2FvQ26l" resolve="dependenciesHelper" />
-                  </node>
-                </node>
-                <node concept="liA8E" id="13En2FwlY_o" role="2OqNvi">
-                  <ref role="37wK5l" node="13En2FwlozC" resolve="getOption" />
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="2Gpval" id="13En2FvIP9i" role="3cqZAp">
-          <node concept="2GrKxI" id="13En2FvIP9j" role="2Gsz3X">
-            <property role="TrG5h" value="crtCycle" />
-          </node>
-          <node concept="37vLTw" id="13En2FvIP9k" role="2GsD0m">
-            <ref role="3cqZAo" node="13En2FvIP9a" resolve="someCyclesStartingFrom" />
-          </node>
-          <node concept="3clFbS" id="13En2FvIP9l" role="2LFqv$">
-            <node concept="3cpWs8" id="13En2FvIP9m" role="3cqZAp">
-              <node concept="3cpWsn" id="13En2FvIP9n" role="3cpWs9">
-                <property role="TrG5h" value="msg" />
-                <node concept="17QB3L" id="13En2FvIP9o" role="1tU5fm" />
-                <node concept="3cpWs3" id="13En2FvIP9p" role="33vP2m">
-                  <node concept="3cpWs3" id="13En2FvIP9q" role="3uHU7B">
-                    <node concept="3cpWs3" id="13En2FvIP9r" role="3uHU7B">
-                      <node concept="Xl_RD" id="13En2FvIP9s" role="3uHU7B">
-                        <property role="Xl_RC" value="Cyclic dependency with length " />
-                      </node>
-                      <node concept="2OqwBi" id="13En2FvIP9t" role="3uHU7w">
-                        <node concept="2GrUjf" id="13En2FvIP9u" role="2Oq$k0">
-                          <ref role="2Gs0qQ" node="13En2FvIP9j" resolve="crtCycle" />
-                        </node>
-                        <node concept="34oBXx" id="13En2FvIP9v" role="2OqNvi" />
-                      </node>
-                    </node>
-                    <node concept="Xl_RD" id="13En2FvIP9w" role="3uHU7w">
-                      <property role="Xl_RC" value=" found: " />
-                    </node>
-                  </node>
-                  <node concept="2OqwBi" id="13En2FvIP9x" role="3uHU7w">
-                    <node concept="2OqwBi" id="13En2FvIP9y" role="2Oq$k0">
-                      <node concept="2GrUjf" id="13En2FvIP9z" role="2Oq$k0">
-                        <ref role="2Gs0qQ" node="13En2FvIP9j" resolve="crtCycle" />
-                      </node>
-                      <node concept="3$u5V9" id="13En2FvIP9$" role="2OqNvi">
-                        <node concept="1bVj0M" id="13En2FvIP9_" role="23t8la">
-                          <node concept="3clFbS" id="13En2FvIP9A" role="1bW5cS">
-                            <node concept="3clFbF" id="13En2FvIP9B" role="3cqZAp">
-                              <node concept="2OqwBi" id="13En2FvIP9C" role="3clFbG">
-                                <node concept="37vLTw" id="13En2FvIP9D" role="2Oq$k0">
-                                  <ref role="3cqZAo" node="13En2FvIP9F" resolve="it" />
-                                </node>
-                                <node concept="liA8E" id="13En2FvIP9E" role="2OqNvi">
-                                  <ref role="37wK5l" to="wyt6:~Object.toString()" resolve="toString" />
-                                </node>
-                              </node>
-                            </node>
-                          </node>
-                          <node concept="gl6BB" id="13En2FvIP9F" role="1bW2Oz">
-                            <property role="TrG5h" value="it" />
-                            <node concept="2jxLKc" id="13En2FvIP9G" role="1tU5fm" />
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                    <node concept="3uJxvA" id="13En2FvIP9H" role="2OqNvi">
-                      <node concept="Xl_RD" id="13En2FvIP9I" role="3uJOhx">
-                        <property role="Xl_RC" value=", " />
-                      </node>
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3clFbF" id="13En2FvIP9J" role="3cqZAp">
-              <node concept="2OqwBi" id="13En2FvIP9K" role="3clFbG">
-                <node concept="37vLTw" id="13En2FvIP9L" role="2Oq$k0">
-                  <ref role="3cqZAo" node="13En2FvIP9T" resolve="res" />
-                </node>
-                <node concept="TSZUe" id="13En2FvIP9M" role="2OqNvi">
-                  <node concept="37vLTw" id="13En2FvIP9N" role="25WWJ7">
-                    <ref role="3cqZAo" node="13En2FvIP9n" resolve="msg" />
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="3cqZAl" id="13En2FvIP9Y" role="3clF45" />
-      <node concept="37vLTG" id="13En2FvIP9O" role="3clF46">
-        <property role="TrG5h" value="components" />
-        <node concept="_YKpA" id="13En2FvIP9P" role="1tU5fm">
-          <node concept="16syzq" id="13En2FvITo3" role="_ZDj9">
-            <ref role="16sUi3" node="13En2FvIxxl" resolve="Component" />
-          </node>
-        </node>
-      </node>
-      <node concept="37vLTG" id="13En2FvIP9R" role="3clF46">
-        <property role="TrG5h" value="startingComponent" />
-        <node concept="16syzq" id="13En2FvJ0oI" role="1tU5fm">
-          <ref role="16sUi3" node="13En2FvIxxl" resolve="Component" />
-        </node>
-      </node>
-      <node concept="37vLTG" id="13En2FvIP9T" role="3clF46">
-        <property role="TrG5h" value="res" />
-        <node concept="_YKpA" id="13En2FvIP9U" role="1tU5fm">
-          <node concept="17QB3L" id="13En2FvIP9V" role="_ZDj9" />
-        </node>
-      </node>
-      <node concept="3Tm1VV" id="13En2FvIP9Z" role="1B3o_S" />
-    </node>
-    <node concept="2tJIrI" id="13En2FvI8on" role="jymVt" />
-    <node concept="3clFb_" id="13En2FvJE3I" role="jymVt">
-      <property role="TrG5h" value="DFSRecursive" />
-      <node concept="3clFbS" id="13En2FvJE3K" role="3clF47">
-        <node concept="3clFbF" id="13En2FvJE3L" role="3cqZAp">
-          <node concept="2OqwBi" id="13En2FvJE3M" role="3clFbG">
-            <node concept="37vLTw" id="13En2FvJE3N" role="2Oq$k0">
-              <ref role="3cqZAo" node="13En2FvJE4K" resolve="visited" />
-            </node>
-            <node concept="TSZUe" id="13En2FvJE3O" role="2OqNvi">
-              <node concept="37vLTw" id="13En2FvJE3P" role="25WWJ7">
-                <ref role="3cqZAo" node="13En2FvJE4v" resolve="currentComponent" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbF" id="13En2FvJE3Q" role="3cqZAp">
-          <node concept="2OqwBi" id="13En2FvJE3R" role="3clFbG">
-            <node concept="37vLTw" id="13En2FvJE3S" role="2Oq$k0">
-              <ref role="3cqZAo" node="13En2FvJE4N" resolve="path" />
-            </node>
-            <node concept="TSZUe" id="13En2FvJE3T" role="2OqNvi">
-              <node concept="37vLTw" id="13En2FvJE3U" role="25WWJ7">
-                <ref role="3cqZAo" node="13En2FvJE4v" resolve="currentComponent" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="2Gpval" id="13En2FvJE3V" role="3cqZAp">
-          <node concept="2GrKxI" id="13En2FvJE3W" role="2Gsz3X">
-            <property role="TrG5h" value="dependency" />
-          </node>
-          <node concept="3EllGN" id="13En2FvJE3X" role="2GsD0m">
-            <node concept="37vLTw" id="13En2FvJE3Y" role="3ElVtu">
-              <ref role="3cqZAo" node="13En2FvJE4v" resolve="currentComponent" />
-            </node>
-            <node concept="37vLTw" id="13En2FvJE3Z" role="3ElQJh">
-              <ref role="3cqZAo" node="13En2FvJE4x" resolve="directDependencies" />
-            </node>
-          </node>
-          <node concept="3clFbS" id="13En2FvJE40" role="2LFqv$">
-            <node concept="3clFbF" id="13En2FvJE41" role="3cqZAp">
-              <node concept="2Sg_IR" id="13En2FvJE42" role="3clFbG">
-                <node concept="37vLTw" id="13En2FvJE43" role="2SgG2M">
-                  <ref role="3cqZAo" node="13En2FvJE4A" resolve="action" />
-                </node>
-                <node concept="2GrUjf" id="13En2FvJE44" role="2SgHGx">
-                  <ref role="2Gs0qQ" node="13En2FvJE3W" resolve="dependency" />
-                </node>
-                <node concept="2OqwBi" id="13En2FvJE45" role="2SgHGx">
-                  <node concept="3EllGN" id="13En2FvJE46" role="2Oq$k0">
-                    <node concept="2GrUjf" id="13En2FvJE47" role="3ElVtu">
-                      <ref role="2Gs0qQ" node="13En2FvJE3W" resolve="dependency" />
-                    </node>
-                    <node concept="37vLTw" id="13En2FvJE48" role="3ElQJh">
-                      <ref role="3cqZAo" node="13En2FvJE4x" resolve="directDependencies" />
-                    </node>
-                  </node>
-                  <node concept="ANE8D" id="13En2FvJE49" role="2OqNvi" />
-                </node>
-                <node concept="37vLTw" id="13En2FvJE4a" role="2SgHGx">
-                  <ref role="3cqZAo" node="13En2FvJE4K" resolve="visited" />
-                </node>
-                <node concept="37vLTw" id="13En2FvJE4b" role="2SgHGx">
-                  <ref role="3cqZAo" node="13En2FvJE4N" resolve="path" />
-                </node>
-              </node>
-            </node>
-            <node concept="3clFbJ" id="13En2FvJE4c" role="3cqZAp">
-              <node concept="3fqX7Q" id="13En2FvJE4d" role="3clFbw">
-                <node concept="2OqwBi" id="13En2FvJE4e" role="3fr31v">
-                  <node concept="37vLTw" id="13En2FvJE4f" role="2Oq$k0">
-                    <ref role="3cqZAo" node="13En2FvJE4K" resolve="visited" />
-                  </node>
-                  <node concept="3JPx81" id="13En2FvJE4g" role="2OqNvi">
-                    <node concept="2GrUjf" id="13En2FvJE4h" role="25WWJ7">
-                      <ref role="2Gs0qQ" node="13En2FvJE3W" resolve="dependency" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-              <node concept="3clFbS" id="13En2FvJE4i" role="3clFbx">
-                <node concept="3clFbF" id="13En2FvJQ5r" role="3cqZAp">
-                  <node concept="1rXfSq" id="13En2FvJQ5p" role="3clFbG">
-                    <ref role="37wK5l" node="13En2FvJE3I" resolve="DFSRecursive" />
-                    <node concept="2GrUjf" id="13En2FvJU7q" role="37wK5m">
-                      <ref role="2Gs0qQ" node="13En2FvJE3W" resolve="dependency" />
-                    </node>
-                    <node concept="37vLTw" id="13En2FvK2Fx" role="37wK5m">
-                      <ref role="3cqZAo" node="13En2FvJE4x" resolve="directDependencies" />
-                    </node>
-                    <node concept="37vLTw" id="13En2FvKaEE" role="37wK5m">
-                      <ref role="3cqZAo" node="13En2FvJE4A" resolve="action" />
-                    </node>
-                    <node concept="37vLTw" id="13En2FvKeOa" role="37wK5m">
-                      <ref role="3cqZAo" node="13En2FvJE4K" resolve="visited" />
-                    </node>
-                    <node concept="2ShNRf" id="13En2FvKiK9" role="37wK5m">
-                      <node concept="Tc6Ow" id="13En2FvKiKa" role="2ShVmc">
-                        <node concept="16syzq" id="13En2FvL65t" role="HW$YZ">
-                          <ref role="16sUi3" node="13En2FvIxxl" resolve="Component" />
-                        </node>
-                        <node concept="2OqwBi" id="13En2FvKiKc" role="I$8f6">
-                          <node concept="37vLTw" id="13En2FvKiKd" role="2Oq$k0">
-                            <ref role="3cqZAo" node="13En2FvJE4N" resolve="path" />
-                          </node>
-                          <node concept="ANE8D" id="13En2FvKiKe" role="2OqNvi" />
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="3cqZAl" id="13En2FvJE4Q" role="3clF45" />
-      <node concept="37vLTG" id="13En2FvJE4v" role="3clF46">
-        <property role="TrG5h" value="currentComponent" />
-        <node concept="16syzq" id="13En2FvKqxe" role="1tU5fm">
-          <ref role="16sUi3" node="13En2FvIxxl" resolve="Component" />
-        </node>
-      </node>
-      <node concept="37vLTG" id="13En2FvJE4x" role="3clF46">
-        <property role="TrG5h" value="directDependencies" />
-        <node concept="3rvAFt" id="13En2FvJE4y" role="1tU5fm">
-          <node concept="16syzq" id="13En2FvK_Yz" role="3rvQeY">
-            <ref role="16sUi3" node="13En2FvIxxl" resolve="Component" />
-          </node>
-          <node concept="2hMVRd" id="13En2FvJE4$" role="3rvSg0">
-            <node concept="16syzq" id="13En2FvKE4L" role="2hN53Y">
-              <ref role="16sUi3" node="13En2FvIxxl" resolve="Component" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="37vLTG" id="13En2FvJE4A" role="3clF46">
-        <property role="TrG5h" value="action" />
-        <node concept="1ajhzC" id="13En2FvJE4B" role="1tU5fm">
-          <node concept="3cqZAl" id="13En2FvJE4C" role="1ajl9A" />
-          <node concept="16syzq" id="13En2FvKIJC" role="1ajw0F">
-            <ref role="16sUi3" node="13En2FvIxxl" resolve="Component" />
-          </node>
-          <node concept="_YKpA" id="13En2FvJE4E" role="1ajw0F">
-            <node concept="16syzq" id="13En2FvKMzo" role="_ZDj9">
-              <ref role="16sUi3" node="13En2FvIxxl" resolve="Component" />
-            </node>
-          </node>
-          <node concept="2hMVRd" id="13En2FvJE4G" role="1ajw0F">
-            <node concept="16syzq" id="13En2FvKQo9" role="2hN53Y">
-              <ref role="16sUi3" node="13En2FvIxxl" resolve="Component" />
-            </node>
-          </node>
-          <node concept="_YKpA" id="13En2FvJE4I" role="1ajw0F">
-            <node concept="16syzq" id="13En2FvKUet" role="_ZDj9">
-              <ref role="16sUi3" node="13En2FvIxxl" resolve="Component" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="37vLTG" id="13En2FvJE4K" role="3clF46">
-        <property role="TrG5h" value="visited" />
-        <node concept="2hMVRd" id="13En2FvJE4L" role="1tU5fm">
-          <node concept="16syzq" id="13En2FvKY5e" role="2hN53Y">
-            <ref role="16sUi3" node="13En2FvIxxl" resolve="Component" />
-          </node>
-        </node>
-      </node>
-      <node concept="37vLTG" id="13En2FvJE4N" role="3clF46">
-        <property role="TrG5h" value="path" />
-        <node concept="_YKpA" id="13En2FvJE4O" role="1tU5fm">
-          <node concept="16syzq" id="13En2FvL1Y1" role="_ZDj9">
-            <ref role="16sUi3" node="13En2FvIxxl" resolve="Component" />
-          </node>
-        </node>
-      </node>
-    </node>
-    <node concept="2tJIrI" id="13En2FvI8pw" role="jymVt" />
-    <node concept="3clFb_" id="13En2FvLiUk" role="jymVt">
-      <property role="TrG5h" value="DFS" />
-      <node concept="3clFbS" id="13En2FvLiUm" role="3clF47">
-        <node concept="3clFbF" id="13En2FvLiUn" role="3cqZAp">
-          <node concept="1rXfSq" id="13En2FvLiUo" role="3clFbG">
-            <ref role="37wK5l" node="13En2FvJE3I" resolve="DFSRecursive" />
-            <node concept="37vLTw" id="13En2FvLiUp" role="37wK5m">
-              <ref role="3cqZAo" node="13En2FvLiUy" resolve="startNode" />
-            </node>
-            <node concept="37vLTw" id="13En2FvLiUq" role="37wK5m">
-              <ref role="3cqZAo" node="13En2FvLiU$" resolve="directDependencies" />
-            </node>
-            <node concept="37vLTw" id="13En2FvLiUr" role="37wK5m">
-              <ref role="3cqZAo" node="13En2FvLiUD" resolve="action" />
-            </node>
-            <node concept="2ShNRf" id="13En2FvLiUs" role="37wK5m">
-              <node concept="2i4dXS" id="13En2FvLiUt" role="2ShVmc">
-                <node concept="16syzq" id="13En2FvLRux" role="HW$YZ">
-                  <ref role="16sUi3" node="13En2FvIxxl" resolve="Component" />
-                </node>
-              </node>
-            </node>
-            <node concept="2ShNRf" id="13En2FvLiUv" role="37wK5m">
-              <node concept="Tc6Ow" id="13En2FvLiUw" role="2ShVmc">
-                <node concept="16syzq" id="13En2FvLWqc" role="HW$YZ">
-                  <ref role="16sUi3" node="13En2FvIxxl" resolve="Component" />
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="3cqZAl" id="13En2FvLiUN" role="3clF45" />
-      <node concept="37vLTG" id="13En2FvLiUy" role="3clF46">
-        <property role="TrG5h" value="startNode" />
-        <node concept="16syzq" id="13En2FvLrEf" role="1tU5fm">
-          <ref role="16sUi3" node="13En2FvIxxl" resolve="Component" />
-        </node>
-      </node>
-      <node concept="37vLTG" id="13En2FvLiU$" role="3clF46">
-        <property role="TrG5h" value="directDependencies" />
-        <node concept="3rvAFt" id="13En2FvLiU_" role="1tU5fm">
-          <node concept="16syzq" id="13En2FvLv$B" role="3rvQeY">
-            <ref role="16sUi3" node="13En2FvIxxl" resolve="Component" />
-          </node>
-          <node concept="2hMVRd" id="13En2FvLiUB" role="3rvSg0">
-            <node concept="16syzq" id="13En2FvLzN0" role="2hN53Y">
-              <ref role="16sUi3" node="13En2FvIxxl" resolve="Component" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="37vLTG" id="13En2FvLiUD" role="3clF46">
-        <property role="TrG5h" value="action" />
-        <node concept="1ajhzC" id="13En2FvLiUE" role="1tU5fm">
-          <node concept="3cqZAl" id="13En2FvLiUF" role="1ajl9A" />
-          <node concept="16syzq" id="13En2FvLBHz" role="1ajw0F">
-            <ref role="16sUi3" node="13En2FvIxxl" resolve="Component" />
-          </node>
-          <node concept="_YKpA" id="13En2FvLiUH" role="1ajw0F">
-            <node concept="16syzq" id="13En2FvLFCD" role="_ZDj9">
-              <ref role="16sUi3" node="13En2FvIxxl" resolve="Component" />
-            </node>
-          </node>
-          <node concept="2hMVRd" id="13En2FvLiUJ" role="1ajw0F">
-            <node concept="16syzq" id="13En2FvLJ$r" role="2hN53Y">
-              <ref role="16sUi3" node="13En2FvIxxl" resolve="Component" />
-            </node>
-          </node>
-          <node concept="_YKpA" id="13En2FvLiUL" role="1ajw0F">
-            <node concept="16syzq" id="13En2FvLNx_" role="_ZDj9">
-              <ref role="16sUi3" node="13En2FvIxxl" resolve="Component" />
-            </node>
-          </node>
-        </node>
-      </node>
-    </node>
-    <node concept="2tJIrI" id="13En2FvI8q0" role="jymVt" />
-    <node concept="3clFb_" id="13En2FvM0mw" role="jymVt">
-      <property role="TrG5h" value="DFS" />
-      <node concept="3clFbS" id="13En2FvM0my" role="3clF47">
-        <node concept="3cpWs8" id="13En2FvM0mz" role="3cqZAp">
-          <node concept="3cpWsn" id="13En2FvM0m$" role="3cpWs9">
-            <property role="TrG5h" value="directComponentDependencies" />
-            <node concept="3rvAFt" id="13En2FvM0m_" role="1tU5fm">
-              <node concept="16syzq" id="13En2FvU1ae" role="3rvQeY">
-                <ref role="16sUi3" node="13En2FvIxxl" resolve="Component" />
-              </node>
-              <node concept="2hMVRd" id="13En2FvM0mB" role="3rvSg0">
-                <node concept="16syzq" id="13En2FvU62J" role="2hN53Y">
-                  <ref role="16sUi3" node="13En2FvIxxl" resolve="Component" />
-                </node>
-              </node>
-            </node>
-            <node concept="2OqwBi" id="13En2FvTv3O" role="33vP2m">
-              <node concept="37vLTw" id="13En2FvTq5U" role="2Oq$k0">
-                <ref role="3cqZAo" node="13En2FvQ26l" resolve="dependenciesHelper" />
-              </node>
-              <node concept="liA8E" id="13En2FvTzWP" role="2OqNvi">
-                <ref role="37wK5l" node="13En2FvyssI" resolve="computeDirectComponentDependencies" />
-                <node concept="37vLTw" id="13En2FvTEN2" role="37wK5m">
-                  <ref role="3cqZAo" node="13En2FvM0mT" resolve="components" />
-                </node>
-                <node concept="37vLTw" id="13En2FvTKx6" role="37wK5m">
-                  <ref role="3cqZAo" node="13En2FvNhxZ" resolve="option" />
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbF" id="13En2FvM0mG" role="3cqZAp">
-          <node concept="2OqwBi" id="13En2FvM0mH" role="3clFbG">
-            <node concept="37vLTw" id="13En2FvM0mI" role="2Oq$k0">
-              <ref role="3cqZAo" node="13En2FvM0mW" resolve="startingComponents" />
-            </node>
-            <node concept="2es0OD" id="13En2FvM0mJ" role="2OqNvi">
-              <node concept="1bVj0M" id="13En2FvM0mK" role="23t8la">
-                <node concept="3clFbS" id="13En2FvM0mL" role="1bW5cS">
-                  <node concept="3clFbF" id="13En2FvMcNx" role="3cqZAp">
-                    <node concept="1rXfSq" id="13En2FvMcNv" role="3clFbG">
-                      <ref role="37wK5l" node="13En2FvLiUk" resolve="DFS" />
-                      <node concept="37vLTw" id="13En2FvMgZo" role="37wK5m">
-                        <ref role="3cqZAo" node="13En2FvM0mR" resolve="startingMod" />
-                      </node>
-                      <node concept="37vLTw" id="13En2FvMpjR" role="37wK5m">
-                        <ref role="3cqZAo" node="13En2FvM0m$" resolve="directComponentDependencies" />
-                      </node>
-                      <node concept="37vLTw" id="13En2FvMxTX" role="37wK5m">
-                        <ref role="3cqZAo" node="13En2FvM0mZ" resolve="action" />
-                      </node>
-                    </node>
-                  </node>
-                </node>
-                <node concept="gl6BB" id="13En2FvM0mR" role="1bW2Oz">
-                  <property role="TrG5h" value="startingMod" />
-                  <node concept="2jxLKc" id="13En2FvM0mS" role="1tU5fm" />
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="3cqZAl" id="13En2FvM0nb" role="3clF45" />
-      <node concept="37vLTG" id="13En2FvM0mT" role="3clF46">
-        <property role="TrG5h" value="components" />
-        <node concept="_YKpA" id="13En2FvM0mU" role="1tU5fm">
-          <node concept="16syzq" id="13En2FvMIXo" role="_ZDj9">
-            <ref role="16sUi3" node="13En2FvIxxl" resolve="Component" />
-          </node>
-        </node>
-      </node>
-      <node concept="37vLTG" id="13En2FvM0mW" role="3clF46">
-        <property role="TrG5h" value="startingComponents" />
-        <node concept="_YKpA" id="13En2FvM0mX" role="1tU5fm">
-          <node concept="16syzq" id="13En2FvMQRg" role="_ZDj9">
-            <ref role="16sUi3" node="13En2FvIxxl" resolve="Component" />
-          </node>
-        </node>
-      </node>
-      <node concept="37vLTG" id="13En2FvM0mZ" role="3clF46">
-        <property role="TrG5h" value="action" />
-        <node concept="1ajhzC" id="13En2FvM0n0" role="1tU5fm">
-          <node concept="3cqZAl" id="13En2FvM0n1" role="1ajl9A" />
-          <node concept="16syzq" id="13En2FvN1wF" role="1ajw0F">
-            <ref role="16sUi3" node="13En2FvIxxl" resolve="Component" />
-          </node>
-          <node concept="_YKpA" id="13En2FvM0n3" role="1ajw0F">
-            <node concept="16syzq" id="13En2FvN5vO" role="_ZDj9">
-              <ref role="16sUi3" node="13En2FvIxxl" resolve="Component" />
-            </node>
-          </node>
-          <node concept="2hMVRd" id="13En2FvM0n5" role="1ajw0F">
-            <node concept="16syzq" id="13En2FvN9vF" role="2hN53Y">
-              <ref role="16sUi3" node="13En2FvIxxl" resolve="Component" />
-            </node>
-          </node>
-          <node concept="_YKpA" id="13En2FvM0n7" role="1ajw0F">
-            <node concept="16syzq" id="13En2FvNdwW" role="_ZDj9">
-              <ref role="16sUi3" node="13En2FvIxxl" resolve="Component" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="37vLTG" id="13En2FvNhxZ" role="3clF46">
-        <property role="TrG5h" value="option" />
-        <node concept="3uibUv" id="13En2FvNm0m" role="1tU5fm">
-          <ref role="3uigEE" node="13En2FvhV7b" resolve="CyclicGenericDependenciesHelper.Option" />
-        </node>
-      </node>
-    </node>
-    <node concept="2tJIrI" id="13En2FvI8qG" role="jymVt" />
-    <node concept="3clFb_" id="13En2FvNZeg" role="jymVt">
-      <property role="TrG5h" value="findSomeCyclesStartingFrom" />
-      <node concept="3clFbS" id="13En2FvNZei" role="3clF47">
-        <node concept="3cpWs8" id="13En2FvNZej" role="3cqZAp">
-          <node concept="3cpWsn" id="13En2FvNZek" role="3cpWs9">
-            <property role="TrG5h" value="cycles" />
-            <node concept="_YKpA" id="13En2FvNZel" role="1tU5fm">
-              <node concept="_YKpA" id="13En2FvNZem" role="_ZDj9">
-                <node concept="16syzq" id="13En2FvOJBC" role="_ZDj9">
-                  <ref role="16sUi3" node="13En2FvIxxl" resolve="Component" />
-                </node>
-              </node>
-            </node>
-            <node concept="2ShNRf" id="13En2FvNZeo" role="33vP2m">
-              <node concept="Tc6Ow" id="13En2FvNZep" role="2ShVmc">
-                <node concept="_YKpA" id="13En2FvNZeq" role="HW$YZ">
-                  <node concept="16syzq" id="13En2FvONHo" role="_ZDj9">
-                    <ref role="16sUi3" node="13En2FvIxxl" resolve="Component" />
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3cpWs8" id="13En2FvNZes" role="3cqZAp">
-          <node concept="3cpWsn" id="13En2FvNZet" role="3cpWs9">
-            <property role="TrG5h" value="addToCycles" />
-            <node concept="1ajhzC" id="13En2FvNZeu" role="1tU5fm">
-              <node concept="16syzq" id="13En2FvOVYx" role="1ajw0F">
-                <ref role="16sUi3" node="13En2FvIxxl" resolve="Component" />
-              </node>
-              <node concept="_YKpA" id="13En2FvNZew" role="1ajw0F">
-                <node concept="16syzq" id="13En2FvP02v" role="_ZDj9">
-                  <ref role="16sUi3" node="13En2FvIxxl" resolve="Component" />
-                </node>
-              </node>
-              <node concept="2hMVRd" id="13En2FvNZey" role="1ajw0F">
-                <node concept="16syzq" id="13En2FvP46t" role="2hN53Y">
-                  <ref role="16sUi3" node="13En2FvIxxl" resolve="Component" />
-                </node>
-              </node>
-              <node concept="_YKpA" id="13En2FvNZe$" role="1ajw0F">
-                <node concept="16syzq" id="13En2FvP8ar" role="_ZDj9">
-                  <ref role="16sUi3" node="13En2FvIxxl" resolve="Component" />
-                </node>
-              </node>
-              <node concept="3cqZAl" id="13En2FvNZeA" role="1ajl9A" />
-            </node>
-            <node concept="1bVj0M" id="13En2FvNZeB" role="33vP2m">
-              <node concept="37vLTG" id="13En2FvNZeC" role="1bW2Oz">
-                <property role="TrG5h" value="current" />
-                <node concept="16syzq" id="13En2FvPcdv" role="1tU5fm">
-                  <ref role="16sUi3" node="13En2FvIxxl" resolve="Component" />
-                </node>
-              </node>
-              <node concept="37vLTG" id="13En2FvNZeE" role="1bW2Oz">
-                <property role="TrG5h" value="adjacents" />
-                <node concept="_YKpA" id="13En2FvNZeF" role="1tU5fm">
-                  <node concept="16syzq" id="13En2FvPggz" role="_ZDj9">
-                    <ref role="16sUi3" node="13En2FvIxxl" resolve="Component" />
-                  </node>
-                </node>
-              </node>
-              <node concept="37vLTG" id="13En2FvNZeH" role="1bW2Oz">
-                <property role="TrG5h" value="visited" />
-                <node concept="2hMVRd" id="13En2FvNZeI" role="1tU5fm">
-                  <node concept="16syzq" id="13En2FvPkjB" role="2hN53Y">
-                    <ref role="16sUi3" node="13En2FvIxxl" resolve="Component" />
-                  </node>
-                </node>
-              </node>
-              <node concept="37vLTG" id="13En2FvNZeK" role="1bW2Oz">
-                <property role="TrG5h" value="currentPath" />
-                <node concept="_YKpA" id="13En2FvNZeL" role="1tU5fm">
-                  <node concept="16syzq" id="13En2FvPomF" role="_ZDj9">
-                    <ref role="16sUi3" node="13En2FvIxxl" resolve="Component" />
-                  </node>
-                </node>
-              </node>
-              <node concept="3clFbS" id="13En2FvNZeN" role="1bW5cS">
-                <node concept="3clFbJ" id="13En2FvNZeO" role="3cqZAp">
-                  <node concept="1Wc70l" id="13En2FvNZeP" role="3clFbw">
-                    <node concept="3eOSWO" id="13En2FvNZeQ" role="3uHU7B">
-                      <node concept="2OqwBi" id="13En2FvNZeR" role="3uHU7B">
-                        <node concept="37vLTw" id="13En2FvNZeS" role="2Oq$k0">
-                          <ref role="3cqZAo" node="13En2FvNZeK" resolve="currentPath" />
-                        </node>
-                        <node concept="34oBXx" id="13En2FvNZeT" role="2OqNvi" />
-                      </node>
-                      <node concept="3cmrfG" id="13En2FvNZeU" role="3uHU7w">
-                        <property role="3cmrfH" value="1" />
-                      </node>
-                    </node>
-                    <node concept="17R0WA" id="13En2FvNZeV" role="3uHU7w">
-                      <node concept="37vLTw" id="13En2FvNZeW" role="3uHU7w">
-                        <ref role="3cqZAo" node="13En2FvNZeC" resolve="current" />
-                      </node>
-                      <node concept="2OqwBi" id="13En2FvNZeX" role="3uHU7B">
-                        <node concept="37vLTw" id="13En2FvNZeY" role="2Oq$k0">
-                          <ref role="3cqZAo" node="13En2FvNZeK" resolve="currentPath" />
-                        </node>
-                        <node concept="1uHKPH" id="13En2FvNZeZ" role="2OqNvi" />
-                      </node>
-                    </node>
-                  </node>
-                  <node concept="3clFbS" id="13En2FvNZf0" role="3clFbx">
-                    <node concept="3clFbF" id="13En2FvNZf1" role="3cqZAp">
-                      <node concept="2OqwBi" id="13En2FvNZf2" role="3clFbG">
-                        <node concept="37vLTw" id="13En2FvNZf3" role="2Oq$k0">
-                          <ref role="3cqZAo" node="13En2FvNZek" resolve="cycles" />
-                        </node>
-                        <node concept="TSZUe" id="13En2FvNZf4" role="2OqNvi">
-                          <node concept="2OqwBi" id="13En2FvNZf5" role="25WWJ7">
-                            <node concept="2OqwBi" id="13En2FvNZf6" role="2Oq$k0">
-                              <node concept="37vLTw" id="13En2FvNZf7" role="2Oq$k0">
-                                <ref role="3cqZAo" node="13En2FvNZeK" resolve="currentPath" />
-                              </node>
-                              <node concept="3QWeyG" id="13En2FvNZf8" role="2OqNvi">
-                                <node concept="2ShNRf" id="13En2FvNZf9" role="576Qk">
-                                  <node concept="2HTt$P" id="13En2FvNZfa" role="2ShVmc">
-                                    <node concept="16syzq" id="13En2FvPspJ" role="2HTBi0">
-                                      <ref role="16sUi3" node="13En2FvIxxl" resolve="Component" />
-                                    </node>
-                                    <node concept="37vLTw" id="13En2FvNZfc" role="2HTEbv">
-                                      <ref role="3cqZAo" node="13En2FvNZeC" resolve="current" />
-                                    </node>
-                                  </node>
-                                </node>
-                              </node>
-                            </node>
-                            <node concept="ANE8D" id="13En2FvNZfd" role="2OqNvi" />
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbF" id="13En2FvNZfe" role="3cqZAp">
-          <node concept="1rXfSq" id="13En2FvNZff" role="3clFbG">
-            <ref role="37wK5l" node="13En2FvM0mw" resolve="DFS" />
-            <node concept="37vLTw" id="13En2FvNZfg" role="37wK5m">
-              <ref role="3cqZAo" node="13En2FvNZfm" resolve="components" />
-            </node>
-            <node concept="37vLTw" id="13En2FvNZfh" role="37wK5m">
-              <ref role="3cqZAo" node="13En2FvNZfp" resolve="startingComponents" />
-            </node>
-            <node concept="37vLTw" id="13En2FvNZfi" role="37wK5m">
-              <ref role="3cqZAo" node="13En2FvNZet" resolve="addToCycles" />
-            </node>
-            <node concept="37vLTw" id="13En2FvNZfj" role="37wK5m">
-              <ref role="3cqZAo" node="13En2FvOyc3" resolve="option" />
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbF" id="13En2FvNZfk" role="3cqZAp">
-          <node concept="37vLTw" id="13En2FvNZfl" role="3clFbG">
-            <ref role="3cqZAo" node="13En2FvNZek" resolve="cycles" />
-          </node>
-        </node>
-      </node>
-      <node concept="A3Dl8" id="13En2FvNZfv" role="3clF45">
-        <node concept="_YKpA" id="13En2FvNZfw" role="A3Ik2">
-          <node concept="16syzq" id="13En2FvO59F" role="_ZDj9">
-            <ref role="16sUi3" node="13En2FvIxxl" resolve="Component" />
-          </node>
-        </node>
-      </node>
-      <node concept="37vLTG" id="13En2FvNZfm" role="3clF46">
-        <property role="TrG5h" value="components" />
-        <node concept="_YKpA" id="13En2FvNZfn" role="1tU5fm">
-          <node concept="16syzq" id="13En2FvO9bn" role="_ZDj9">
-            <ref role="16sUi3" node="13En2FvIxxl" resolve="Component" />
-          </node>
-        </node>
-      </node>
-      <node concept="37vLTG" id="13En2FvNZfp" role="3clF46">
-        <property role="TrG5h" value="startingComponents" />
-        <node concept="_YKpA" id="13En2FvNZfq" role="1tU5fm">
-          <node concept="16syzq" id="13En2FvOhVv" role="_ZDj9">
-            <ref role="16sUi3" node="13En2FvIxxl" resolve="Component" />
-          </node>
-        </node>
-      </node>
-      <node concept="37vLTG" id="13En2FvOyc3" role="3clF46">
-        <property role="TrG5h" value="option" />
-        <node concept="3uibUv" id="13En2FvOArq" role="1tU5fm">
-          <ref role="3uigEE" node="13En2FvhV7b" resolve="CyclicGenericDependenciesHelper.Option" />
-        </node>
-      </node>
-      <node concept="3Tm1VV" id="13En2FvNZfu" role="1B3o_S" />
-    </node>
-    <node concept="2tJIrI" id="13En2FvI8rY" role="jymVt" />
-    <node concept="16euLQ" id="13En2FvIxxl" role="16eVyc">
-      <property role="TrG5h" value="Component" />
-    </node>
-  </node>
   <node concept="312cEu" id="13En2Fv5upa">
     <property role="TrG5h" value="CyclicGenericDependenciesHelper" />
     <property role="3GE5qa" value="helpers" />
@@ -7867,31 +7076,48 @@
                           </node>
                         </node>
                         <node concept="2OqwBi" id="13En2Fvr$KB" role="3uHU7w">
-                          <node concept="2S7cBI" id="13En2Fvr$KC" role="2OqNvi">
-                            <node concept="1bVj0M" id="13En2Fvr$KD" role="23t8la">
-                              <node concept="3clFbS" id="13En2Fvr$KE" role="1bW5cS">
-                                <node concept="3clFbF" id="13En2Fvr$KF" role="3cqZAp">
-                                  <node concept="2Sg_IR" id="13En2Fvr$KG" role="3clFbG">
-                                    <node concept="37vLTw" id="13En2Fvr$KH" role="2SgG2M">
-                                      <ref role="3cqZAo" node="13En2Fw8U7C" resolve="componentNameResolver" />
-                                    </node>
-                                    <node concept="37vLTw" id="13En2Fvr$KI" role="2SgHGx">
-                                      <ref role="3cqZAo" node="13En2Fvr$KJ" resolve="it" />
+                          <node concept="2OqwBi" id="3OtVAWnYmAp" role="2Oq$k0">
+                            <node concept="2GrUjf" id="13En2Fvr$KM" role="2Oq$k0">
+                              <ref role="2Gs0qQ" node="13En2Fvr$Kh" resolve="crtStronglyConnectedComponent" />
+                            </node>
+                            <node concept="3$u5V9" id="3OtVAWnYwZO" role="2OqNvi">
+                              <node concept="1bVj0M" id="3OtVAWnYwZQ" role="23t8la">
+                                <node concept="3clFbS" id="3OtVAWnYwZR" role="1bW5cS">
+                                  <node concept="3clFbF" id="3OtVAWnYDOm" role="3cqZAp">
+                                    <node concept="2Sg_IR" id="3OtVAWnYMCi" role="3clFbG">
+                                      <node concept="37vLTw" id="3OtVAWnYMCj" role="2SgG2M">
+                                        <ref role="3cqZAo" node="13En2Fw8U7C" resolve="componentNameResolver" />
+                                      </node>
+                                      <node concept="37vLTw" id="3OtVAWnYVlB" role="2SgHGx">
+                                        <ref role="3cqZAo" node="3OtVAWnYwZS" resolve="it" />
+                                      </node>
                                     </node>
                                   </node>
                                 </node>
+                                <node concept="gl6BB" id="3OtVAWnYwZS" role="1bW2Oz">
+                                  <property role="TrG5h" value="it" />
+                                  <node concept="2jxLKc" id="3OtVAWnYwZT" role="1tU5fm" />
+                                </node>
                               </node>
-                              <node concept="gl6BB" id="13En2Fvr$KJ" role="1bW2Oz">
-                                <property role="TrG5h" value="it" />
-                                <node concept="2jxLKc" id="13En2Fvr$KK" role="1tU5fm" />
-                              </node>
-                            </node>
-                            <node concept="1nlBCl" id="13En2Fvr$KL" role="2S7zOq">
-                              <property role="3clFbU" value="true" />
                             </node>
                           </node>
-                          <node concept="2GrUjf" id="13En2Fvr$KM" role="2Oq$k0">
-                            <ref role="2Gs0qQ" node="13En2Fvr$Kh" resolve="crtStronglyConnectedComponent" />
+                          <node concept="2S7cBI" id="3OtVAWnZq2E" role="2OqNvi">
+                            <node concept="1nlBCl" id="3OtVAWnZq2N" role="2S7zOq">
+                              <property role="3clFbU" value="true" />
+                            </node>
+                            <node concept="1bVj0M" id="3OtVAWnZq2H" role="23t8la">
+                              <node concept="3clFbS" id="3OtVAWnZq2I" role="1bW5cS">
+                                <node concept="3clFbF" id="3OtVAWnZyrF" role="3cqZAp">
+                                  <node concept="37vLTw" id="3OtVAWnZyrE" role="3clFbG">
+                                    <ref role="3cqZAo" node="3OtVAWnZq2J" resolve="it" />
+                                  </node>
+                                </node>
+                              </node>
+                              <node concept="gl6BB" id="3OtVAWnZq2J" role="1bW2Oz">
+                                <property role="TrG5h" value="it" />
+                                <node concept="2jxLKc" id="3OtVAWnZq2K" role="1tU5fm" />
+                              </node>
+                            </node>
                           </node>
                         </node>
                       </node>
@@ -9489,6 +8715,777 @@
     </node>
     <node concept="3Tm1VV" id="13En2Fv5uAT" role="1B3o_S" />
     <node concept="16euLQ" id="13En2Fv6yo$" role="16eVyc">
+      <property role="TrG5h" value="Component" />
+    </node>
+  </node>
+  <node concept="312cEu" id="13En2FvI8nj">
+    <property role="3GE5qa" value="helpers" />
+    <property role="TrG5h" value="CyclicComponentDependenciesFromStartingPointHelper" />
+    <node concept="3Tm1VV" id="13En2FvI8nk" role="1B3o_S" />
+    <node concept="312cEg" id="13En2FvQ26l" role="jymVt">
+      <property role="TrG5h" value="dependenciesHelper" />
+      <node concept="3uibUv" id="13En2FvPXiL" role="1tU5fm">
+        <ref role="3uigEE" node="13En2Fv5upa" resolve="CyclicGenericDependenciesHelper" />
+        <node concept="16syzq" id="13En2FvSp0p" role="11_B2D">
+          <ref role="16sUi3" node="13En2FvIxxl" resolve="Component" />
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="13En2FvI8nl" role="jymVt" />
+    <node concept="3clFbW" id="13En2FvQ$NN" role="jymVt">
+      <node concept="3cqZAl" id="13En2FvQ$NO" role="3clF45" />
+      <node concept="3clFbS" id="13En2FvQ$NQ" role="3clF47">
+        <node concept="3clFbF" id="13En2FvRARK" role="3cqZAp">
+          <node concept="37vLTI" id="13En2FvRJo8" role="3clFbG">
+            <node concept="2OqwBi" id="13En2FvRB0U" role="37vLTJ">
+              <node concept="Xjq3P" id="13En2FvRARJ" role="2Oq$k0" />
+              <node concept="2OwXpG" id="13En2FvRF7Z" role="2OqNvi">
+                <ref role="2Oxat5" node="13En2FvQ26l" resolve="dependenciesHelper" />
+              </node>
+            </node>
+            <node concept="37vLTw" id="13En2Fw5E5s" role="37vLTx">
+              <ref role="3cqZAo" node="13En2Fw5uPk" resolve="dependenciesHelper" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="13En2FvQ$NR" role="1B3o_S" />
+      <node concept="37vLTG" id="13En2Fw5uPk" role="3clF46">
+        <property role="TrG5h" value="dependenciesHelper" />
+        <node concept="3uibUv" id="13En2Fw5uPj" role="1tU5fm">
+          <ref role="3uigEE" node="13En2Fv5upa" resolve="CyclicGenericDependenciesHelper" />
+          <node concept="16syzq" id="13En2Fw5yx4" role="11_B2D">
+            <ref role="16sUi3" node="13En2FvIxxl" resolve="Component" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="13En2FvQm9f" role="jymVt" />
+    <node concept="2tJIrI" id="13En2FvPSu_" role="jymVt" />
+    <node concept="3clFb_" id="13En2FvIP8Y" role="jymVt">
+      <property role="TrG5h" value="computeSomeCycles" />
+      <node concept="3clFbS" id="13En2FvIP90" role="3clF47">
+        <node concept="3cpWs8" id="13En2FvIP91" role="3cqZAp">
+          <node concept="3cpWsn" id="13En2FvIP92" role="3cpWs9">
+            <property role="TrG5h" value="startingComponents" />
+            <node concept="_YKpA" id="13En2FvIP93" role="1tU5fm">
+              <node concept="16syzq" id="13En2FvJ7qY" role="_ZDj9">
+                <ref role="16sUi3" node="13En2FvIxxl" resolve="Component" />
+              </node>
+            </node>
+            <node concept="2ShNRf" id="13En2FvIP95" role="33vP2m">
+              <node concept="Tc6Ow" id="13En2FvIP96" role="2ShVmc">
+                <node concept="16syzq" id="13En2FvJm4a" role="HW$YZ">
+                  <ref role="16sUi3" node="13En2FvIxxl" resolve="Component" />
+                </node>
+                <node concept="37vLTw" id="13En2FvIP98" role="HW$Y0">
+                  <ref role="3cqZAo" node="13En2FvIP9R" resolve="startingComponent" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="13En2FvIP99" role="3cqZAp">
+          <node concept="3cpWsn" id="13En2FvIP9a" role="3cpWs9">
+            <property role="TrG5h" value="someCyclesStartingFrom" />
+            <node concept="A3Dl8" id="13En2FvIP9f" role="1tU5fm">
+              <node concept="_YKpA" id="13En2FvIP9g" role="A3Ik2">
+                <node concept="16syzq" id="13En2FvJp__" role="_ZDj9">
+                  <ref role="16sUi3" node="13En2FvIxxl" resolve="Component" />
+                </node>
+              </node>
+            </node>
+            <node concept="1rXfSq" id="13En2FvSz3i" role="33vP2m">
+              <ref role="37wK5l" node="13En2FvNZeg" resolve="findSomeCyclesStartingFrom" />
+              <node concept="37vLTw" id="13En2FvSGXh" role="37wK5m">
+                <ref role="3cqZAo" node="13En2FvIP9O" resolve="components" />
+              </node>
+              <node concept="37vLTw" id="13En2FvST$f" role="37wK5m">
+                <ref role="3cqZAo" node="13En2FvIP92" resolve="startingComponents" />
+              </node>
+              <node concept="2OqwBi" id="13En2FwiIqm" role="37wK5m">
+                <node concept="2OqwBi" id="13En2FwiCoY" role="2Oq$k0">
+                  <node concept="Xjq3P" id="13En2FwiAPT" role="2Oq$k0" />
+                  <node concept="2OwXpG" id="13En2FwiH9d" role="2OqNvi">
+                    <ref role="2Oxat5" node="13En2FvQ26l" resolve="dependenciesHelper" />
+                  </node>
+                </node>
+                <node concept="liA8E" id="13En2FwlY_o" role="2OqNvi">
+                  <ref role="37wK5l" node="13En2FwlozC" resolve="getOption" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="2Gpval" id="13En2FvIP9i" role="3cqZAp">
+          <node concept="2GrKxI" id="13En2FvIP9j" role="2Gsz3X">
+            <property role="TrG5h" value="crtCycle" />
+          </node>
+          <node concept="37vLTw" id="13En2FvIP9k" role="2GsD0m">
+            <ref role="3cqZAo" node="13En2FvIP9a" resolve="someCyclesStartingFrom" />
+          </node>
+          <node concept="3clFbS" id="13En2FvIP9l" role="2LFqv$">
+            <node concept="3cpWs8" id="13En2FvIP9m" role="3cqZAp">
+              <node concept="3cpWsn" id="13En2FvIP9n" role="3cpWs9">
+                <property role="TrG5h" value="msg" />
+                <node concept="17QB3L" id="13En2FvIP9o" role="1tU5fm" />
+                <node concept="3cpWs3" id="13En2FvIP9p" role="33vP2m">
+                  <node concept="3cpWs3" id="13En2FvIP9q" role="3uHU7B">
+                    <node concept="3cpWs3" id="13En2FvIP9r" role="3uHU7B">
+                      <node concept="Xl_RD" id="13En2FvIP9s" role="3uHU7B">
+                        <property role="Xl_RC" value="Cyclic dependency with length " />
+                      </node>
+                      <node concept="2OqwBi" id="13En2FvIP9t" role="3uHU7w">
+                        <node concept="2GrUjf" id="13En2FvIP9u" role="2Oq$k0">
+                          <ref role="2Gs0qQ" node="13En2FvIP9j" resolve="crtCycle" />
+                        </node>
+                        <node concept="34oBXx" id="13En2FvIP9v" role="2OqNvi" />
+                      </node>
+                    </node>
+                    <node concept="Xl_RD" id="13En2FvIP9w" role="3uHU7w">
+                      <property role="Xl_RC" value=" found: " />
+                    </node>
+                  </node>
+                  <node concept="2OqwBi" id="13En2FvIP9x" role="3uHU7w">
+                    <node concept="2OqwBi" id="13En2FvIP9y" role="2Oq$k0">
+                      <node concept="2GrUjf" id="13En2FvIP9z" role="2Oq$k0">
+                        <ref role="2Gs0qQ" node="13En2FvIP9j" resolve="crtCycle" />
+                      </node>
+                      <node concept="3$u5V9" id="13En2FvIP9$" role="2OqNvi">
+                        <node concept="1bVj0M" id="13En2FvIP9_" role="23t8la">
+                          <node concept="3clFbS" id="13En2FvIP9A" role="1bW5cS">
+                            <node concept="3clFbF" id="13En2FvIP9B" role="3cqZAp">
+                              <node concept="2OqwBi" id="13En2FvIP9C" role="3clFbG">
+                                <node concept="37vLTw" id="13En2FvIP9D" role="2Oq$k0">
+                                  <ref role="3cqZAo" node="13En2FvIP9F" resolve="it" />
+                                </node>
+                                <node concept="liA8E" id="13En2FvIP9E" role="2OqNvi">
+                                  <ref role="37wK5l" to="wyt6:~Object.toString()" resolve="toString" />
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                          <node concept="gl6BB" id="13En2FvIP9F" role="1bW2Oz">
+                            <property role="TrG5h" value="it" />
+                            <node concept="2jxLKc" id="13En2FvIP9G" role="1tU5fm" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="3uJxvA" id="13En2FvIP9H" role="2OqNvi">
+                      <node concept="Xl_RD" id="13En2FvIP9I" role="3uJOhx">
+                        <property role="Xl_RC" value=", " />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbF" id="13En2FvIP9J" role="3cqZAp">
+              <node concept="2OqwBi" id="13En2FvIP9K" role="3clFbG">
+                <node concept="37vLTw" id="13En2FvIP9L" role="2Oq$k0">
+                  <ref role="3cqZAo" node="13En2FvIP9T" resolve="res" />
+                </node>
+                <node concept="TSZUe" id="13En2FvIP9M" role="2OqNvi">
+                  <node concept="37vLTw" id="13En2FvIP9N" role="25WWJ7">
+                    <ref role="3cqZAo" node="13En2FvIP9n" resolve="msg" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3cqZAl" id="13En2FvIP9Y" role="3clF45" />
+      <node concept="37vLTG" id="13En2FvIP9O" role="3clF46">
+        <property role="TrG5h" value="components" />
+        <node concept="_YKpA" id="13En2FvIP9P" role="1tU5fm">
+          <node concept="16syzq" id="13En2FvITo3" role="_ZDj9">
+            <ref role="16sUi3" node="13En2FvIxxl" resolve="Component" />
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="13En2FvIP9R" role="3clF46">
+        <property role="TrG5h" value="startingComponent" />
+        <node concept="16syzq" id="13En2FvJ0oI" role="1tU5fm">
+          <ref role="16sUi3" node="13En2FvIxxl" resolve="Component" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="13En2FvIP9T" role="3clF46">
+        <property role="TrG5h" value="res" />
+        <node concept="_YKpA" id="13En2FvIP9U" role="1tU5fm">
+          <node concept="17QB3L" id="13En2FvIP9V" role="_ZDj9" />
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="13En2FvIP9Z" role="1B3o_S" />
+    </node>
+    <node concept="2tJIrI" id="13En2FvI8on" role="jymVt" />
+    <node concept="3clFb_" id="13En2FvJE3I" role="jymVt">
+      <property role="TrG5h" value="DFSRecursive" />
+      <node concept="3clFbS" id="13En2FvJE3K" role="3clF47">
+        <node concept="3clFbF" id="13En2FvJE3L" role="3cqZAp">
+          <node concept="2OqwBi" id="13En2FvJE3M" role="3clFbG">
+            <node concept="37vLTw" id="13En2FvJE3N" role="2Oq$k0">
+              <ref role="3cqZAo" node="13En2FvJE4K" resolve="visited" />
+            </node>
+            <node concept="TSZUe" id="13En2FvJE3O" role="2OqNvi">
+              <node concept="37vLTw" id="13En2FvJE3P" role="25WWJ7">
+                <ref role="3cqZAo" node="13En2FvJE4v" resolve="currentComponent" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="13En2FvJE3Q" role="3cqZAp">
+          <node concept="2OqwBi" id="13En2FvJE3R" role="3clFbG">
+            <node concept="37vLTw" id="13En2FvJE3S" role="2Oq$k0">
+              <ref role="3cqZAo" node="13En2FvJE4N" resolve="path" />
+            </node>
+            <node concept="TSZUe" id="13En2FvJE3T" role="2OqNvi">
+              <node concept="37vLTw" id="13En2FvJE3U" role="25WWJ7">
+                <ref role="3cqZAo" node="13En2FvJE4v" resolve="currentComponent" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="2Gpval" id="13En2FvJE3V" role="3cqZAp">
+          <node concept="2GrKxI" id="13En2FvJE3W" role="2Gsz3X">
+            <property role="TrG5h" value="dependency" />
+          </node>
+          <node concept="3EllGN" id="13En2FvJE3X" role="2GsD0m">
+            <node concept="37vLTw" id="13En2FvJE3Y" role="3ElVtu">
+              <ref role="3cqZAo" node="13En2FvJE4v" resolve="currentComponent" />
+            </node>
+            <node concept="37vLTw" id="13En2FvJE3Z" role="3ElQJh">
+              <ref role="3cqZAo" node="13En2FvJE4x" resolve="directDependencies" />
+            </node>
+          </node>
+          <node concept="3clFbS" id="13En2FvJE40" role="2LFqv$">
+            <node concept="3clFbF" id="13En2FvJE41" role="3cqZAp">
+              <node concept="2Sg_IR" id="13En2FvJE42" role="3clFbG">
+                <node concept="37vLTw" id="13En2FvJE43" role="2SgG2M">
+                  <ref role="3cqZAo" node="13En2FvJE4A" resolve="action" />
+                </node>
+                <node concept="2GrUjf" id="13En2FvJE44" role="2SgHGx">
+                  <ref role="2Gs0qQ" node="13En2FvJE3W" resolve="dependency" />
+                </node>
+                <node concept="2OqwBi" id="13En2FvJE45" role="2SgHGx">
+                  <node concept="3EllGN" id="13En2FvJE46" role="2Oq$k0">
+                    <node concept="2GrUjf" id="13En2FvJE47" role="3ElVtu">
+                      <ref role="2Gs0qQ" node="13En2FvJE3W" resolve="dependency" />
+                    </node>
+                    <node concept="37vLTw" id="13En2FvJE48" role="3ElQJh">
+                      <ref role="3cqZAo" node="13En2FvJE4x" resolve="directDependencies" />
+                    </node>
+                  </node>
+                  <node concept="ANE8D" id="13En2FvJE49" role="2OqNvi" />
+                </node>
+                <node concept="37vLTw" id="13En2FvJE4a" role="2SgHGx">
+                  <ref role="3cqZAo" node="13En2FvJE4K" resolve="visited" />
+                </node>
+                <node concept="37vLTw" id="13En2FvJE4b" role="2SgHGx">
+                  <ref role="3cqZAo" node="13En2FvJE4N" resolve="path" />
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbJ" id="13En2FvJE4c" role="3cqZAp">
+              <node concept="3fqX7Q" id="13En2FvJE4d" role="3clFbw">
+                <node concept="2OqwBi" id="13En2FvJE4e" role="3fr31v">
+                  <node concept="37vLTw" id="13En2FvJE4f" role="2Oq$k0">
+                    <ref role="3cqZAo" node="13En2FvJE4K" resolve="visited" />
+                  </node>
+                  <node concept="3JPx81" id="13En2FvJE4g" role="2OqNvi">
+                    <node concept="2GrUjf" id="13En2FvJE4h" role="25WWJ7">
+                      <ref role="2Gs0qQ" node="13En2FvJE3W" resolve="dependency" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3clFbS" id="13En2FvJE4i" role="3clFbx">
+                <node concept="3clFbF" id="13En2FvJQ5r" role="3cqZAp">
+                  <node concept="1rXfSq" id="13En2FvJQ5p" role="3clFbG">
+                    <ref role="37wK5l" node="13En2FvJE3I" resolve="DFSRecursive" />
+                    <node concept="2GrUjf" id="13En2FvJU7q" role="37wK5m">
+                      <ref role="2Gs0qQ" node="13En2FvJE3W" resolve="dependency" />
+                    </node>
+                    <node concept="37vLTw" id="13En2FvK2Fx" role="37wK5m">
+                      <ref role="3cqZAo" node="13En2FvJE4x" resolve="directDependencies" />
+                    </node>
+                    <node concept="37vLTw" id="13En2FvKaEE" role="37wK5m">
+                      <ref role="3cqZAo" node="13En2FvJE4A" resolve="action" />
+                    </node>
+                    <node concept="37vLTw" id="13En2FvKeOa" role="37wK5m">
+                      <ref role="3cqZAo" node="13En2FvJE4K" resolve="visited" />
+                    </node>
+                    <node concept="2ShNRf" id="13En2FvKiK9" role="37wK5m">
+                      <node concept="Tc6Ow" id="13En2FvKiKa" role="2ShVmc">
+                        <node concept="16syzq" id="13En2FvL65t" role="HW$YZ">
+                          <ref role="16sUi3" node="13En2FvIxxl" resolve="Component" />
+                        </node>
+                        <node concept="2OqwBi" id="13En2FvKiKc" role="I$8f6">
+                          <node concept="37vLTw" id="13En2FvKiKd" role="2Oq$k0">
+                            <ref role="3cqZAo" node="13En2FvJE4N" resolve="path" />
+                          </node>
+                          <node concept="ANE8D" id="13En2FvKiKe" role="2OqNvi" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3cqZAl" id="13En2FvJE4Q" role="3clF45" />
+      <node concept="37vLTG" id="13En2FvJE4v" role="3clF46">
+        <property role="TrG5h" value="currentComponent" />
+        <node concept="16syzq" id="13En2FvKqxe" role="1tU5fm">
+          <ref role="16sUi3" node="13En2FvIxxl" resolve="Component" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="13En2FvJE4x" role="3clF46">
+        <property role="TrG5h" value="directDependencies" />
+        <node concept="3rvAFt" id="13En2FvJE4y" role="1tU5fm">
+          <node concept="16syzq" id="13En2FvK_Yz" role="3rvQeY">
+            <ref role="16sUi3" node="13En2FvIxxl" resolve="Component" />
+          </node>
+          <node concept="2hMVRd" id="13En2FvJE4$" role="3rvSg0">
+            <node concept="16syzq" id="13En2FvKE4L" role="2hN53Y">
+              <ref role="16sUi3" node="13En2FvIxxl" resolve="Component" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="13En2FvJE4A" role="3clF46">
+        <property role="TrG5h" value="action" />
+        <node concept="1ajhzC" id="13En2FvJE4B" role="1tU5fm">
+          <node concept="3cqZAl" id="13En2FvJE4C" role="1ajl9A" />
+          <node concept="16syzq" id="13En2FvKIJC" role="1ajw0F">
+            <ref role="16sUi3" node="13En2FvIxxl" resolve="Component" />
+          </node>
+          <node concept="_YKpA" id="13En2FvJE4E" role="1ajw0F">
+            <node concept="16syzq" id="13En2FvKMzo" role="_ZDj9">
+              <ref role="16sUi3" node="13En2FvIxxl" resolve="Component" />
+            </node>
+          </node>
+          <node concept="2hMVRd" id="13En2FvJE4G" role="1ajw0F">
+            <node concept="16syzq" id="13En2FvKQo9" role="2hN53Y">
+              <ref role="16sUi3" node="13En2FvIxxl" resolve="Component" />
+            </node>
+          </node>
+          <node concept="_YKpA" id="13En2FvJE4I" role="1ajw0F">
+            <node concept="16syzq" id="13En2FvKUet" role="_ZDj9">
+              <ref role="16sUi3" node="13En2FvIxxl" resolve="Component" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="13En2FvJE4K" role="3clF46">
+        <property role="TrG5h" value="visited" />
+        <node concept="2hMVRd" id="13En2FvJE4L" role="1tU5fm">
+          <node concept="16syzq" id="13En2FvKY5e" role="2hN53Y">
+            <ref role="16sUi3" node="13En2FvIxxl" resolve="Component" />
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="13En2FvJE4N" role="3clF46">
+        <property role="TrG5h" value="path" />
+        <node concept="_YKpA" id="13En2FvJE4O" role="1tU5fm">
+          <node concept="16syzq" id="13En2FvL1Y1" role="_ZDj9">
+            <ref role="16sUi3" node="13En2FvIxxl" resolve="Component" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="13En2FvI8pw" role="jymVt" />
+    <node concept="3clFb_" id="13En2FvLiUk" role="jymVt">
+      <property role="TrG5h" value="DFS" />
+      <node concept="3clFbS" id="13En2FvLiUm" role="3clF47">
+        <node concept="3clFbF" id="13En2FvLiUn" role="3cqZAp">
+          <node concept="1rXfSq" id="13En2FvLiUo" role="3clFbG">
+            <ref role="37wK5l" node="13En2FvJE3I" resolve="DFSRecursive" />
+            <node concept="37vLTw" id="13En2FvLiUp" role="37wK5m">
+              <ref role="3cqZAo" node="13En2FvLiUy" resolve="startNode" />
+            </node>
+            <node concept="37vLTw" id="13En2FvLiUq" role="37wK5m">
+              <ref role="3cqZAo" node="13En2FvLiU$" resolve="directDependencies" />
+            </node>
+            <node concept="37vLTw" id="13En2FvLiUr" role="37wK5m">
+              <ref role="3cqZAo" node="13En2FvLiUD" resolve="action" />
+            </node>
+            <node concept="2ShNRf" id="13En2FvLiUs" role="37wK5m">
+              <node concept="2i4dXS" id="13En2FvLiUt" role="2ShVmc">
+                <node concept="16syzq" id="13En2FvLRux" role="HW$YZ">
+                  <ref role="16sUi3" node="13En2FvIxxl" resolve="Component" />
+                </node>
+              </node>
+            </node>
+            <node concept="2ShNRf" id="13En2FvLiUv" role="37wK5m">
+              <node concept="Tc6Ow" id="13En2FvLiUw" role="2ShVmc">
+                <node concept="16syzq" id="13En2FvLWqc" role="HW$YZ">
+                  <ref role="16sUi3" node="13En2FvIxxl" resolve="Component" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3cqZAl" id="13En2FvLiUN" role="3clF45" />
+      <node concept="37vLTG" id="13En2FvLiUy" role="3clF46">
+        <property role="TrG5h" value="startNode" />
+        <node concept="16syzq" id="13En2FvLrEf" role="1tU5fm">
+          <ref role="16sUi3" node="13En2FvIxxl" resolve="Component" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="13En2FvLiU$" role="3clF46">
+        <property role="TrG5h" value="directDependencies" />
+        <node concept="3rvAFt" id="13En2FvLiU_" role="1tU5fm">
+          <node concept="16syzq" id="13En2FvLv$B" role="3rvQeY">
+            <ref role="16sUi3" node="13En2FvIxxl" resolve="Component" />
+          </node>
+          <node concept="2hMVRd" id="13En2FvLiUB" role="3rvSg0">
+            <node concept="16syzq" id="13En2FvLzN0" role="2hN53Y">
+              <ref role="16sUi3" node="13En2FvIxxl" resolve="Component" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="13En2FvLiUD" role="3clF46">
+        <property role="TrG5h" value="action" />
+        <node concept="1ajhzC" id="13En2FvLiUE" role="1tU5fm">
+          <node concept="3cqZAl" id="13En2FvLiUF" role="1ajl9A" />
+          <node concept="16syzq" id="13En2FvLBHz" role="1ajw0F">
+            <ref role="16sUi3" node="13En2FvIxxl" resolve="Component" />
+          </node>
+          <node concept="_YKpA" id="13En2FvLiUH" role="1ajw0F">
+            <node concept="16syzq" id="13En2FvLFCD" role="_ZDj9">
+              <ref role="16sUi3" node="13En2FvIxxl" resolve="Component" />
+            </node>
+          </node>
+          <node concept="2hMVRd" id="13En2FvLiUJ" role="1ajw0F">
+            <node concept="16syzq" id="13En2FvLJ$r" role="2hN53Y">
+              <ref role="16sUi3" node="13En2FvIxxl" resolve="Component" />
+            </node>
+          </node>
+          <node concept="_YKpA" id="13En2FvLiUL" role="1ajw0F">
+            <node concept="16syzq" id="13En2FvLNx_" role="_ZDj9">
+              <ref role="16sUi3" node="13En2FvIxxl" resolve="Component" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="13En2FvI8q0" role="jymVt" />
+    <node concept="3clFb_" id="13En2FvM0mw" role="jymVt">
+      <property role="TrG5h" value="DFS" />
+      <node concept="3clFbS" id="13En2FvM0my" role="3clF47">
+        <node concept="3cpWs8" id="13En2FvM0mz" role="3cqZAp">
+          <node concept="3cpWsn" id="13En2FvM0m$" role="3cpWs9">
+            <property role="TrG5h" value="directComponentDependencies" />
+            <node concept="3rvAFt" id="13En2FvM0m_" role="1tU5fm">
+              <node concept="16syzq" id="13En2FvU1ae" role="3rvQeY">
+                <ref role="16sUi3" node="13En2FvIxxl" resolve="Component" />
+              </node>
+              <node concept="2hMVRd" id="13En2FvM0mB" role="3rvSg0">
+                <node concept="16syzq" id="13En2FvU62J" role="2hN53Y">
+                  <ref role="16sUi3" node="13En2FvIxxl" resolve="Component" />
+                </node>
+              </node>
+            </node>
+            <node concept="2OqwBi" id="13En2FvTv3O" role="33vP2m">
+              <node concept="37vLTw" id="13En2FvTq5U" role="2Oq$k0">
+                <ref role="3cqZAo" node="13En2FvQ26l" resolve="dependenciesHelper" />
+              </node>
+              <node concept="liA8E" id="13En2FvTzWP" role="2OqNvi">
+                <ref role="37wK5l" node="13En2FvyssI" resolve="computeDirectComponentDependencies" />
+                <node concept="37vLTw" id="13En2FvTEN2" role="37wK5m">
+                  <ref role="3cqZAo" node="13En2FvM0mT" resolve="components" />
+                </node>
+                <node concept="37vLTw" id="13En2FvTKx6" role="37wK5m">
+                  <ref role="3cqZAo" node="13En2FvNhxZ" resolve="option" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="13En2FvM0mG" role="3cqZAp">
+          <node concept="2OqwBi" id="13En2FvM0mH" role="3clFbG">
+            <node concept="37vLTw" id="13En2FvM0mI" role="2Oq$k0">
+              <ref role="3cqZAo" node="13En2FvM0mW" resolve="startingComponents" />
+            </node>
+            <node concept="2es0OD" id="13En2FvM0mJ" role="2OqNvi">
+              <node concept="1bVj0M" id="13En2FvM0mK" role="23t8la">
+                <node concept="3clFbS" id="13En2FvM0mL" role="1bW5cS">
+                  <node concept="3clFbF" id="13En2FvMcNx" role="3cqZAp">
+                    <node concept="1rXfSq" id="13En2FvMcNv" role="3clFbG">
+                      <ref role="37wK5l" node="13En2FvLiUk" resolve="DFS" />
+                      <node concept="37vLTw" id="13En2FvMgZo" role="37wK5m">
+                        <ref role="3cqZAo" node="13En2FvM0mR" resolve="startingMod" />
+                      </node>
+                      <node concept="37vLTw" id="13En2FvMpjR" role="37wK5m">
+                        <ref role="3cqZAo" node="13En2FvM0m$" resolve="directComponentDependencies" />
+                      </node>
+                      <node concept="37vLTw" id="13En2FvMxTX" role="37wK5m">
+                        <ref role="3cqZAo" node="13En2FvM0mZ" resolve="action" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="gl6BB" id="13En2FvM0mR" role="1bW2Oz">
+                  <property role="TrG5h" value="startingMod" />
+                  <node concept="2jxLKc" id="13En2FvM0mS" role="1tU5fm" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3cqZAl" id="13En2FvM0nb" role="3clF45" />
+      <node concept="37vLTG" id="13En2FvM0mT" role="3clF46">
+        <property role="TrG5h" value="components" />
+        <node concept="_YKpA" id="13En2FvM0mU" role="1tU5fm">
+          <node concept="16syzq" id="13En2FvMIXo" role="_ZDj9">
+            <ref role="16sUi3" node="13En2FvIxxl" resolve="Component" />
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="13En2FvM0mW" role="3clF46">
+        <property role="TrG5h" value="startingComponents" />
+        <node concept="_YKpA" id="13En2FvM0mX" role="1tU5fm">
+          <node concept="16syzq" id="13En2FvMQRg" role="_ZDj9">
+            <ref role="16sUi3" node="13En2FvIxxl" resolve="Component" />
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="13En2FvM0mZ" role="3clF46">
+        <property role="TrG5h" value="action" />
+        <node concept="1ajhzC" id="13En2FvM0n0" role="1tU5fm">
+          <node concept="3cqZAl" id="13En2FvM0n1" role="1ajl9A" />
+          <node concept="16syzq" id="13En2FvN1wF" role="1ajw0F">
+            <ref role="16sUi3" node="13En2FvIxxl" resolve="Component" />
+          </node>
+          <node concept="_YKpA" id="13En2FvM0n3" role="1ajw0F">
+            <node concept="16syzq" id="13En2FvN5vO" role="_ZDj9">
+              <ref role="16sUi3" node="13En2FvIxxl" resolve="Component" />
+            </node>
+          </node>
+          <node concept="2hMVRd" id="13En2FvM0n5" role="1ajw0F">
+            <node concept="16syzq" id="13En2FvN9vF" role="2hN53Y">
+              <ref role="16sUi3" node="13En2FvIxxl" resolve="Component" />
+            </node>
+          </node>
+          <node concept="_YKpA" id="13En2FvM0n7" role="1ajw0F">
+            <node concept="16syzq" id="13En2FvNdwW" role="_ZDj9">
+              <ref role="16sUi3" node="13En2FvIxxl" resolve="Component" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="13En2FvNhxZ" role="3clF46">
+        <property role="TrG5h" value="option" />
+        <node concept="3uibUv" id="13En2FvNm0m" role="1tU5fm">
+          <ref role="3uigEE" node="13En2FvhV7b" resolve="CyclicGenericDependenciesHelper.Option" />
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="13En2FvI8qG" role="jymVt" />
+    <node concept="3clFb_" id="13En2FvNZeg" role="jymVt">
+      <property role="TrG5h" value="findSomeCyclesStartingFrom" />
+      <node concept="3clFbS" id="13En2FvNZei" role="3clF47">
+        <node concept="3cpWs8" id="13En2FvNZej" role="3cqZAp">
+          <node concept="3cpWsn" id="13En2FvNZek" role="3cpWs9">
+            <property role="TrG5h" value="cycles" />
+            <node concept="_YKpA" id="13En2FvNZel" role="1tU5fm">
+              <node concept="_YKpA" id="13En2FvNZem" role="_ZDj9">
+                <node concept="16syzq" id="13En2FvOJBC" role="_ZDj9">
+                  <ref role="16sUi3" node="13En2FvIxxl" resolve="Component" />
+                </node>
+              </node>
+            </node>
+            <node concept="2ShNRf" id="13En2FvNZeo" role="33vP2m">
+              <node concept="Tc6Ow" id="13En2FvNZep" role="2ShVmc">
+                <node concept="_YKpA" id="13En2FvNZeq" role="HW$YZ">
+                  <node concept="16syzq" id="13En2FvONHo" role="_ZDj9">
+                    <ref role="16sUi3" node="13En2FvIxxl" resolve="Component" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="13En2FvNZes" role="3cqZAp">
+          <node concept="3cpWsn" id="13En2FvNZet" role="3cpWs9">
+            <property role="TrG5h" value="addToCycles" />
+            <node concept="1ajhzC" id="13En2FvNZeu" role="1tU5fm">
+              <node concept="16syzq" id="13En2FvOVYx" role="1ajw0F">
+                <ref role="16sUi3" node="13En2FvIxxl" resolve="Component" />
+              </node>
+              <node concept="_YKpA" id="13En2FvNZew" role="1ajw0F">
+                <node concept="16syzq" id="13En2FvP02v" role="_ZDj9">
+                  <ref role="16sUi3" node="13En2FvIxxl" resolve="Component" />
+                </node>
+              </node>
+              <node concept="2hMVRd" id="13En2FvNZey" role="1ajw0F">
+                <node concept="16syzq" id="13En2FvP46t" role="2hN53Y">
+                  <ref role="16sUi3" node="13En2FvIxxl" resolve="Component" />
+                </node>
+              </node>
+              <node concept="_YKpA" id="13En2FvNZe$" role="1ajw0F">
+                <node concept="16syzq" id="13En2FvP8ar" role="_ZDj9">
+                  <ref role="16sUi3" node="13En2FvIxxl" resolve="Component" />
+                </node>
+              </node>
+              <node concept="3cqZAl" id="13En2FvNZeA" role="1ajl9A" />
+            </node>
+            <node concept="1bVj0M" id="13En2FvNZeB" role="33vP2m">
+              <node concept="37vLTG" id="13En2FvNZeC" role="1bW2Oz">
+                <property role="TrG5h" value="current" />
+                <node concept="16syzq" id="13En2FvPcdv" role="1tU5fm">
+                  <ref role="16sUi3" node="13En2FvIxxl" resolve="Component" />
+                </node>
+              </node>
+              <node concept="37vLTG" id="13En2FvNZeE" role="1bW2Oz">
+                <property role="TrG5h" value="adjacents" />
+                <node concept="_YKpA" id="13En2FvNZeF" role="1tU5fm">
+                  <node concept="16syzq" id="13En2FvPggz" role="_ZDj9">
+                    <ref role="16sUi3" node="13En2FvIxxl" resolve="Component" />
+                  </node>
+                </node>
+              </node>
+              <node concept="37vLTG" id="13En2FvNZeH" role="1bW2Oz">
+                <property role="TrG5h" value="visited" />
+                <node concept="2hMVRd" id="13En2FvNZeI" role="1tU5fm">
+                  <node concept="16syzq" id="13En2FvPkjB" role="2hN53Y">
+                    <ref role="16sUi3" node="13En2FvIxxl" resolve="Component" />
+                  </node>
+                </node>
+              </node>
+              <node concept="37vLTG" id="13En2FvNZeK" role="1bW2Oz">
+                <property role="TrG5h" value="currentPath" />
+                <node concept="_YKpA" id="13En2FvNZeL" role="1tU5fm">
+                  <node concept="16syzq" id="13En2FvPomF" role="_ZDj9">
+                    <ref role="16sUi3" node="13En2FvIxxl" resolve="Component" />
+                  </node>
+                </node>
+              </node>
+              <node concept="3clFbS" id="13En2FvNZeN" role="1bW5cS">
+                <node concept="3clFbJ" id="13En2FvNZeO" role="3cqZAp">
+                  <node concept="1Wc70l" id="13En2FvNZeP" role="3clFbw">
+                    <node concept="3eOSWO" id="13En2FvNZeQ" role="3uHU7B">
+                      <node concept="2OqwBi" id="13En2FvNZeR" role="3uHU7B">
+                        <node concept="37vLTw" id="13En2FvNZeS" role="2Oq$k0">
+                          <ref role="3cqZAo" node="13En2FvNZeK" resolve="currentPath" />
+                        </node>
+                        <node concept="34oBXx" id="13En2FvNZeT" role="2OqNvi" />
+                      </node>
+                      <node concept="3cmrfG" id="13En2FvNZeU" role="3uHU7w">
+                        <property role="3cmrfH" value="1" />
+                      </node>
+                    </node>
+                    <node concept="17R0WA" id="13En2FvNZeV" role="3uHU7w">
+                      <node concept="37vLTw" id="13En2FvNZeW" role="3uHU7w">
+                        <ref role="3cqZAo" node="13En2FvNZeC" resolve="current" />
+                      </node>
+                      <node concept="2OqwBi" id="13En2FvNZeX" role="3uHU7B">
+                        <node concept="37vLTw" id="13En2FvNZeY" role="2Oq$k0">
+                          <ref role="3cqZAo" node="13En2FvNZeK" resolve="currentPath" />
+                        </node>
+                        <node concept="1uHKPH" id="13En2FvNZeZ" role="2OqNvi" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3clFbS" id="13En2FvNZf0" role="3clFbx">
+                    <node concept="3clFbF" id="13En2FvNZf1" role="3cqZAp">
+                      <node concept="2OqwBi" id="13En2FvNZf2" role="3clFbG">
+                        <node concept="37vLTw" id="13En2FvNZf3" role="2Oq$k0">
+                          <ref role="3cqZAo" node="13En2FvNZek" resolve="cycles" />
+                        </node>
+                        <node concept="TSZUe" id="13En2FvNZf4" role="2OqNvi">
+                          <node concept="2OqwBi" id="13En2FvNZf5" role="25WWJ7">
+                            <node concept="2OqwBi" id="13En2FvNZf6" role="2Oq$k0">
+                              <node concept="37vLTw" id="13En2FvNZf7" role="2Oq$k0">
+                                <ref role="3cqZAo" node="13En2FvNZeK" resolve="currentPath" />
+                              </node>
+                              <node concept="3QWeyG" id="13En2FvNZf8" role="2OqNvi">
+                                <node concept="2ShNRf" id="13En2FvNZf9" role="576Qk">
+                                  <node concept="2HTt$P" id="13En2FvNZfa" role="2ShVmc">
+                                    <node concept="16syzq" id="13En2FvPspJ" role="2HTBi0">
+                                      <ref role="16sUi3" node="13En2FvIxxl" resolve="Component" />
+                                    </node>
+                                    <node concept="37vLTw" id="13En2FvNZfc" role="2HTEbv">
+                                      <ref role="3cqZAo" node="13En2FvNZeC" resolve="current" />
+                                    </node>
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                            <node concept="ANE8D" id="13En2FvNZfd" role="2OqNvi" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="13En2FvNZfe" role="3cqZAp">
+          <node concept="1rXfSq" id="13En2FvNZff" role="3clFbG">
+            <ref role="37wK5l" node="13En2FvM0mw" resolve="DFS" />
+            <node concept="37vLTw" id="13En2FvNZfg" role="37wK5m">
+              <ref role="3cqZAo" node="13En2FvNZfm" resolve="components" />
+            </node>
+            <node concept="37vLTw" id="13En2FvNZfh" role="37wK5m">
+              <ref role="3cqZAo" node="13En2FvNZfp" resolve="startingComponents" />
+            </node>
+            <node concept="37vLTw" id="13En2FvNZfi" role="37wK5m">
+              <ref role="3cqZAo" node="13En2FvNZet" resolve="addToCycles" />
+            </node>
+            <node concept="37vLTw" id="13En2FvNZfj" role="37wK5m">
+              <ref role="3cqZAo" node="13En2FvOyc3" resolve="option" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="13En2FvNZfk" role="3cqZAp">
+          <node concept="37vLTw" id="13En2FvNZfl" role="3clFbG">
+            <ref role="3cqZAo" node="13En2FvNZek" resolve="cycles" />
+          </node>
+        </node>
+      </node>
+      <node concept="A3Dl8" id="13En2FvNZfv" role="3clF45">
+        <node concept="_YKpA" id="13En2FvNZfw" role="A3Ik2">
+          <node concept="16syzq" id="13En2FvO59F" role="_ZDj9">
+            <ref role="16sUi3" node="13En2FvIxxl" resolve="Component" />
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="13En2FvNZfm" role="3clF46">
+        <property role="TrG5h" value="components" />
+        <node concept="_YKpA" id="13En2FvNZfn" role="1tU5fm">
+          <node concept="16syzq" id="13En2FvO9bn" role="_ZDj9">
+            <ref role="16sUi3" node="13En2FvIxxl" resolve="Component" />
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="13En2FvNZfp" role="3clF46">
+        <property role="TrG5h" value="startingComponents" />
+        <node concept="_YKpA" id="13En2FvNZfq" role="1tU5fm">
+          <node concept="16syzq" id="13En2FvOhVv" role="_ZDj9">
+            <ref role="16sUi3" node="13En2FvIxxl" resolve="Component" />
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="13En2FvOyc3" role="3clF46">
+        <property role="TrG5h" value="option" />
+        <node concept="3uibUv" id="13En2FvOArq" role="1tU5fm">
+          <ref role="3uigEE" node="13En2FvhV7b" resolve="CyclicGenericDependenciesHelper.Option" />
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="13En2FvNZfu" role="1B3o_S" />
+    </node>
+    <node concept="2tJIrI" id="13En2FvI8rY" role="jymVt" />
+    <node concept="16euLQ" id="13En2FvIxxl" role="16eVyc">
       <property role="TrG5h" value="Component" />
     </node>
   </node>

--- a/code/languages/org.mpsqa.lint/solutions/org.mpsqa.lint.generic.linters_library/models/org.mpsqa.lint.generic.linters_library.modules.mps
+++ b/code/languages/org.mpsqa.lint/solutions/org.mpsqa.lint.generic.linters_library/models/org.mpsqa.lint.generic.linters_library.modules.mps
@@ -39,80 +39,80 @@
   </imports>
   <registry>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
-      <concept id="1080223426719" name="jetbrains.mps.baseLanguage.structure.OrExpression" flags="ng" index="22lmx$" />
-      <concept id="1082485599095" name="jetbrains.mps.baseLanguage.structure.BlockStatement" flags="ng" index="9aQIb">
+      <concept id="1080223426719" name="jetbrains.mps.baseLanguage.structure.OrExpression" flags="nn" index="22lmx$" />
+      <concept id="1082485599095" name="jetbrains.mps.baseLanguage.structure.BlockStatement" flags="nn" index="9aQIb">
         <child id="1082485599096" name="statements" index="9aQI4" />
       </concept>
-      <concept id="1215693861676" name="jetbrains.mps.baseLanguage.structure.BaseAssignmentExpression" flags="ng" index="d038R">
+      <concept id="1215693861676" name="jetbrains.mps.baseLanguage.structure.BaseAssignmentExpression" flags="nn" index="d038R">
         <child id="1068498886297" name="rValue" index="37vLTx" />
         <child id="1068498886295" name="lValue" index="37vLTJ" />
       </concept>
-      <concept id="1215695189714" name="jetbrains.mps.baseLanguage.structure.PlusAssignmentExpression" flags="ng" index="d57v9" />
-      <concept id="4836112446988635817" name="jetbrains.mps.baseLanguage.structure.UndefinedType" flags="ig" index="2jxLKc" />
-      <concept id="1202948039474" name="jetbrains.mps.baseLanguage.structure.InstanceMethodCallOperation" flags="ng" index="liA8E" />
+      <concept id="1215695189714" name="jetbrains.mps.baseLanguage.structure.PlusAssignmentExpression" flags="nn" index="d57v9" />
+      <concept id="4836112446988635817" name="jetbrains.mps.baseLanguage.structure.UndefinedType" flags="in" index="2jxLKc" />
+      <concept id="1202948039474" name="jetbrains.mps.baseLanguage.structure.InstanceMethodCallOperation" flags="nn" index="liA8E" />
       <concept id="8118189177080264853" name="jetbrains.mps.baseLanguage.structure.AlternativeType" flags="ig" index="nSUau">
         <child id="8118189177080264854" name="alternative" index="nSUat" />
       </concept>
-      <concept id="1465982738277781862" name="jetbrains.mps.baseLanguage.structure.PlaceholderMember" flags="ng" index="2tJIrI" />
-      <concept id="1076505808687" name="jetbrains.mps.baseLanguage.structure.WhileStatement" flags="ng" index="2$JKZl">
+      <concept id="1465982738277781862" name="jetbrains.mps.baseLanguage.structure.PlaceholderMember" flags="nn" index="2tJIrI" />
+      <concept id="1076505808687" name="jetbrains.mps.baseLanguage.structure.WhileStatement" flags="nn" index="2$JKZl">
         <child id="1076505808688" name="condition" index="2$JKZa" />
       </concept>
-      <concept id="1239714755177" name="jetbrains.mps.baseLanguage.structure.AbstractUnaryNumberOperation" flags="ng" index="2$Kvd9">
+      <concept id="1239714755177" name="jetbrains.mps.baseLanguage.structure.AbstractUnaryNumberOperation" flags="nn" index="2$Kvd9">
         <child id="1239714902950" name="expression" index="2$L3a6" />
       </concept>
-      <concept id="1188207840427" name="jetbrains.mps.baseLanguage.structure.AnnotationInstance" flags="ng" index="2AHcQZ">
+      <concept id="1188207840427" name="jetbrains.mps.baseLanguage.structure.AnnotationInstance" flags="nn" index="2AHcQZ">
         <reference id="1188208074048" name="annotation" index="2AI5Lk" />
       </concept>
       <concept id="1188208481402" name="jetbrains.mps.baseLanguage.structure.HasAnnotation" flags="ngI" index="2AJDlI">
         <child id="1188208488637" name="annotation" index="2AJF6D" />
       </concept>
-      <concept id="2820489544401957797" name="jetbrains.mps.baseLanguage.structure.DefaultClassCreator" flags="ng" index="HV5vD">
+      <concept id="2820489544401957797" name="jetbrains.mps.baseLanguage.structure.DefaultClassCreator" flags="nn" index="HV5vD">
         <reference id="2820489544401957798" name="classifier" index="HV5vE" />
       </concept>
-      <concept id="1154032098014" name="jetbrains.mps.baseLanguage.structure.AbstractLoopStatement" flags="ng" index="2LF5Ji">
+      <concept id="1154032098014" name="jetbrains.mps.baseLanguage.structure.AbstractLoopStatement" flags="nn" index="2LF5Ji">
         <child id="1154032183016" name="body" index="2LFqv$" />
       </concept>
-      <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="ng" index="2OqwBi">
+      <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
         <child id="1197027771414" name="operand" index="2Oq$k0" />
         <child id="1197027833540" name="operation" index="2OqNvi" />
       </concept>
-      <concept id="1197029447546" name="jetbrains.mps.baseLanguage.structure.FieldReferenceOperation" flags="ng" index="2OwXpG">
+      <concept id="1197029447546" name="jetbrains.mps.baseLanguage.structure.FieldReferenceOperation" flags="nn" index="2OwXpG">
         <reference id="1197029500499" name="fieldDeclaration" index="2Oxat5" />
       </concept>
-      <concept id="1083260308424" name="jetbrains.mps.baseLanguage.structure.EnumConstantReference" flags="ng" index="Rm8GO">
+      <concept id="1083260308424" name="jetbrains.mps.baseLanguage.structure.EnumConstantReference" flags="nn" index="Rm8GO">
         <reference id="1083260308426" name="enumConstantDeclaration" index="Rm8GQ" />
         <reference id="1144432896254" name="enumClass" index="1Px2BO" />
       </concept>
-      <concept id="1145552977093" name="jetbrains.mps.baseLanguage.structure.GenericNewExpression" flags="ng" index="2ShNRf">
+      <concept id="1145552977093" name="jetbrains.mps.baseLanguage.structure.GenericNewExpression" flags="nn" index="2ShNRf">
         <child id="1145553007750" name="creator" index="2ShVmc" />
       </concept>
-      <concept id="1137021947720" name="jetbrains.mps.baseLanguage.structure.ConceptFunction" flags="ig" index="2VMwT0">
+      <concept id="1137021947720" name="jetbrains.mps.baseLanguage.structure.ConceptFunction" flags="in" index="2VMwT0">
         <child id="1137022507850" name="body" index="2VODD2" />
       </concept>
       <concept id="1070462154015" name="jetbrains.mps.baseLanguage.structure.StaticFieldDeclaration" flags="ig" index="Wx3nA" />
-      <concept id="1070475354124" name="jetbrains.mps.baseLanguage.structure.ThisExpression" flags="ng" index="Xjq3P" />
-      <concept id="1070475926800" name="jetbrains.mps.baseLanguage.structure.StringLiteral" flags="ng" index="Xl_RD">
+      <concept id="1070475354124" name="jetbrains.mps.baseLanguage.structure.ThisExpression" flags="nn" index="Xjq3P" />
+      <concept id="1070475926800" name="jetbrains.mps.baseLanguage.structure.StringLiteral" flags="nn" index="Xl_RD">
         <property id="1070475926801" name="value" index="Xl_RC" />
       </concept>
       <concept id="4952749571008284462" name="jetbrains.mps.baseLanguage.structure.CatchVariable" flags="ng" index="XOnhg" />
-      <concept id="1182160077978" name="jetbrains.mps.baseLanguage.structure.AnonymousClassCreator" flags="ng" index="YeOm9">
+      <concept id="1182160077978" name="jetbrains.mps.baseLanguage.structure.AnonymousClassCreator" flags="nn" index="YeOm9">
         <child id="1182160096073" name="cls" index="YeSDq" />
       </concept>
       <concept id="1081236700938" name="jetbrains.mps.baseLanguage.structure.StaticMethodDeclaration" flags="ig" index="2YIFZL" />
-      <concept id="1081236700937" name="jetbrains.mps.baseLanguage.structure.StaticMethodCall" flags="ng" index="2YIFZM">
+      <concept id="1081236700937" name="jetbrains.mps.baseLanguage.structure.StaticMethodCall" flags="nn" index="2YIFZM">
         <reference id="1144433194310" name="classConcept" index="1Pybhc" />
       </concept>
-      <concept id="1081256982272" name="jetbrains.mps.baseLanguage.structure.InstanceOfExpression" flags="ng" index="2ZW3vV">
+      <concept id="1081256982272" name="jetbrains.mps.baseLanguage.structure.InstanceOfExpression" flags="nn" index="2ZW3vV">
         <child id="1081256993305" name="classType" index="2ZW6by" />
         <child id="1081256993304" name="leftExpression" index="2ZW6bz" />
       </concept>
-      <concept id="1070533707846" name="jetbrains.mps.baseLanguage.structure.StaticFieldReference" flags="ng" index="10M0yZ">
+      <concept id="1070533707846" name="jetbrains.mps.baseLanguage.structure.StaticFieldReference" flags="nn" index="10M0yZ">
         <reference id="1144433057691" name="classifier" index="1PxDUh" />
       </concept>
-      <concept id="1070534058343" name="jetbrains.mps.baseLanguage.structure.NullLiteral" flags="ng" index="10Nm6u" />
-      <concept id="1070534370425" name="jetbrains.mps.baseLanguage.structure.IntegerType" flags="ig" index="10Oyi0" />
-      <concept id="1070534644030" name="jetbrains.mps.baseLanguage.structure.BooleanType" flags="ig" index="10P_77" />
-      <concept id="1070534934090" name="jetbrains.mps.baseLanguage.structure.CastExpression" flags="ng" index="10QFUN">
+      <concept id="1070534058343" name="jetbrains.mps.baseLanguage.structure.NullLiteral" flags="nn" index="10Nm6u" />
+      <concept id="1070534370425" name="jetbrains.mps.baseLanguage.structure.IntegerType" flags="in" index="10Oyi0" />
+      <concept id="1070534644030" name="jetbrains.mps.baseLanguage.structure.BooleanType" flags="in" index="10P_77" />
+      <concept id="1070534934090" name="jetbrains.mps.baseLanguage.structure.CastExpression" flags="nn" index="10QFUN">
         <child id="1070534934091" name="type" index="10QFUM" />
         <child id="1070534934092" name="expression" index="10QFUP" />
       </concept>
@@ -129,16 +129,16 @@
       <concept id="1109279851642" name="jetbrains.mps.baseLanguage.structure.GenericDeclaration" flags="ng" index="16eOlS">
         <child id="1109279881614" name="typeVariableDeclaration" index="16eVyc" />
       </concept>
-      <concept id="1109283449304" name="jetbrains.mps.baseLanguage.structure.TypeVariableReference" flags="ig" index="16syzq">
+      <concept id="1109283449304" name="jetbrains.mps.baseLanguage.structure.TypeVariableReference" flags="in" index="16syzq">
         <reference id="1109283546497" name="typeVariableDeclaration" index="16sUi3" />
       </concept>
-      <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="ng" index="37vLTw">
+      <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
         <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
       </concept>
       <concept id="1068498886292" name="jetbrains.mps.baseLanguage.structure.ParameterDeclaration" flags="ir" index="37vLTG" />
-      <concept id="1068498886294" name="jetbrains.mps.baseLanguage.structure.AssignmentExpression" flags="ng" index="37vLTI" />
-      <concept id="1225271177708" name="jetbrains.mps.baseLanguage.structure.StringType" flags="ig" index="17QB3L" />
-      <concept id="1225271283259" name="jetbrains.mps.baseLanguage.structure.NPEEqualsExpression" flags="ng" index="17R0WA" />
+      <concept id="1068498886294" name="jetbrains.mps.baseLanguage.structure.AssignmentExpression" flags="nn" index="37vLTI" />
+      <concept id="1225271177708" name="jetbrains.mps.baseLanguage.structure.StringType" flags="in" index="17QB3L" />
+      <concept id="1225271283259" name="jetbrains.mps.baseLanguage.structure.NPEEqualsExpression" flags="nn" index="17R0WA" />
       <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
         <child id="5680397130376446158" name="type" index="1tU5fm" />
       </concept>
@@ -149,110 +149,110 @@
         <child id="1068580123135" name="body" index="3clF47" />
       </concept>
       <concept id="1068580123165" name="jetbrains.mps.baseLanguage.structure.InstanceMethodDeclaration" flags="ig" index="3clFb_" />
-      <concept id="1068580123152" name="jetbrains.mps.baseLanguage.structure.EqualsExpression" flags="ng" index="3clFbC" />
-      <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="ng" index="3clFbF">
+      <concept id="1068580123152" name="jetbrains.mps.baseLanguage.structure.EqualsExpression" flags="nn" index="3clFbC" />
+      <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
         <child id="1068580123156" name="expression" index="3clFbG" />
       </concept>
-      <concept id="1068580123157" name="jetbrains.mps.baseLanguage.structure.Statement" flags="ng" index="3clFbH" />
-      <concept id="1068580123159" name="jetbrains.mps.baseLanguage.structure.IfStatement" flags="ng" index="3clFbJ">
+      <concept id="1068580123157" name="jetbrains.mps.baseLanguage.structure.Statement" flags="nn" index="3clFbH" />
+      <concept id="1068580123159" name="jetbrains.mps.baseLanguage.structure.IfStatement" flags="nn" index="3clFbJ">
         <child id="1082485599094" name="ifFalseStatement" index="9aQIa" />
         <child id="1068580123160" name="condition" index="3clFbw" />
         <child id="1068580123161" name="ifTrue" index="3clFbx" />
       </concept>
-      <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sg" stub="5293379017992965193" index="3clFbS">
+      <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
         <child id="1068581517665" name="statement" index="3cqZAp" />
       </concept>
-      <concept id="1068580123137" name="jetbrains.mps.baseLanguage.structure.BooleanConstant" flags="ng" index="3clFbT">
+      <concept id="1068580123137" name="jetbrains.mps.baseLanguage.structure.BooleanConstant" flags="nn" index="3clFbT">
         <property id="1068580123138" name="value" index="3clFbU" />
       </concept>
       <concept id="1068580123140" name="jetbrains.mps.baseLanguage.structure.ConstructorDeclaration" flags="ig" index="3clFbW" />
-      <concept id="1068580320020" name="jetbrains.mps.baseLanguage.structure.IntegerConstant" flags="ng" index="3cmrfG">
+      <concept id="1068580320020" name="jetbrains.mps.baseLanguage.structure.IntegerConstant" flags="nn" index="3cmrfG">
         <property id="1068580320021" name="value" index="3cmrfH" />
       </concept>
-      <concept id="1068581242875" name="jetbrains.mps.baseLanguage.structure.PlusExpression" flags="ng" index="3cpWs3" />
-      <concept id="1068581242878" name="jetbrains.mps.baseLanguage.structure.ReturnStatement" flags="ng" index="3cpWs6">
+      <concept id="1068581242875" name="jetbrains.mps.baseLanguage.structure.PlusExpression" flags="nn" index="3cpWs3" />
+      <concept id="1068581242878" name="jetbrains.mps.baseLanguage.structure.ReturnStatement" flags="nn" index="3cpWs6">
         <child id="1068581517676" name="expression" index="3cqZAk" />
       </concept>
-      <concept id="1068581242864" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclarationStatement" flags="ng" index="3cpWs8">
+      <concept id="1068581242864" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclarationStatement" flags="nn" index="3cpWs8">
         <child id="1068581242865" name="localVariableDeclaration" index="3cpWs9" />
       </concept>
       <concept id="1068581242863" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclaration" flags="nr" index="3cpWsn" />
-      <concept id="1068581517677" name="jetbrains.mps.baseLanguage.structure.VoidType" flags="ig" index="3cqZAl" />
-      <concept id="1079359253375" name="jetbrains.mps.baseLanguage.structure.ParenthesizedExpression" flags="ng" index="1eOMI4">
+      <concept id="1068581517677" name="jetbrains.mps.baseLanguage.structure.VoidType" flags="in" index="3cqZAl" />
+      <concept id="1079359253375" name="jetbrains.mps.baseLanguage.structure.ParenthesizedExpression" flags="nn" index="1eOMI4">
         <child id="1079359253376" name="expression" index="1eOMHV" />
       </concept>
-      <concept id="1081506762703" name="jetbrains.mps.baseLanguage.structure.GreaterThanExpression" flags="ng" index="3eOSWO" />
-      <concept id="1081506773034" name="jetbrains.mps.baseLanguage.structure.LessThanExpression" flags="ng" index="3eOVzh" />
-      <concept id="1081516740877" name="jetbrains.mps.baseLanguage.structure.NotExpression" flags="ng" index="3fqX7Q">
+      <concept id="1081506762703" name="jetbrains.mps.baseLanguage.structure.GreaterThanExpression" flags="nn" index="3eOSWO" />
+      <concept id="1081506773034" name="jetbrains.mps.baseLanguage.structure.LessThanExpression" flags="nn" index="3eOVzh" />
+      <concept id="1081516740877" name="jetbrains.mps.baseLanguage.structure.NotExpression" flags="nn" index="3fqX7Q">
         <child id="1081516765348" name="expression" index="3fr31v" />
       </concept>
-      <concept id="1160998861373" name="jetbrains.mps.baseLanguage.structure.AssertStatement" flags="ng" index="1gVbGN">
+      <concept id="1160998861373" name="jetbrains.mps.baseLanguage.structure.AssertStatement" flags="nn" index="1gVbGN">
         <child id="1160998896846" name="condition" index="1gVkn0" />
       </concept>
       <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ngI" index="1ndlxa">
         <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
         <child id="1068499141038" name="actualArgument" index="37wK5m" />
       </concept>
-      <concept id="1073063089578" name="jetbrains.mps.baseLanguage.structure.SuperMethodCall" flags="ng" index="3nyPlj" />
-      <concept id="1212685548494" name="jetbrains.mps.baseLanguage.structure.ClassCreator" flags="ng" index="1pGfFk">
+      <concept id="1073063089578" name="jetbrains.mps.baseLanguage.structure.SuperMethodCall" flags="nn" index="3nyPlj" />
+      <concept id="1212685548494" name="jetbrains.mps.baseLanguage.structure.ClassCreator" flags="nn" index="1pGfFk">
         <child id="1212687122400" name="typeParameter" index="1pMfVU" />
       </concept>
       <concept id="1107461130800" name="jetbrains.mps.baseLanguage.structure.Classifier" flags="ng" index="3pOWGL">
         <property id="521412098689998745" name="nonStatic" index="2bfB8j" />
         <child id="5375687026011219971" name="member" index="jymVt" unordered="true" />
       </concept>
-      <concept id="7812454656619025412" name="jetbrains.mps.baseLanguage.structure.LocalMethodCall" flags="ng" index="1rXfSq" />
-      <concept id="1107535904670" name="jetbrains.mps.baseLanguage.structure.ClassifierType" flags="ig" index="3uibUv">
+      <concept id="7812454656619025412" name="jetbrains.mps.baseLanguage.structure.LocalMethodCall" flags="nn" index="1rXfSq" />
+      <concept id="1107535904670" name="jetbrains.mps.baseLanguage.structure.ClassifierType" flags="in" index="3uibUv">
         <reference id="1107535924139" name="classifier" index="3uigEE" />
         <child id="1109201940907" name="parameter" index="11_B2D" />
       </concept>
-      <concept id="1081773326031" name="jetbrains.mps.baseLanguage.structure.BinaryOperation" flags="ng" index="3uHJSO">
+      <concept id="1081773326031" name="jetbrains.mps.baseLanguage.structure.BinaryOperation" flags="nn" index="3uHJSO">
         <child id="1081773367579" name="rightExpression" index="3uHU7w" />
         <child id="1081773367580" name="leftExpression" index="3uHU7B" />
       </concept>
-      <concept id="1214918800624" name="jetbrains.mps.baseLanguage.structure.PostfixIncrementExpression" flags="ng" index="3uNrnE" />
+      <concept id="1214918800624" name="jetbrains.mps.baseLanguage.structure.PostfixIncrementExpression" flags="nn" index="3uNrnE" />
       <concept id="3093926081414150598" name="jetbrains.mps.baseLanguage.structure.MultipleCatchClause" flags="ng" index="3uVAMA">
         <child id="8276990574895933173" name="catchBody" index="1zc67A" />
         <child id="8276990574895933172" name="throwable" index="1zc67B" />
       </concept>
-      <concept id="1073239437375" name="jetbrains.mps.baseLanguage.structure.NotEqualsExpression" flags="ng" index="3y3z36" />
-      <concept id="1081855346303" name="jetbrains.mps.baseLanguage.structure.BreakStatement" flags="ng" index="3zACq4" />
+      <concept id="1073239437375" name="jetbrains.mps.baseLanguage.structure.NotEqualsExpression" flags="nn" index="3y3z36" />
+      <concept id="1081855346303" name="jetbrains.mps.baseLanguage.structure.BreakStatement" flags="nn" index="3zACq4" />
       <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ngI" index="1B3ioH">
         <child id="1178549979242" name="visibility" index="1B3o_S" />
       </concept>
-      <concept id="1144226303539" name="jetbrains.mps.baseLanguage.structure.ForeachStatement" flags="ng" index="1DcWWT">
+      <concept id="1144226303539" name="jetbrains.mps.baseLanguage.structure.ForeachStatement" flags="nn" index="1DcWWT">
         <child id="1144226360166" name="iterable" index="1DdaDG" />
       </concept>
-      <concept id="1144230876926" name="jetbrains.mps.baseLanguage.structure.AbstractForStatement" flags="ng" index="1DupvO">
+      <concept id="1144230876926" name="jetbrains.mps.baseLanguage.structure.AbstractForStatement" flags="nn" index="1DupvO">
         <child id="1144230900587" name="variable" index="1Duv9x" />
       </concept>
-      <concept id="1144231330558" name="jetbrains.mps.baseLanguage.structure.ForStatement" flags="ng" index="1Dw8fO">
+      <concept id="1144231330558" name="jetbrains.mps.baseLanguage.structure.ForStatement" flags="nn" index="1Dw8fO">
         <child id="1144231399730" name="condition" index="1Dwp0S" />
         <child id="1144231408325" name="iteration" index="1Dwrff" />
       </concept>
-      <concept id="5351203823916750322" name="jetbrains.mps.baseLanguage.structure.TryUniversalStatement" flags="ng" index="3J1_TO">
+      <concept id="5351203823916750322" name="jetbrains.mps.baseLanguage.structure.TryUniversalStatement" flags="nn" index="3J1_TO">
         <child id="8276990574886367510" name="catchClause" index="1zxBo5" />
         <child id="8276990574886367508" name="body" index="1zxBo7" />
       </concept>
-      <concept id="1163668896201" name="jetbrains.mps.baseLanguage.structure.TernaryOperatorExpression" flags="ng" index="3K4zz7">
+      <concept id="1163668896201" name="jetbrains.mps.baseLanguage.structure.TernaryOperatorExpression" flags="nn" index="3K4zz7">
         <child id="1163668914799" name="condition" index="3K4Cdx" />
         <child id="1163668922816" name="ifTrue" index="3K4E3e" />
         <child id="1163668934364" name="ifFalse" index="3K4GZi" />
       </concept>
-      <concept id="1082113931046" name="jetbrains.mps.baseLanguage.structure.ContinueStatement" flags="ng" index="3N13vt" />
-      <concept id="6329021646629104954" name="jetbrains.mps.baseLanguage.structure.SingleLineComment" flags="ng" index="3SKdUt">
+      <concept id="1082113931046" name="jetbrains.mps.baseLanguage.structure.ContinueStatement" flags="nn" index="3N13vt" />
+      <concept id="6329021646629104954" name="jetbrains.mps.baseLanguage.structure.SingleLineComment" flags="nn" index="3SKdUt">
         <child id="8356039341262087992" name="line" index="1aUNEU" />
       </concept>
-      <concept id="1146644602865" name="jetbrains.mps.baseLanguage.structure.PublicVisibility" flags="ng" index="3Tm1VV" />
-      <concept id="1146644623116" name="jetbrains.mps.baseLanguage.structure.PrivateVisibility" flags="ng" index="3Tm6S6" />
-      <concept id="1080120340718" name="jetbrains.mps.baseLanguage.structure.AndExpression" flags="ng" index="1Wc70l" />
+      <concept id="1146644602865" name="jetbrains.mps.baseLanguage.structure.PublicVisibility" flags="nn" index="3Tm1VV" />
+      <concept id="1146644623116" name="jetbrains.mps.baseLanguage.structure.PrivateVisibility" flags="nn" index="3Tm6S6" />
+      <concept id="1080120340718" name="jetbrains.mps.baseLanguage.structure.AndExpression" flags="nn" index="1Wc70l" />
       <concept id="1170345865475" name="jetbrains.mps.baseLanguage.structure.AnonymousClass" flags="ig" index="1Y3b0j">
         <reference id="1170346070688" name="classifier" index="1Y3XeK" />
         <child id="1201186121363" name="typeParameter" index="2Ghqu4" />
       </concept>
     </language>
     <language id="774bf8a0-62e5-41e1-af63-f4812e60e48b" name="jetbrains.mps.baseLanguage.checkedDots">
-      <concept id="4079382982702596667" name="jetbrains.mps.baseLanguage.checkedDots.structure.CheckedDotExpression" flags="ng" index="2EnYce" />
+      <concept id="4079382982702596667" name="jetbrains.mps.baseLanguage.checkedDots.structure.CheckedDotExpression" flags="nn" index="2EnYce" />
     </language>
     <language id="40ab19e9-751a-4433-b645-0e65160e58a0" name="org.mpsqa.lint.generic">
       <concept id="7741759128795038157" name="org.mpsqa.lint.generic.structure.CheckableScriptParameter" flags="ng" index="2j1K4_">
@@ -268,7 +268,7 @@
         <child id="7741759128795045752" name="exp" index="2j1LYg" />
         <child id="7741759128795065723" name="paramRef" index="2j1YQj" />
       </concept>
-      <concept id="1209559114970" name="org.mpsqa.lint.generic.structure.ConceptFunctionParameter_Module" flags="ng" index="2vlQn3" />
+      <concept id="1209559114970" name="org.mpsqa.lint.generic.structure.ConceptFunctionParameter_Module" flags="nn" index="2vlQn3" />
       <concept id="7679435328618353697" name="org.mpsqa.lint.generic.structure.FormatException" flags="ng" index="vsK6v">
         <child id="7679435328618377120" name="exception" index="vsfCu" />
       </concept>
@@ -287,19 +287,19 @@
     </language>
     <language id="fd392034-7849-419d-9071-12563d152375" name="jetbrains.mps.baseLanguage.closures">
       <concept id="2524418899405758586" name="jetbrains.mps.baseLanguage.closures.structure.InferredClosureParameterDeclaration" flags="ig" index="gl6BB" />
-      <concept id="1235746970280" name="jetbrains.mps.baseLanguage.closures.structure.CompactInvokeFunctionExpression" flags="ng" index="2Sg_IR">
+      <concept id="1235746970280" name="jetbrains.mps.baseLanguage.closures.structure.CompactInvokeFunctionExpression" flags="nn" index="2Sg_IR">
         <child id="1235746996653" name="function" index="2SgG2M" />
         <child id="1235747002942" name="parameter" index="2SgHGx" />
       </concept>
-      <concept id="1199542442495" name="jetbrains.mps.baseLanguage.closures.structure.FunctionType" flags="ig" index="1ajhzC">
+      <concept id="1199542442495" name="jetbrains.mps.baseLanguage.closures.structure.FunctionType" flags="in" index="1ajhzC">
         <child id="1199542457201" name="resultType" index="1ajl9A" />
         <child id="1199542501692" name="parameterType" index="1ajw0F" />
       </concept>
-      <concept id="1199569711397" name="jetbrains.mps.baseLanguage.closures.structure.ClosureLiteral" flags="ng" index="1bVj0M">
+      <concept id="1199569711397" name="jetbrains.mps.baseLanguage.closures.structure.ClosureLiteral" flags="nn" index="1bVj0M">
         <child id="1199569906740" name="parameter" index="1bW2Oz" />
         <child id="1199569916463" name="body" index="1bW5cS" />
       </concept>
-      <concept id="1225797177491" name="jetbrains.mps.baseLanguage.closures.structure.InvokeFunctionOperation" flags="ng" index="1Bd96e">
+      <concept id="1225797177491" name="jetbrains.mps.baseLanguage.closures.structure.InvokeFunctionOperation" flags="nn" index="1Bd96e">
         <child id="1225797361612" name="parameter" index="1BdPVh" />
       </concept>
     </language>
@@ -340,8 +340,8 @@
       </concept>
     </language>
     <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
-      <concept id="1143226024141" name="jetbrains.mps.lang.smodel.structure.SModelType" flags="ig" index="H_c77" />
-      <concept id="1171323947159" name="jetbrains.mps.lang.smodel.structure.Model_NodesOperation" flags="ng" index="2SmgA7" />
+      <concept id="1143226024141" name="jetbrains.mps.lang.smodel.structure.SModelType" flags="in" index="H_c77" />
+      <concept id="1171323947159" name="jetbrains.mps.lang.smodel.structure.Model_NodesOperation" flags="nn" index="2SmgA7" />
       <concept id="1678062499342629858" name="jetbrains.mps.lang.smodel.structure.ModuleRefExpression" flags="ng" index="37shsh">
         <child id="1678062499342629861" name="moduleId" index="37shsm" />
       </concept>
@@ -360,16 +360,16 @@
       <concept id="5106752179536586436" name="jetbrains.mps.lang.text.structure.IndentedPoint" flags="ngI" index="2RT3b8">
         <property id="5106752179536586491" name="indentation" index="2RT3bR" />
       </concept>
-      <concept id="155656958578482948" name="jetbrains.mps.lang.text.structure.Word" flags="ng" index="3oM_SD">
+      <concept id="155656958578482948" name="jetbrains.mps.lang.text.structure.Word" flags="nn" index="3oM_SD">
         <property id="155656958578482949" name="value" index="3oM_SC" />
         <property id="6328114375520539774" name="bold" index="1X82S1" />
         <property id="6328114375520539796" name="underlined" index="1X82VF" />
         <property id="6328114375520539777" name="italic" index="1X82VY" />
       </concept>
-      <concept id="2535923850359206929" name="jetbrains.mps.lang.text.structure.Text" flags="ng" index="1Pa9Pv">
+      <concept id="2535923850359206929" name="jetbrains.mps.lang.text.structure.Text" flags="nn" index="1Pa9Pv">
         <child id="2535923850359210936" name="lines" index="1PaQFQ" />
       </concept>
-      <concept id="2535923850359271782" name="jetbrains.mps.lang.text.structure.Line" flags="ng" index="1PaTwC">
+      <concept id="2535923850359271782" name="jetbrains.mps.lang.text.structure.Line" flags="nn" index="1PaTwC">
         <child id="2535923850359271783" name="elements" index="1PaTwD" />
       </concept>
     </language>
@@ -381,88 +381,88 @@
       </concept>
     </language>
     <language id="83888646-71ce-4f1c-9c53-c54016f6ad4f" name="jetbrains.mps.baseLanguage.collections">
-      <concept id="1204796164442" name="jetbrains.mps.baseLanguage.collections.structure.InternalSequenceOperation" flags="ng" index="23sCx2">
+      <concept id="1204796164442" name="jetbrains.mps.baseLanguage.collections.structure.InternalSequenceOperation" flags="nn" index="23sCx2">
         <child id="1204796294226" name="closure" index="23t8la" />
       </concept>
-      <concept id="1176906603202" name="jetbrains.mps.baseLanguage.collections.structure.BinaryOperation" flags="ng" index="56pJg">
+      <concept id="1176906603202" name="jetbrains.mps.baseLanguage.collections.structure.BinaryOperation" flags="nn" index="56pJg">
         <child id="1176906787974" name="rightExpression" index="576Qk" />
       </concept>
-      <concept id="540871147943773365" name="jetbrains.mps.baseLanguage.collections.structure.SingleArgumentSequenceOperation" flags="ng" index="25WWJ4">
+      <concept id="540871147943773365" name="jetbrains.mps.baseLanguage.collections.structure.SingleArgumentSequenceOperation" flags="nn" index="25WWJ4">
         <child id="540871147943773366" name="argument" index="25WWJ7" />
       </concept>
-      <concept id="1176923520476" name="jetbrains.mps.baseLanguage.collections.structure.ExcludeOperation" flags="ng" index="66VNe" />
-      <concept id="1204980550705" name="jetbrains.mps.baseLanguage.collections.structure.VisitAllOperation" flags="ng" index="2es0OD" />
-      <concept id="1226511727824" name="jetbrains.mps.baseLanguage.collections.structure.SetType" flags="ig" index="2hMVRd">
+      <concept id="1176923520476" name="jetbrains.mps.baseLanguage.collections.structure.ExcludeOperation" flags="nn" index="66VNe" />
+      <concept id="1204980550705" name="jetbrains.mps.baseLanguage.collections.structure.VisitAllOperation" flags="nn" index="2es0OD" />
+      <concept id="1226511727824" name="jetbrains.mps.baseLanguage.collections.structure.SetType" flags="in" index="2hMVRd">
         <child id="1226511765987" name="elementType" index="2hN53Y" />
       </concept>
-      <concept id="1226516258405" name="jetbrains.mps.baseLanguage.collections.structure.HashSetCreator" flags="ng" index="2i4dXS" />
-      <concept id="1151688443754" name="jetbrains.mps.baseLanguage.collections.structure.ListType" flags="ig" index="_YKpA">
+      <concept id="1226516258405" name="jetbrains.mps.baseLanguage.collections.structure.HashSetCreator" flags="nn" index="2i4dXS" />
+      <concept id="1151688443754" name="jetbrains.mps.baseLanguage.collections.structure.ListType" flags="in" index="_YKpA">
         <child id="1151688676805" name="elementType" index="_ZDj9" />
       </concept>
-      <concept id="1151689724996" name="jetbrains.mps.baseLanguage.collections.structure.SequenceType" flags="ig" index="A3Dl8">
+      <concept id="1151689724996" name="jetbrains.mps.baseLanguage.collections.structure.SequenceType" flags="in" index="A3Dl8">
         <child id="1151689745422" name="elementType" index="A3Ik2" />
       </concept>
-      <concept id="1151702311717" name="jetbrains.mps.baseLanguage.collections.structure.ToListOperation" flags="ng" index="ANE8D" />
-      <concept id="1209727891789" name="jetbrains.mps.baseLanguage.collections.structure.ComparatorSortOperation" flags="ng" index="2DpFxk">
+      <concept id="1151702311717" name="jetbrains.mps.baseLanguage.collections.structure.ToListOperation" flags="nn" index="ANE8D" />
+      <concept id="1209727891789" name="jetbrains.mps.baseLanguage.collections.structure.ComparatorSortOperation" flags="nn" index="2DpFxk">
         <child id="1209727996925" name="ascending" index="2Dq5b$" />
       </concept>
-      <concept id="1153943597977" name="jetbrains.mps.baseLanguage.collections.structure.ForEachStatement" flags="ng" index="2Gpval">
+      <concept id="1153943597977" name="jetbrains.mps.baseLanguage.collections.structure.ForEachStatement" flags="nn" index="2Gpval">
         <child id="1153944400369" name="variable" index="2Gsz3X" />
         <child id="1153944424730" name="inputSequence" index="2GsD0m" />
       </concept>
       <concept id="1153944193378" name="jetbrains.mps.baseLanguage.collections.structure.ForEachVariable" flags="nr" index="2GrKxI" />
-      <concept id="1153944233411" name="jetbrains.mps.baseLanguage.collections.structure.ForEachVariableReference" flags="ng" index="2GrUjf">
+      <concept id="1153944233411" name="jetbrains.mps.baseLanguage.collections.structure.ForEachVariableReference" flags="nn" index="2GrUjf">
         <reference id="1153944258490" name="variable" index="2Gs0qQ" />
       </concept>
-      <concept id="1235573135402" name="jetbrains.mps.baseLanguage.collections.structure.SingletonSequenceCreator" flags="ng" index="2HTt$P">
+      <concept id="1235573135402" name="jetbrains.mps.baseLanguage.collections.structure.SingletonSequenceCreator" flags="nn" index="2HTt$P">
         <child id="1235573175711" name="elementType" index="2HTBi0" />
         <child id="1235573187520" name="singletonValue" index="2HTEbv" />
       </concept>
-      <concept id="1237721394592" name="jetbrains.mps.baseLanguage.collections.structure.AbstractContainerCreator" flags="ng" index="HWqM0">
+      <concept id="1237721394592" name="jetbrains.mps.baseLanguage.collections.structure.AbstractContainerCreator" flags="nn" index="HWqM0">
         <child id="1237721435808" name="initValue" index="HW$Y0" />
         <child id="1237721435807" name="elementType" index="HW$YZ" />
         <child id="1237731803878" name="copyFrom" index="I$8f6" />
       </concept>
-      <concept id="1227008614712" name="jetbrains.mps.baseLanguage.collections.structure.LinkedListCreator" flags="ng" index="2Jqq0_" />
-      <concept id="1227022210526" name="jetbrains.mps.baseLanguage.collections.structure.ClearAllElementsOperation" flags="ng" index="2Kehj3" />
-      <concept id="1205679737078" name="jetbrains.mps.baseLanguage.collections.structure.SortOperation" flags="ng" index="2S7cBI">
+      <concept id="1227008614712" name="jetbrains.mps.baseLanguage.collections.structure.LinkedListCreator" flags="nn" index="2Jqq0_" />
+      <concept id="1227022210526" name="jetbrains.mps.baseLanguage.collections.structure.ClearAllElementsOperation" flags="nn" index="2Kehj3" />
+      <concept id="1205679737078" name="jetbrains.mps.baseLanguage.collections.structure.SortOperation" flags="nn" index="2S7cBI">
         <child id="1205679832066" name="ascending" index="2S7zOq" />
       </concept>
-      <concept id="1160600644654" name="jetbrains.mps.baseLanguage.collections.structure.ListCreatorWithInit" flags="ng" index="Tc6Ow" />
-      <concept id="1160612413312" name="jetbrains.mps.baseLanguage.collections.structure.AddElementOperation" flags="ng" index="TSZUe" />
-      <concept id="1160666733551" name="jetbrains.mps.baseLanguage.collections.structure.AddAllElementsOperation" flags="ng" index="X8dFx" />
-      <concept id="1162934736510" name="jetbrains.mps.baseLanguage.collections.structure.GetElementOperation" flags="ng" index="34jXtK" />
-      <concept id="1162935959151" name="jetbrains.mps.baseLanguage.collections.structure.GetSizeOperation" flags="ng" index="34oBXx" />
-      <concept id="1167380149909" name="jetbrains.mps.baseLanguage.collections.structure.RemoveElementOperation" flags="ng" index="3dhRuq" />
-      <concept id="1201872418428" name="jetbrains.mps.baseLanguage.collections.structure.GetKeysOperation" flags="ng" index="3lbrtF" />
-      <concept id="1178286324487" name="jetbrains.mps.baseLanguage.collections.structure.SortDirection" flags="ng" index="1nlBCl" />
-      <concept id="1197683403723" name="jetbrains.mps.baseLanguage.collections.structure.MapType" flags="ig" index="3rvAFt">
+      <concept id="1160600644654" name="jetbrains.mps.baseLanguage.collections.structure.ListCreatorWithInit" flags="nn" index="Tc6Ow" />
+      <concept id="1160612413312" name="jetbrains.mps.baseLanguage.collections.structure.AddElementOperation" flags="nn" index="TSZUe" />
+      <concept id="1160666733551" name="jetbrains.mps.baseLanguage.collections.structure.AddAllElementsOperation" flags="nn" index="X8dFx" />
+      <concept id="1162934736510" name="jetbrains.mps.baseLanguage.collections.structure.GetElementOperation" flags="nn" index="34jXtK" />
+      <concept id="1162935959151" name="jetbrains.mps.baseLanguage.collections.structure.GetSizeOperation" flags="nn" index="34oBXx" />
+      <concept id="1167380149909" name="jetbrains.mps.baseLanguage.collections.structure.RemoveElementOperation" flags="nn" index="3dhRuq" />
+      <concept id="1201872418428" name="jetbrains.mps.baseLanguage.collections.structure.GetKeysOperation" flags="nn" index="3lbrtF" />
+      <concept id="1178286324487" name="jetbrains.mps.baseLanguage.collections.structure.SortDirection" flags="nn" index="1nlBCl" />
+      <concept id="1197683403723" name="jetbrains.mps.baseLanguage.collections.structure.MapType" flags="in" index="3rvAFt">
         <child id="1197683466920" name="keyType" index="3rvQeY" />
         <child id="1197683475734" name="valueType" index="3rvSg0" />
       </concept>
-      <concept id="1197686869805" name="jetbrains.mps.baseLanguage.collections.structure.HashMapCreator" flags="ng" index="3rGOSV">
+      <concept id="1197686869805" name="jetbrains.mps.baseLanguage.collections.structure.HashMapCreator" flags="nn" index="3rGOSV">
         <child id="1197687026896" name="keyType" index="3rHrn6" />
         <child id="1197687035757" name="valueType" index="3rHtpV" />
       </concept>
-      <concept id="1165525191778" name="jetbrains.mps.baseLanguage.collections.structure.GetFirstOperation" flags="ng" index="1uHKPH" />
-      <concept id="1240687580870" name="jetbrains.mps.baseLanguage.collections.structure.JoinOperation" flags="ng" index="3uJxvA">
+      <concept id="1165525191778" name="jetbrains.mps.baseLanguage.collections.structure.GetFirstOperation" flags="nn" index="1uHKPH" />
+      <concept id="1240687580870" name="jetbrains.mps.baseLanguage.collections.structure.JoinOperation" flags="nn" index="3uJxvA">
         <child id="1240687658305" name="delimiter" index="3uJOhx" />
       </concept>
-      <concept id="1202120902084" name="jetbrains.mps.baseLanguage.collections.structure.WhereOperation" flags="ng" index="3zZkjj" />
-      <concept id="1202128969694" name="jetbrains.mps.baseLanguage.collections.structure.SelectOperation" flags="ng" index="3$u5V9" />
-      <concept id="1240824834947" name="jetbrains.mps.baseLanguage.collections.structure.ValueAccessOperation" flags="ng" index="3AV6Ez" />
-      <concept id="1240825616499" name="jetbrains.mps.baseLanguage.collections.structure.KeyAccessOperation" flags="ng" index="3AY5_j" />
-      <concept id="1197932370469" name="jetbrains.mps.baseLanguage.collections.structure.MapElement" flags="ng" index="3EllGN">
+      <concept id="1202120902084" name="jetbrains.mps.baseLanguage.collections.structure.WhereOperation" flags="nn" index="3zZkjj" />
+      <concept id="1202128969694" name="jetbrains.mps.baseLanguage.collections.structure.SelectOperation" flags="nn" index="3$u5V9" />
+      <concept id="1240824834947" name="jetbrains.mps.baseLanguage.collections.structure.ValueAccessOperation" flags="nn" index="3AV6Ez" />
+      <concept id="1240825616499" name="jetbrains.mps.baseLanguage.collections.structure.KeyAccessOperation" flags="nn" index="3AY5_j" />
+      <concept id="1197932370469" name="jetbrains.mps.baseLanguage.collections.structure.MapElement" flags="nn" index="3EllGN">
         <child id="1197932505799" name="map" index="3ElQJh" />
         <child id="1197932525128" name="key" index="3ElVtu" />
       </concept>
-      <concept id="1176501494711" name="jetbrains.mps.baseLanguage.collections.structure.IsNotEmptyOperation" flags="ng" index="3GX2aA" />
-      <concept id="1172254888721" name="jetbrains.mps.baseLanguage.collections.structure.ContainsOperation" flags="ng" index="3JPx81" />
-      <concept id="1180964022718" name="jetbrains.mps.baseLanguage.collections.structure.ConcatOperation" flags="ng" index="3QWeyG" />
-      <concept id="1228228912534" name="jetbrains.mps.baseLanguage.collections.structure.DowncastExpression" flags="ng" index="3S9uib">
+      <concept id="1176501494711" name="jetbrains.mps.baseLanguage.collections.structure.IsNotEmptyOperation" flags="nn" index="3GX2aA" />
+      <concept id="1172254888721" name="jetbrains.mps.baseLanguage.collections.structure.ContainsOperation" flags="nn" index="3JPx81" />
+      <concept id="1180964022718" name="jetbrains.mps.baseLanguage.collections.structure.ConcatOperation" flags="nn" index="3QWeyG" />
+      <concept id="1228228912534" name="jetbrains.mps.baseLanguage.collections.structure.DowncastExpression" flags="nn" index="3S9uib">
         <child id="1228228959951" name="expression" index="3S9DZi" />
       </concept>
-      <concept id="1178894719932" name="jetbrains.mps.baseLanguage.collections.structure.DistinctOperation" flags="ng" index="1VAtEI" />
+      <concept id="1178894719932" name="jetbrains.mps.baseLanguage.collections.structure.DistinctOperation" flags="nn" index="1VAtEI" />
     </language>
   </registry>
   <node concept="1MIHA_" id="2dSiT1hKT_t">

--- a/code/languages/org.mpsqa.lint/solutions/org.mpsqa.lint.generic.linters_library/models/org.mpsqa.lint.generic.linters_library.modules.mps
+++ b/code/languages/org.mpsqa.lint/solutions/org.mpsqa.lint.generic.linters_library/models/org.mpsqa.lint.generic.linters_library.modules.mps
@@ -66,6 +66,9 @@
       <concept id="1188208481402" name="jetbrains.mps.baseLanguage.structure.HasAnnotation" flags="ngI" index="2AJDlI">
         <child id="1188208488637" name="annotation" index="2AJF6D" />
       </concept>
+      <concept id="2820489544401957797" name="jetbrains.mps.baseLanguage.structure.DefaultClassCreator" flags="nn" index="HV5vD">
+        <reference id="2820489544401957798" name="classifier" index="HV5vE" />
+      </concept>
       <concept id="1154032098014" name="jetbrains.mps.baseLanguage.structure.AbstractLoopStatement" flags="nn" index="2LF5Ji">
         <child id="1154032183016" name="body" index="2LFqv$" />
       </concept>
@@ -103,6 +106,9 @@
         <child id="1081256993305" name="classType" index="2ZW6by" />
         <child id="1081256993304" name="leftExpression" index="2ZW6bz" />
       </concept>
+      <concept id="1070533707846" name="jetbrains.mps.baseLanguage.structure.StaticFieldReference" flags="nn" index="10M0yZ">
+        <reference id="1144433057691" name="classifier" index="1PxDUh" />
+      </concept>
       <concept id="1070534058343" name="jetbrains.mps.baseLanguage.structure.NullLiteral" flags="nn" index="10Nm6u" />
       <concept id="1070534370425" name="jetbrains.mps.baseLanguage.structure.IntegerType" flags="in" index="10Oyi0" />
       <concept id="1070534644030" name="jetbrains.mps.baseLanguage.structure.BooleanType" flags="in" index="10P_77" />
@@ -118,6 +124,13 @@
       </concept>
       <concept id="1513279640923991009" name="jetbrains.mps.baseLanguage.structure.IGenericClassCreator" flags="ngI" index="366HgL">
         <property id="1513279640906337053" name="inferTypeParams" index="373rjd" />
+      </concept>
+      <concept id="1109279763828" name="jetbrains.mps.baseLanguage.structure.TypeVariableDeclaration" flags="ng" index="16euLQ" />
+      <concept id="1109279851642" name="jetbrains.mps.baseLanguage.structure.GenericDeclaration" flags="ng" index="16eOlS">
+        <child id="1109279881614" name="typeVariableDeclaration" index="16eVyc" />
+      </concept>
+      <concept id="1109283449304" name="jetbrains.mps.baseLanguage.structure.TypeVariableReference" flags="in" index="16syzq">
+        <reference id="1109283546497" name="typeVariableDeclaration" index="16sUi3" />
       </concept>
       <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
         <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
@@ -220,6 +233,11 @@
       <concept id="5351203823916750322" name="jetbrains.mps.baseLanguage.structure.TryUniversalStatement" flags="nn" index="3J1_TO">
         <child id="8276990574886367510" name="catchClause" index="1zxBo5" />
         <child id="8276990574886367508" name="body" index="1zxBo7" />
+      </concept>
+      <concept id="1163668896201" name="jetbrains.mps.baseLanguage.structure.TernaryOperatorExpression" flags="nn" index="3K4zz7">
+        <child id="1163668914799" name="condition" index="3K4Cdx" />
+        <child id="1163668922816" name="ifTrue" index="3K4E3e" />
+        <child id="1163668934364" name="ifFalse" index="3K4GZi" />
       </concept>
       <concept id="1082113931046" name="jetbrains.mps.baseLanguage.structure.ContinueStatement" flags="nn" index="3N13vt" />
       <concept id="6329021646629104954" name="jetbrains.mps.baseLanguage.structure.SingleLineComment" flags="nn" index="3SKdUt">
@@ -2763,19 +2781,53 @@
         <node concept="3clFbH" id="4aEqBbb$5Lh" role="3cqZAp" />
         <node concept="L3pyB" id="4aEqBbb$5Li" role="3cqZAp">
           <node concept="3clFbS" id="4aEqBbb$5Lj" role="L3pyw">
-            <node concept="3clFbF" id="47tbZooWmGX" role="3cqZAp">
-              <node concept="2YIFZM" id="47tbZooWmTz" role="3clFbG">
-                <ref role="37wK5l" node="47tbZooV55x" resolve="computeTooLargeCycles" />
-                <ref role="1Pybhc" node="4aEqBbbBtjF" resolve="CyclicModuleDependenciesHelper" />
-                <node concept="2OqwBi" id="47tbZooWoGh" role="37wK5m">
-                  <node concept="EzsRk" id="47tbZooWomm" role="2Oq$k0" />
-                  <node concept="ANE8D" id="47tbZooWpcY" role="2OqNvi" />
+            <node concept="3clFbF" id="13En2FwdDQK" role="3cqZAp">
+              <node concept="2OqwBi" id="13En2FwdNsN" role="3clFbG">
+                <node concept="2YIFZM" id="13En2FwdLog" role="2Oq$k0">
+                  <ref role="37wK5l" node="13En2FvVD7A" resolve="getDependenciesHelper" />
+                  <ref role="1Pybhc" node="4aEqBbbBtjF" resolve="CyclicModuleDependenciesHelper" />
+                  <node concept="3clFbT" id="13En2FwdLxd" role="37wK5m" />
+                  <node concept="2OqwBi" id="13En2FwdMr1" role="37wK5m">
+                    <node concept="1MG55F" id="13En2FwdLGU" role="2Oq$k0" />
+                    <node concept="liA8E" id="13En2FwdNel" role="2OqNvi">
+                      <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                    </node>
+                  </node>
                 </node>
-                <node concept="37vLTw" id="47tbZooWneA" role="37wK5m">
-                  <ref role="3cqZAo" node="4aEqBbb$5Lb" resolve="res" />
-                </node>
-                <node concept="2j1LYi" id="47tbZooWn$O" role="37wK5m">
-                  <ref role="2j1LYj" node="47tbZooQUks" resolve="cycleLength" />
+                <node concept="liA8E" id="13En2FwdO1d" role="2OqNvi">
+                  <ref role="37wK5l" node="13En2Fvu8h0" resolve="computeTooLargeCycles" />
+                  <node concept="2OqwBi" id="13En2FwdSfR" role="37wK5m">
+                    <node concept="2OqwBi" id="13En2FwdPLy" role="2Oq$k0">
+                      <node concept="EzsRk" id="13En2FwdOSm" role="2Oq$k0" />
+                      <node concept="3$u5V9" id="13En2FwdQ$b" role="2OqNvi">
+                        <node concept="1bVj0M" id="13En2FwdQ$d" role="23t8la">
+                          <node concept="3clFbS" id="13En2FwdQ$e" role="1bW5cS">
+                            <node concept="3clFbF" id="13En2FwdQVH" role="3cqZAp">
+                              <node concept="2OqwBi" id="13En2FwdR3Y" role="3clFbG">
+                                <node concept="37vLTw" id="13En2FwdQVG" role="2Oq$k0">
+                                  <ref role="3cqZAo" node="13En2FwdQ$f" resolve="it" />
+                                </node>
+                                <node concept="liA8E" id="13En2FwdRqZ" role="2OqNvi">
+                                  <ref role="37wK5l" to="lui2:~SModule.getModuleReference()" resolve="getModuleReference" />
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                          <node concept="gl6BB" id="13En2FwdQ$f" role="1bW2Oz">
+                            <property role="TrG5h" value="it" />
+                            <node concept="2jxLKc" id="13En2FwdQ$g" role="1tU5fm" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="ANE8D" id="13En2FwdTdT" role="2OqNvi" />
+                  </node>
+                  <node concept="37vLTw" id="13En2FwdTJg" role="37wK5m">
+                    <ref role="3cqZAo" node="4aEqBbb$5Lb" resolve="res" />
+                  </node>
+                  <node concept="2j1LYi" id="13En2FwdU6k" role="37wK5m">
+                    <ref role="2j1LYj" node="47tbZooQUks" resolve="cycleLength" />
+                  </node>
                 </node>
               </node>
             </node>
@@ -3760,824 +3812,375 @@
     <property role="TrG5h" value="CyclicModuleDependenciesHelper" />
     <property role="3GE5qa" value="helpers" />
     <node concept="2tJIrI" id="4aEqBbbBtlf" role="jymVt" />
-    <node concept="2tJIrI" id="47tbZooUKtH" role="jymVt" />
-    <node concept="2YIFZL" id="44nYoQPiJ59" role="jymVt">
-      <property role="TrG5h" value="computeTooLargeStronglyConnectedComponents" />
-      <node concept="37vLTG" id="44nYoQPiJ5a" role="3clF46">
-        <property role="TrG5h" value="modules" />
-        <node concept="_YKpA" id="44nYoQPiJ5b" role="1tU5fm">
-          <node concept="3uibUv" id="44nYoQPiJ5c" role="_ZDj9">
-            <ref role="3uigEE" to="lui2:~SModule" resolve="SModule" />
-          </node>
+    <node concept="Wx3nA" id="13En2FvYTVe" role="jymVt">
+      <property role="TrG5h" value="CONSIDER_USED_LANGUAGES_OPTION" />
+      <property role="3TUv4t" value="true" />
+      <node concept="3uibUv" id="13En2FvYTVh" role="1tU5fm">
+        <ref role="3uigEE" node="13En2FvhV7b" resolve="CyclicGenericDependenciesHelper.Option" />
+      </node>
+      <node concept="2ShNRf" id="13En2FvYTVi" role="33vP2m">
+        <node concept="HV5vD" id="13En2FvYTVj" role="2ShVmc">
+          <property role="373rjd" value="true" />
+          <ref role="HV5vE" node="13En2FvhV7b" resolve="CyclicGenericDependenciesHelper.Option" />
         </node>
       </node>
-      <node concept="37vLTG" id="44nYoQPiJ5d" role="3clF46">
-        <property role="TrG5h" value="res" />
-        <node concept="_YKpA" id="44nYoQPiJ5e" role="1tU5fm">
-          <node concept="17QB3L" id="44nYoQPiJ5f" role="_ZDj9" />
+      <node concept="3Tm1VV" id="13En2FvYTVg" role="1B3o_S" />
+    </node>
+    <node concept="2tJIrI" id="13En2FvWjkn" role="jymVt" />
+    <node concept="2YIFZL" id="13En2Fw73pu" role="jymVt">
+      <property role="TrG5h" value="getStartingPointHelper" />
+      <node concept="37vLTG" id="13En2Fw7so_" role="3clF46">
+        <property role="TrG5h" value="considerUsedLanguages" />
+        <node concept="10P_77" id="13En2Fw7soA" role="1tU5fm" />
+      </node>
+      <node concept="37vLTG" id="13En2Fw7x0L" role="3clF46">
+        <property role="TrG5h" value="repository" />
+        <node concept="3uibUv" id="13En2Fw7_FB" role="1tU5fm">
+          <ref role="3uigEE" to="lui2:~SRepository" resolve="SRepository" />
         </node>
       </node>
-      <node concept="37vLTG" id="44nYoQPiJ5g" role="3clF46">
-        <property role="TrG5h" value="minLength" />
-        <node concept="10Oyi0" id="44nYoQPiJ5h" role="1tU5fm" />
-      </node>
-      <node concept="3cqZAl" id="44nYoQPiJ5i" role="3clF45" />
-      <node concept="3clFbS" id="44nYoQPiJ5j" role="3clF47">
-        <node concept="3clFbH" id="3b1aCyg4a63" role="3cqZAp" />
-        <node concept="3cpWs8" id="3b1aCyg4ycs" role="3cqZAp">
-          <node concept="3cpWsn" id="3b1aCyg4yct" role="3cpWs9">
-            <property role="TrG5h" value="directModuleDependencies" />
-            <node concept="3rvAFt" id="3b1aCyg4x1D" role="1tU5fm">
-              <node concept="3uibUv" id="3b1aCyg4x1M" role="3rvQeY">
-                <ref role="3uigEE" to="lui2:~SModule" resolve="SModule" />
-              </node>
-              <node concept="2hMVRd" id="3b1aCyg4x1N" role="3rvSg0">
-                <node concept="3uibUv" id="3b1aCyg4x1O" role="2hN53Y">
-                  <ref role="3uigEE" to="lui2:~SModule" resolve="SModule" />
+      <node concept="3clFbS" id="13En2Fw73px" role="3clF47">
+        <node concept="3clFbF" id="13En2Fw7ena" role="3cqZAp">
+          <node concept="2ShNRf" id="13En2Fw7en8" role="3clFbG">
+            <node concept="1pGfFk" id="13En2Fw7jac" role="2ShVmc">
+              <property role="373rjd" value="true" />
+              <ref role="37wK5l" node="13En2FvQ$NN" resolve="CyclicComponentDependenciesFromStartingPointHelper" />
+              <node concept="1rXfSq" id="13En2Fw7nMo" role="37wK5m">
+                <ref role="37wK5l" node="13En2FvVD7A" resolve="getDependenciesHelper" />
+                <node concept="37vLTw" id="13En2Fw7J3I" role="37wK5m">
+                  <ref role="3cqZAo" node="13En2Fw7so_" resolve="considerUsedLanguages" />
+                </node>
+                <node concept="37vLTw" id="13En2Fw7SBc" role="37wK5m">
+                  <ref role="3cqZAo" node="13En2Fw7x0L" resolve="repository" />
                 </node>
               </node>
-            </node>
-            <node concept="1rXfSq" id="3b1aCyg4ycu" role="33vP2m">
-              <ref role="37wK5l" node="3b1aCyg4gsX" resolve="computeDirectModuleDependencies" />
-              <node concept="37vLTw" id="3b1aCyg4ycv" role="37wK5m">
-                <ref role="3cqZAo" node="44nYoQPiJ5a" resolve="modules" />
-              </node>
-              <node concept="3clFbT" id="1SbpUw9RozB" role="37wK5m" />
-            </node>
-          </node>
-        </node>
-        <node concept="3cpWs8" id="3b1aCyg4IDT" role="3cqZAp">
-          <node concept="3cpWsn" id="3b1aCyg4IDU" role="3cpWs9">
-            <property role="TrG5h" value="indirectDependencies" />
-            <node concept="3rvAFt" id="3b1aCyg4HnJ" role="1tU5fm">
-              <node concept="3uibUv" id="3b1aCyg4HnU" role="3rvQeY">
-                <ref role="3uigEE" to="lui2:~SModule" resolve="SModule" />
-              </node>
-              <node concept="2hMVRd" id="3b1aCyg4HnS" role="3rvSg0">
-                <node concept="3uibUv" id="3b1aCyg4HnT" role="2hN53Y">
-                  <ref role="3uigEE" to="lui2:~SModule" resolve="SModule" />
-                </node>
-              </node>
-            </node>
-            <node concept="1rXfSq" id="3b1aCyg4IDV" role="33vP2m">
-              <ref role="37wK5l" node="3b1aCyfEME5" resolve="computeIndirectDependencies" />
-              <node concept="37vLTw" id="3b1aCyg4IDW" role="37wK5m">
-                <ref role="3cqZAo" node="3b1aCyg4yct" resolve="directModuleDependencies" />
+              <node concept="3uibUv" id="13En2Fwm5BA" role="1pMfVU">
+                <ref role="3uigEE" to="lui2:~SModuleReference" resolve="SModuleReference" />
               </node>
             </node>
           </node>
         </node>
-        <node concept="3clFbH" id="3b1aCyg4aeJ" role="3cqZAp" />
-        <node concept="3cpWs8" id="3b1aCyg53pm" role="3cqZAp">
-          <node concept="3cpWsn" id="3b1aCyg53pp" role="3cpWs9">
-            <property role="TrG5h" value="listOfStronglyConnectedComponents" />
-            <node concept="_YKpA" id="3b1aCyg53pi" role="1tU5fm">
-              <node concept="2hMVRd" id="3b1aCygb5On" role="_ZDj9">
-                <node concept="3uibUv" id="3b1aCygb5Op" role="2hN53Y">
-                  <ref role="3uigEE" to="lui2:~SModule" resolve="SModule" />
+      </node>
+      <node concept="3Tm1VV" id="13En2Fw6M8f" role="1B3o_S" />
+      <node concept="3uibUv" id="13En2Fw6YUm" role="3clF45">
+        <ref role="3uigEE" node="13En2FvI8nj" resolve="CyclicComponentDependenciesFromStartingPointHelper" />
+        <node concept="3uibUv" id="13En2Fwikfo" role="11_B2D">
+          <ref role="3uigEE" to="lui2:~SModuleReference" resolve="SModuleReference" />
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="13En2Fw6BGo" role="jymVt" />
+    <node concept="2YIFZL" id="13En2FvVD7A" role="jymVt">
+      <property role="TrG5h" value="getDependenciesHelper" />
+      <node concept="3clFbS" id="13En2FvVD7D" role="3clF47">
+        <node concept="3cpWs8" id="13En2Fwb4rR" role="3cqZAp">
+          <node concept="3cpWsn" id="13En2Fwb4rS" role="3cpWs9">
+            <property role="TrG5h" value="dependencyResolver" />
+            <node concept="1ajhzC" id="13En2Fwb4rK" role="1tU5fm">
+              <node concept="_YKpA" id="13En2Fwb4rL" role="1ajw0F">
+                <node concept="3uibUv" id="13En2Fwb4rM" role="_ZDj9">
+                  <ref role="3uigEE" to="lui2:~SModuleReference" resolve="SModuleReference" />
+                </node>
+              </node>
+              <node concept="3uibUv" id="13En2Fwb4rN" role="1ajw0F">
+                <ref role="3uigEE" to="lui2:~SModuleReference" resolve="SModuleReference" />
+              </node>
+              <node concept="3uibUv" id="13En2Fwb4rO" role="1ajw0F">
+                <ref role="3uigEE" node="13En2FvhV7b" resolve="CyclicGenericDependenciesHelper.Option" />
+              </node>
+              <node concept="A3Dl8" id="13En2Fwb4rP" role="1ajl9A">
+                <node concept="3uibUv" id="13En2Fwb4rQ" role="A3Ik2">
+                  <ref role="3uigEE" to="lui2:~SModuleReference" resolve="SModuleReference" />
                 </node>
               </node>
             </node>
-            <node concept="2ShNRf" id="3b1aCyg5vwQ" role="33vP2m">
-              <node concept="Tc6Ow" id="3b1aCyg5zmN" role="2ShVmc">
-                <node concept="2hMVRd" id="3b1aCygb9R8" role="HW$YZ">
-                  <node concept="3uibUv" id="3b1aCygb9Ra" role="2hN53Y">
-                    <ref role="3uigEE" to="lui2:~SModule" resolve="SModule" />
+            <node concept="1bVj0M" id="13En2Fwb4rT" role="33vP2m">
+              <node concept="gl6BB" id="13En2Fwb4rU" role="1bW2Oz">
+                <property role="TrG5h" value="modules" />
+                <node concept="2jxLKc" id="13En2Fwb4rV" role="1tU5fm" />
+              </node>
+              <node concept="gl6BB" id="13En2Fwb4rW" role="1bW2Oz">
+                <property role="TrG5h" value="moduleReference" />
+                <node concept="2jxLKc" id="13En2Fwb4rX" role="1tU5fm" />
+              </node>
+              <node concept="gl6BB" id="13En2Fwb4rY" role="1bW2Oz">
+                <property role="TrG5h" value="option" />
+                <node concept="2jxLKc" id="13En2Fwb4rZ" role="1tU5fm" />
+              </node>
+              <node concept="3clFbS" id="13En2Fwb4s0" role="1bW5cS">
+                <node concept="3cpWs8" id="13En2Fwb4s1" role="3cqZAp">
+                  <node concept="3cpWsn" id="13En2Fwb4s2" role="3cpWs9">
+                    <property role="TrG5h" value="currentDependencies" />
+                    <node concept="2hMVRd" id="13En2Fwb4s3" role="1tU5fm">
+                      <node concept="3uibUv" id="13En2Fwb4s4" role="2hN53Y">
+                        <ref role="3uigEE" to="lui2:~SModuleReference" resolve="SModuleReference" />
+                      </node>
+                    </node>
+                    <node concept="2ShNRf" id="13En2Fwb4s5" role="33vP2m">
+                      <node concept="2i4dXS" id="13En2Fwb4s6" role="2ShVmc">
+                        <node concept="3uibUv" id="13En2Fwb4s7" role="HW$YZ">
+                          <ref role="3uigEE" to="lui2:~SModuleReference" resolve="SModuleReference" />
+                        </node>
+                      </node>
+                    </node>
                   </node>
                 </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbH" id="3b1aCyg4Wmh" role="3cqZAp" />
-        <node concept="3cpWs8" id="3b1aCyg60tW" role="3cqZAp">
-          <node concept="3cpWsn" id="3b1aCyg60tZ" role="3cpWs9">
-            <property role="TrG5h" value="tmp" />
-            <node concept="_YKpA" id="3b1aCyg60tS" role="1tU5fm">
-              <node concept="3uibUv" id="3b1aCyg64f3" role="_ZDj9">
-                <ref role="3uigEE" to="lui2:~SModule" resolve="SModule" />
-              </node>
-            </node>
-            <node concept="2ShNRf" id="3b1aCyg6bPU" role="33vP2m">
-              <node concept="Tc6Ow" id="3b1aCyg6goA" role="2ShVmc">
-                <node concept="3uibUv" id="3b1aCyg6mcI" role="HW$YZ">
-                  <ref role="3uigEE" to="lui2:~SModule" resolve="SModule" />
-                </node>
-                <node concept="37vLTw" id="3b1aCyg6tHL" role="I$8f6">
-                  <ref role="3cqZAo" node="44nYoQPiJ5a" resolve="modules" />
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="1Dw8fO" id="3b1aCyg6$Ar" role="3cqZAp">
-          <node concept="3clFbS" id="3b1aCyg6$At" role="2LFqv$">
-            <node concept="3cpWs8" id="3b1aCyg7Be9" role="3cqZAp">
-              <node concept="3cpWsn" id="3b1aCyg7Bec" role="3cpWs9">
-                <property role="TrG5h" value="crtStronglyConnectedComponent" />
-                <node concept="2hMVRd" id="3b1aCygbeH9" role="1tU5fm">
-                  <node concept="3uibUv" id="3b1aCygbeHb" role="2hN53Y">
-                    <ref role="3uigEE" to="lui2:~SModule" resolve="SModule" />
-                  </node>
-                </node>
-                <node concept="2ShNRf" id="3b1aCyg7ZD$" role="33vP2m">
-                  <node concept="2i4dXS" id="3b1aCygbbp1" role="2ShVmc">
-                    <node concept="3uibUv" id="3b1aCygbbp3" role="HW$YZ">
+                <node concept="3cpWs8" id="13En2Fwb4s8" role="3cqZAp">
+                  <node concept="3cpWsn" id="13En2Fwb4s9" role="3cpWs9">
+                    <property role="TrG5h" value="module" />
+                    <node concept="3uibUv" id="13En2Fwb4sa" role="1tU5fm">
                       <ref role="3uigEE" to="lui2:~SModule" resolve="SModule" />
                     </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3clFbF" id="3b1aCyg9Scs" role="3cqZAp">
-              <node concept="2OqwBi" id="3b1aCyg9WhV" role="3clFbG">
-                <node concept="37vLTw" id="3b1aCyg9Scq" role="2Oq$k0">
-                  <ref role="3cqZAo" node="3b1aCyg53pp" resolve="listOfStronglyConnectedComponents" />
-                </node>
-                <node concept="TSZUe" id="3b1aCyga1fh" role="2OqNvi">
-                  <node concept="37vLTw" id="3b1aCyga4GM" role="25WWJ7">
-                    <ref role="3cqZAo" node="3b1aCyg7Bec" resolve="crtStronglyConnectedComponent" />
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3cpWs8" id="3b1aCyg7aDR" role="3cqZAp">
-              <node concept="3cpWsn" id="3b1aCyg7aDS" role="3cpWs9">
-                <property role="TrG5h" value="crtModule" />
-                <node concept="3uibUv" id="3b1aCyg7aDT" role="1tU5fm">
-                  <ref role="3uigEE" to="lui2:~SModule" resolve="SModule" />
-                </node>
-                <node concept="2OqwBi" id="3b1aCyg7jOv" role="33vP2m">
-                  <node concept="37vLTw" id="3b1aCyg7gY7" role="2Oq$k0">
-                    <ref role="3cqZAo" node="3b1aCyg60tZ" resolve="tmp" />
-                  </node>
-                  <node concept="34jXtK" id="3b1aCyg7nda" role="2OqNvi">
-                    <node concept="37vLTw" id="3b1aCyg7qeQ" role="25WWJ7">
-                      <ref role="3cqZAo" node="3b1aCyg6$Au" resolve="i" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3clFbF" id="3b1aCyg8iD3" role="3cqZAp">
-              <node concept="2OqwBi" id="3b1aCyg8mK_" role="3clFbG">
-                <node concept="37vLTw" id="3b1aCyg8iD1" role="2Oq$k0">
-                  <ref role="3cqZAo" node="3b1aCyg7Bec" resolve="crtStronglyConnectedComponent" />
-                </node>
-                <node concept="TSZUe" id="3b1aCyg8rba" role="2OqNvi">
-                  <node concept="37vLTw" id="3b1aCyg8uyp" role="25WWJ7">
-                    <ref role="3cqZAo" node="3b1aCyg7aDS" resolve="crtModule" />
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="2Gpval" id="3b1aCyg8DTD" role="3cqZAp">
-              <node concept="2GrKxI" id="3b1aCyg8DTF" role="2Gsz3X">
-                <property role="TrG5h" value="dep" />
-              </node>
-              <node concept="3EllGN" id="3b1aCyg8P2G" role="2GsD0m">
-                <node concept="37vLTw" id="3b1aCyg8RNL" role="3ElVtu">
-                  <ref role="3cqZAo" node="3b1aCyg7aDS" resolve="crtModule" />
-                </node>
-                <node concept="37vLTw" id="3b1aCyg8MpE" role="3ElQJh">
-                  <ref role="3cqZAo" node="3b1aCyg4IDU" resolve="indirectDependencies" />
-                </node>
-              </node>
-              <node concept="3clFbS" id="3b1aCyg8DTJ" role="2LFqv$">
-                <node concept="3clFbJ" id="3b1aCyg8Vxo" role="3cqZAp">
-                  <node concept="2OqwBi" id="3b1aCyg96ZZ" role="3clFbw">
-                    <node concept="3EllGN" id="3b1aCyg91Fh" role="2Oq$k0">
-                      <node concept="2GrUjf" id="3b1aCyg94Os" role="3ElVtu">
-                        <ref role="2Gs0qQ" node="3b1aCyg8DTF" resolve="dep" />
+                    <node concept="2OqwBi" id="13En2Fwb4sb" role="33vP2m">
+                      <node concept="37vLTw" id="13En2Fwb4sc" role="2Oq$k0">
+                        <ref role="3cqZAo" node="13En2Fwb4rW" resolve="moduleReference" />
                       </node>
-                      <node concept="37vLTw" id="3b1aCyg8Ywa" role="3ElQJh">
-                        <ref role="3cqZAo" node="3b1aCyg4IDU" resolve="indirectDependencies" />
-                      </node>
-                    </node>
-                    <node concept="3JPx81" id="3b1aCyg9cCK" role="2OqNvi">
-                      <node concept="37vLTw" id="3b1aCyg9h9V" role="25WWJ7">
-                        <ref role="3cqZAo" node="3b1aCyg7aDS" resolve="crtModule" />
-                      </node>
-                    </node>
-                  </node>
-                  <node concept="3clFbS" id="3b1aCyg8Vxq" role="3clFbx">
-                    <node concept="3clFbF" id="3b1aCyg9l6S" role="3cqZAp">
-                      <node concept="2OqwBi" id="3b1aCyg9oKC" role="3clFbG">
-                        <node concept="37vLTw" id="3b1aCyg9l6R" role="2Oq$k0">
-                          <ref role="3cqZAo" node="3b1aCyg7Bec" resolve="crtStronglyConnectedComponent" />
-                        </node>
-                        <node concept="TSZUe" id="3b1aCyg9sYY" role="2OqNvi">
-                          <node concept="2GrUjf" id="3b1aCyg9vYs" role="25WWJ7">
-                            <ref role="2Gs0qQ" node="3b1aCyg8DTF" resolve="dep" />
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                    <node concept="3clFbF" id="3b1aCyg9A$5" role="3cqZAp">
-                      <node concept="2OqwBi" id="3b1aCyg9EdY" role="3clFbG">
-                        <node concept="37vLTw" id="3b1aCyg9A$3" role="2Oq$k0">
-                          <ref role="3cqZAo" node="3b1aCyg60tZ" resolve="tmp" />
-                        </node>
-                        <node concept="3dhRuq" id="3b1aCyg9HWE" role="2OqNvi">
-                          <node concept="2GrUjf" id="3b1aCyg9LAH" role="25WWJ7">
-                            <ref role="2Gs0qQ" node="3b1aCyg8DTF" resolve="dep" />
-                          </node>
+                      <node concept="liA8E" id="13En2Fwb4sd" role="2OqNvi">
+                        <ref role="37wK5l" to="lui2:~SModuleReference.resolve(org.jetbrains.mps.openapi.module.SRepository)" resolve="resolve" />
+                        <node concept="37vLTw" id="13En2Fwb4se" role="37wK5m">
+                          <ref role="3cqZAo" node="13En2Fw00za" resolve="repository" />
                         </node>
                       </node>
                     </node>
                   </node>
                 </node>
-              </node>
-            </node>
-          </node>
-          <node concept="3cpWsn" id="3b1aCyg6$Au" role="1Duv9x">
-            <property role="TrG5h" value="i" />
-            <node concept="10Oyi0" id="3b1aCyg6Cf7" role="1tU5fm" />
-            <node concept="3cmrfG" id="3b1aCyg6Ivs" role="33vP2m">
-              <property role="3cmrfH" value="0" />
-            </node>
-          </node>
-          <node concept="3eOVzh" id="3b1aCyg6OpP" role="1Dwp0S">
-            <node concept="2OqwBi" id="3b1aCyg6Wh7" role="3uHU7w">
-              <node concept="37vLTw" id="3b1aCyg6SB0" role="2Oq$k0">
-                <ref role="3cqZAo" node="3b1aCyg60tZ" resolve="tmp" />
-              </node>
-              <node concept="34oBXx" id="3b1aCyg70ft" role="2OqNvi" />
-            </node>
-            <node concept="37vLTw" id="3b1aCyg6LcO" role="3uHU7B">
-              <ref role="3cqZAo" node="3b1aCyg6$Au" resolve="i" />
-            </node>
-          </node>
-          <node concept="3uNrnE" id="3b1aCyg73RH" role="1Dwrff">
-            <node concept="37vLTw" id="3b1aCyg73RJ" role="2$L3a6">
-              <ref role="3cqZAo" node="3b1aCyg6$Au" resolve="i" />
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbH" id="3b1aCyg6x9I" role="3cqZAp" />
-        <node concept="2Gpval" id="44nYoQPiJ5t" role="3cqZAp">
-          <node concept="2GrKxI" id="44nYoQPiJ5u" role="2Gsz3X">
-            <property role="TrG5h" value="crtStronglyConnectedComponent" />
-          </node>
-          <node concept="37vLTw" id="44nYoQPiJ5v" role="2GsD0m">
-            <ref role="3cqZAo" node="3b1aCyg53pp" resolve="listOfStronglyConnectedComponents" />
-          </node>
-          <node concept="3clFbS" id="44nYoQPiJ5w" role="2LFqv$">
-            <node concept="3clFbJ" id="44nYoQPiJ5x" role="3cqZAp">
-              <node concept="3eOSWO" id="44nYoQPiJ5y" role="3clFbw">
-                <node concept="37vLTw" id="44nYoQPiJ5z" role="3uHU7w">
-                  <ref role="3cqZAo" node="44nYoQPiJ5g" resolve="minLength" />
-                </node>
-                <node concept="2OqwBi" id="44nYoQPiJ5$" role="3uHU7B">
-                  <node concept="34oBXx" id="3b1aCygan_Y" role="2OqNvi" />
-                  <node concept="2GrUjf" id="44nYoQPiJ5A" role="2Oq$k0">
-                    <ref role="2Gs0qQ" node="44nYoQPiJ5u" resolve="crtStronglyConnectedComponent" />
+                <node concept="2Gpval" id="13En2Fwb4sf" role="3cqZAp">
+                  <node concept="2GrKxI" id="13En2Fwb4sg" role="2Gsz3X">
+                    <property role="TrG5h" value="dep" />
                   </node>
-                </node>
-              </node>
-              <node concept="3clFbS" id="44nYoQPiJ5B" role="3clFbx">
-                <node concept="3clFbF" id="44nYoQPiJ5C" role="3cqZAp">
-                  <node concept="2OqwBi" id="44nYoQPiJ5D" role="3clFbG">
-                    <node concept="37vLTw" id="44nYoQPiJ5E" role="2Oq$k0">
-                      <ref role="3cqZAo" node="44nYoQPiJ5d" resolve="res" />
-                    </node>
-                    <node concept="TSZUe" id="44nYoQPiJ5F" role="2OqNvi">
-                      <node concept="3cpWs3" id="44nYoQPiJ5G" role="25WWJ7">
-                        <node concept="3cpWs3" id="44nYoQPiJ5H" role="3uHU7B">
-                          <node concept="3cpWs3" id="44nYoQPiJ5I" role="3uHU7B">
-                            <node concept="Xl_RD" id="44nYoQPiJ5J" role="3uHU7B">
-                              <property role="Xl_RC" value="Strongly connected component with length " />
+                  <node concept="3clFbS" id="13En2Fwb4sh" role="2LFqv$">
+                    <node concept="3cpWs8" id="13En2Fwb4si" role="3cqZAp">
+                      <node concept="3cpWsn" id="13En2Fwb4sj" role="3cpWs9">
+                        <property role="TrG5h" value="target" />
+                        <node concept="3uibUv" id="13En2Fwb4sk" role="1tU5fm">
+                          <ref role="3uigEE" to="lui2:~SModuleReference" resolve="SModuleReference" />
+                        </node>
+                        <node concept="2OqwBi" id="13En2Fwb4sl" role="33vP2m">
+                          <node concept="2OqwBi" id="13En2Fwb4sm" role="2Oq$k0">
+                            <node concept="2GrUjf" id="13En2Fwb4sn" role="2Oq$k0">
+                              <ref role="2Gs0qQ" node="13En2Fwb4sg" resolve="dep" />
                             </node>
-                            <node concept="2OqwBi" id="44nYoQPiJ5K" role="3uHU7w">
-                              <node concept="2GrUjf" id="44nYoQPiJ5L" role="2Oq$k0">
-                                <ref role="2Gs0qQ" node="44nYoQPiJ5u" resolve="crtStronglyConnectedComponent" />
+                            <node concept="liA8E" id="13En2Fwb4so" role="2OqNvi">
+                              <ref role="37wK5l" to="lui2:~SDependency.getTarget()" resolve="getTarget" />
+                            </node>
+                          </node>
+                          <node concept="liA8E" id="13En2Fwb4sp" role="2OqNvi">
+                            <ref role="37wK5l" to="lui2:~SModule.getModuleReference()" resolve="getModuleReference" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="3clFbJ" id="13En2Fwb4sq" role="3cqZAp">
+                      <node concept="1Wc70l" id="13En2Fwb4sr" role="3clFbw">
+                        <node concept="2OqwBi" id="13En2Fwb4ss" role="3uHU7w">
+                          <node concept="37vLTw" id="13En2Fwb4st" role="2Oq$k0">
+                            <ref role="3cqZAo" node="13En2Fwb4rU" resolve="modules" />
+                          </node>
+                          <node concept="3JPx81" id="13En2Fwb4su" role="2OqNvi">
+                            <node concept="37vLTw" id="13En2Fwb4sv" role="25WWJ7">
+                              <ref role="3cqZAo" node="13En2Fwb4sj" resolve="target" />
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="3y3z36" id="13En2Fwb4sw" role="3uHU7B">
+                          <node concept="37vLTw" id="13En2Fwb4sx" role="3uHU7B">
+                            <ref role="3cqZAo" node="13En2Fwb4sj" resolve="target" />
+                          </node>
+                          <node concept="10Nm6u" id="13En2Fwb4sy" role="3uHU7w" />
+                        </node>
+                      </node>
+                      <node concept="3clFbS" id="13En2Fwb4sz" role="3clFbx">
+                        <node concept="3clFbF" id="13En2Fwb4s$" role="3cqZAp">
+                          <node concept="2OqwBi" id="13En2Fwb4s_" role="3clFbG">
+                            <node concept="37vLTw" id="13En2Fwb4sA" role="2Oq$k0">
+                              <ref role="3cqZAo" node="13En2Fwb4s2" resolve="currentDependencies" />
+                            </node>
+                            <node concept="TSZUe" id="13En2Fwb4sB" role="2OqNvi">
+                              <node concept="37vLTw" id="13En2Fwb4sC" role="25WWJ7">
+                                <ref role="3cqZAo" node="13En2Fwb4sj" resolve="target" />
                               </node>
-                              <node concept="34oBXx" id="3b1aCygapnp" role="2OqNvi" />
                             </node>
                           </node>
-                          <node concept="Xl_RD" id="44nYoQPiJ5N" role="3uHU7w">
-                            <property role="Xl_RC" value=" found: " />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="2OqwBi" id="13En2Fwb4sD" role="2GsD0m">
+                    <node concept="37vLTw" id="13En2Fwb4sE" role="2Oq$k0">
+                      <ref role="3cqZAo" node="13En2Fwb4s9" resolve="module" />
+                    </node>
+                    <node concept="liA8E" id="13En2Fwb4sF" role="2OqNvi">
+                      <ref role="37wK5l" to="lui2:~SModule.getDeclaredDependencies()" resolve="getDeclaredDependencies" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="3clFbJ" id="13En2Fwb4sG" role="3cqZAp">
+                  <node concept="3clFbS" id="13En2Fwb4sH" role="3clFbx">
+                    <node concept="2Gpval" id="13En2Fwb4sI" role="3cqZAp">
+                      <node concept="2GrKxI" id="13En2Fwb4sJ" role="2Gsz3X">
+                        <property role="TrG5h" value="lang" />
+                      </node>
+                      <node concept="3clFbS" id="13En2Fwb4sK" role="2LFqv$">
+                        <node concept="3cpWs8" id="13En2Fwb4sL" role="3cqZAp">
+                          <node concept="3cpWsn" id="13En2Fwb4sM" role="3cpWs9">
+                            <property role="TrG5h" value="target" />
+                            <node concept="3uibUv" id="13En2Fwb4sN" role="1tU5fm">
+                              <ref role="3uigEE" to="lui2:~SModuleReference" resolve="SModuleReference" />
+                            </node>
+                            <node concept="2OqwBi" id="13En2Fwb4sO" role="33vP2m">
+                              <node concept="2OqwBi" id="13En2Fwb4sP" role="2Oq$k0">
+                                <node concept="2GrUjf" id="13En2Fwb4sQ" role="2Oq$k0">
+                                  <ref role="2Gs0qQ" node="13En2Fwb4sJ" resolve="lang" />
+                                </node>
+                                <node concept="liA8E" id="13En2Fwb4sR" role="2OqNvi">
+                                  <ref role="37wK5l" to="c17a:~SLanguage.getSourceModule()" resolve="getSourceModule" />
+                                </node>
+                              </node>
+                              <node concept="liA8E" id="13En2Fwb4sS" role="2OqNvi">
+                                <ref role="37wK5l" to="lui2:~SModule.getModuleReference()" resolve="getModuleReference" />
+                              </node>
+                            </node>
                           </node>
                         </node>
-                        <node concept="2OqwBi" id="44nYoQPiJ5O" role="3uHU7w">
-                          <node concept="2S7cBI" id="44nYoQPiJ5Q" role="2OqNvi">
-                            <node concept="1bVj0M" id="44nYoQPiJ5R" role="23t8la">
-                              <node concept="3clFbS" id="44nYoQPiJ5S" role="1bW5cS">
-                                <node concept="3clFbF" id="44nYoQPiJ5T" role="3cqZAp">
-                                  <node concept="2OqwBi" id="44nYoQPiJ5U" role="3clFbG">
-                                    <node concept="37vLTw" id="44nYoQPiJ5V" role="2Oq$k0">
-                                      <ref role="3cqZAo" node="6T$NbgWIi01" resolve="it" />
-                                    </node>
-                                    <node concept="liA8E" id="44nYoQPiJ5W" role="2OqNvi">
-                                      <ref role="37wK5l" to="lui2:~SModule.getModuleName()" resolve="getModuleName" />
-                                    </node>
+                        <node concept="3clFbJ" id="13En2Fwb4sT" role="3cqZAp">
+                          <node concept="1Wc70l" id="13En2Fwb4sU" role="3clFbw">
+                            <node concept="2OqwBi" id="13En2Fwb4sV" role="3uHU7w">
+                              <node concept="37vLTw" id="13En2Fwb4sW" role="2Oq$k0">
+                                <ref role="3cqZAo" node="13En2Fwb4rU" resolve="modules" />
+                              </node>
+                              <node concept="3JPx81" id="13En2Fwb4sX" role="2OqNvi">
+                                <node concept="37vLTw" id="13En2Fwb4sY" role="25WWJ7">
+                                  <ref role="3cqZAo" node="13En2Fwb4sM" resolve="target" />
+                                </node>
+                              </node>
+                            </node>
+                            <node concept="3y3z36" id="13En2Fwb4sZ" role="3uHU7B">
+                              <node concept="37vLTw" id="13En2Fwb4t0" role="3uHU7B">
+                                <ref role="3cqZAo" node="13En2Fwb4sM" resolve="target" />
+                              </node>
+                              <node concept="10Nm6u" id="13En2Fwb4t1" role="3uHU7w" />
+                            </node>
+                          </node>
+                          <node concept="3clFbS" id="13En2Fwb4t2" role="3clFbx">
+                            <node concept="3clFbF" id="13En2Fwb4t3" role="3cqZAp">
+                              <node concept="2OqwBi" id="13En2Fwb4t4" role="3clFbG">
+                                <node concept="37vLTw" id="13En2Fwb4t5" role="2Oq$k0">
+                                  <ref role="3cqZAo" node="13En2Fwb4s2" resolve="currentDependencies" />
+                                </node>
+                                <node concept="TSZUe" id="13En2Fwb4t6" role="2OqNvi">
+                                  <node concept="37vLTw" id="13En2Fwb4t7" role="25WWJ7">
+                                    <ref role="3cqZAo" node="13En2Fwb4sM" resolve="target" />
                                   </node>
                                 </node>
                               </node>
-                              <node concept="gl6BB" id="6T$NbgWIi01" role="1bW2Oz">
-                                <property role="TrG5h" value="it" />
-                                <node concept="2jxLKc" id="6T$NbgWIi02" role="1tU5fm" />
-                              </node>
                             </node>
-                            <node concept="1nlBCl" id="44nYoQPiJ5Z" role="2S7zOq">
-                              <property role="3clFbU" value="true" />
-                            </node>
-                          </node>
-                          <node concept="2GrUjf" id="3b1aCygauqb" role="2Oq$k0">
-                            <ref role="2Gs0qQ" node="44nYoQPiJ5u" resolve="crtStronglyConnectedComponent" />
                           </node>
                         </node>
                       </node>
+                      <node concept="2OqwBi" id="13En2Fwb4t8" role="2GsD0m">
+                        <node concept="37vLTw" id="13En2Fwb4t9" role="2Oq$k0">
+                          <ref role="3cqZAo" node="13En2Fwb4s9" resolve="module" />
+                        </node>
+                        <node concept="liA8E" id="13En2Fwb4ta" role="2OqNvi">
+                          <ref role="37wK5l" to="lui2:~SModule.getUsedLanguages()" resolve="getUsedLanguages" />
+                        </node>
+                      </node>
                     </node>
+                  </node>
+                  <node concept="37vLTw" id="13En2Fwb4tb" role="3clFbw">
+                    <ref role="3cqZAo" node="13En2FvW8Iz" resolve="considerUsedLanguages" />
+                  </node>
+                </node>
+                <node concept="3clFbF" id="13En2Fwb4tc" role="3cqZAp">
+                  <node concept="37vLTw" id="13En2Fwb4td" role="3clFbG">
+                    <ref role="3cqZAo" node="13En2Fwb4s2" resolve="currentDependencies" />
                   </node>
                 </node>
               </node>
             </node>
           </node>
         </node>
-      </node>
-    </node>
-    <node concept="2tJIrI" id="47tbZooUKUT" role="jymVt" />
-    <node concept="2YIFZL" id="47tbZooV55x" role="jymVt">
-      <property role="TrG5h" value="computeTooLargeCycles" />
-      <node concept="37vLTG" id="47tbZooV7SE" role="3clF46">
-        <property role="TrG5h" value="modules" />
-        <node concept="_YKpA" id="47tbZooV7SF" role="1tU5fm">
-          <node concept="3uibUv" id="47tbZooV7SG" role="_ZDj9">
-            <ref role="3uigEE" to="lui2:~SModule" resolve="SModule" />
-          </node>
-        </node>
-      </node>
-      <node concept="37vLTG" id="47tbZooV7SH" role="3clF46">
-        <property role="TrG5h" value="res" />
-        <node concept="_YKpA" id="47tbZooV7SI" role="1tU5fm">
-          <node concept="17QB3L" id="47tbZooV7SJ" role="_ZDj9" />
-        </node>
-      </node>
-      <node concept="37vLTG" id="47tbZooV7SK" role="3clF46">
-        <property role="TrG5h" value="cycleLength" />
-        <node concept="10Oyi0" id="47tbZooV7SL" role="1tU5fm" />
-      </node>
-      <node concept="3cqZAl" id="47tbZooV55z" role="3clF45" />
-      <node concept="3clFbS" id="47tbZooV55_" role="3clF47">
-        <node concept="3cpWs8" id="47tbZooVkdG" role="3cqZAp">
-          <node concept="3cpWsn" id="47tbZooVkdH" role="3cpWs9">
-            <property role="TrG5h" value="allCycles" />
-            <node concept="2hMVRd" id="5EjFUKYhsce" role="1tU5fm">
-              <node concept="3uibUv" id="3b1aCyfUejc" role="2hN53Y">
-                <ref role="3uigEE" to="33ny:~ArrayList" resolve="ArrayList" />
-                <node concept="3uibUv" id="3b1aCyfUejd" role="11_B2D">
-                  <ref role="3uigEE" to="lui2:~SModule" resolve="SModule" />
-                </node>
+        <node concept="3cpWs8" id="13En2Fwc0bh" role="3cqZAp">
+          <node concept="3cpWsn" id="13En2Fwc0bk" role="3cpWs9">
+            <property role="TrG5h" value="componentNameResolver" />
+            <node concept="1ajhzC" id="13En2Fwc0bm" role="1tU5fm">
+              <node concept="17QB3L" id="13En2Fwc0bn" role="1ajl9A" />
+              <node concept="3uibUv" id="13En2Fwc0bo" role="1ajw0F">
+                <ref role="3uigEE" to="lui2:~SModuleReference" resolve="SModuleReference" />
               </node>
             </node>
-            <node concept="1rXfSq" id="47tbZooVkdI" role="33vP2m">
-              <ref role="37wK5l" node="47tbZooU$aK" resolve="computeAllCycles" />
-              <node concept="37vLTw" id="47tbZooVkdJ" role="37wK5m">
-                <ref role="3cqZAo" node="47tbZooV7SE" resolve="modules" />
+            <node concept="1bVj0M" id="13En2Fwch$M" role="33vP2m">
+              <node concept="3clFbS" id="13En2Fwch$O" role="1bW5cS">
+                <node concept="3clFbF" id="13En2FwcA4v" role="3cqZAp">
+                  <node concept="2OqwBi" id="13En2FwcAKy" role="3clFbG">
+                    <node concept="37vLTw" id="13En2FwcA4u" role="2Oq$k0">
+                      <ref role="3cqZAo" node="13En2FwcmFW" resolve="moduleReference" />
+                    </node>
+                    <node concept="liA8E" id="13En2FwcG3l" role="2OqNvi">
+                      <ref role="37wK5l" to="lui2:~SModuleReference.getModuleName()" resolve="getModuleName" />
+                    </node>
+                  </node>
+                </node>
               </node>
-              <node concept="3clFbT" id="1SbpUw9Rtxg" role="37wK5m" />
-              <node concept="3cmrfG" id="1SbpUw9TFni" role="37wK5m">
-                <property role="3cmrfH" value="-1" />
+              <node concept="37vLTG" id="13En2FwcmFW" role="1bW2Oz">
+                <property role="TrG5h" value="moduleReference" />
+                <node concept="3uibUv" id="13En2FwcmFV" role="1tU5fm">
+                  <ref role="3uigEE" to="lui2:~SModuleReference" resolve="SModuleReference" />
+                </node>
               </node>
             </node>
           </node>
         </node>
-        <node concept="2Gpval" id="47tbZooVr5L" role="3cqZAp">
-          <node concept="2GrKxI" id="47tbZooVr5N" role="2Gsz3X">
-            <property role="TrG5h" value="crtCycle" />
-          </node>
-          <node concept="37vLTw" id="47tbZooVstM" role="2GsD0m">
-            <ref role="3cqZAo" node="47tbZooVkdH" resolve="allCycles" />
-          </node>
-          <node concept="3clFbS" id="47tbZooVr5R" role="2LFqv$">
-            <node concept="3clFbJ" id="47tbZooVtgN" role="3cqZAp">
-              <node concept="3eOSWO" id="3b1aCyfYjcv" role="3clFbw">
-                <node concept="2OqwBi" id="47tbZooVum3" role="3uHU7B">
-                  <node concept="liA8E" id="3b1aCyfUg_9" role="2OqNvi">
-                    <ref role="37wK5l" to="33ny:~ArrayList.size()" resolve="size" />
-                  </node>
-                  <node concept="2GrUjf" id="47tbZooZWiy" role="2Oq$k0">
-                    <ref role="2Gs0qQ" node="47tbZooVr5N" resolve="crtCycle" />
-                  </node>
-                </node>
-                <node concept="37vLTw" id="47tbZooVyjL" role="3uHU7w">
-                  <ref role="3cqZAo" node="47tbZooV7SK" resolve="cycleLength" />
-                </node>
+        <node concept="3clFbH" id="13En2FwbFJn" role="3cqZAp" />
+        <node concept="3clFbF" id="13En2FvW0ML" role="3cqZAp">
+          <node concept="2ShNRf" id="13En2FvW0MJ" role="3clFbG">
+            <node concept="1pGfFk" id="13En2FvW4Tb" role="2ShVmc">
+              <property role="373rjd" value="true" />
+              <ref role="37wK5l" node="13En2FvqZ5e" />
+              <node concept="3uibUv" id="13En2FvXXuX" role="1pMfVU">
+                <ref role="3uigEE" to="lui2:~SModuleReference" resolve="SModuleReference" />
               </node>
-              <node concept="3clFbS" id="47tbZooVtgP" role="3clFbx">
-                <node concept="3cpWs8" id="3b1aCyfYkRR" role="3cqZAp">
-                  <node concept="3cpWsn" id="3b1aCyfYkRS" role="3cpWs9">
-                    <property role="TrG5h" value="msg" />
-                    <node concept="17QB3L" id="3b1aCyfYjOq" role="1tU5fm" />
-                    <node concept="3cpWs3" id="3b1aCyfYkRT" role="33vP2m">
-                      <node concept="3cpWs3" id="3b1aCyfYkRU" role="3uHU7B">
-                        <node concept="3cpWs3" id="3b1aCyfYkRV" role="3uHU7B">
-                          <node concept="Xl_RD" id="3b1aCyfYkRW" role="3uHU7B">
-                            <property role="Xl_RC" value="Cyclic dependency with length " />
-                          </node>
-                          <node concept="2OqwBi" id="3b1aCyfYkRX" role="3uHU7w">
-                            <node concept="2GrUjf" id="3b1aCyfYkRY" role="2Oq$k0">
-                              <ref role="2Gs0qQ" node="47tbZooVr5N" resolve="crtCycle" />
-                            </node>
-                            <node concept="liA8E" id="3b1aCyfYkRZ" role="2OqNvi">
-                              <ref role="37wK5l" to="33ny:~ArrayList.size()" resolve="size" />
-                            </node>
-                          </node>
-                        </node>
-                        <node concept="Xl_RD" id="3b1aCyfYkS0" role="3uHU7w">
-                          <property role="Xl_RC" value=" found: " />
-                        </node>
-                      </node>
-                      <node concept="1rXfSq" id="1gULBtOfXD_" role="3uHU7w">
-                        <ref role="37wK5l" node="1gULBtOgaIe" resolve="formatCycle" />
-                        <node concept="2GrUjf" id="1gULBtOfZOQ" role="37wK5m">
-                          <ref role="2Gs0qQ" node="47tbZooVr5N" resolve="crtCycle" />
-                        </node>
-                      </node>
-                    </node>
-                  </node>
+              <node concept="37vLTw" id="13En2Fwb4te" role="37wK5m">
+                <ref role="3cqZAo" node="13En2Fwb4rS" resolve="function" />
+              </node>
+              <node concept="37vLTw" id="13En2FvYa6I" role="37wK5m">
+                <ref role="3cqZAo" node="1gULBtOjnwD" resolve="COMPARE_MODULE_REFS" />
+              </node>
+              <node concept="37vLTw" id="13En2FwcX1e" role="37wK5m">
+                <ref role="3cqZAo" node="13En2Fwc0bk" resolve="componentNameResolver" />
+              </node>
+              <node concept="3K4zz7" id="13En2FvY$PS" role="37wK5m">
+                <node concept="37vLTw" id="13En2FvZ3qG" role="3K4E3e">
+                  <ref role="3cqZAo" node="13En2FvYTVe" resolve="CONSIDER_USED_LANGUAGES_OPTION" />
                 </node>
-                <node concept="3clFbF" id="47tbZooVyQV" role="3cqZAp">
-                  <node concept="2OqwBi" id="47tbZooVyQW" role="3clFbG">
-                    <node concept="37vLTw" id="47tbZooVyQX" role="2Oq$k0">
-                      <ref role="3cqZAo" node="47tbZooV7SH" resolve="res" />
-                    </node>
-                    <node concept="TSZUe" id="47tbZooVyQY" role="2OqNvi">
-                      <node concept="37vLTw" id="3b1aCyfYkSg" role="25WWJ7">
-                        <ref role="3cqZAo" node="3b1aCyfYkRS" resolve="msg" />
-                      </node>
-                    </node>
-                  </node>
+                <node concept="10Nm6u" id="13En2FvZ8ac" role="3K4GZi" />
+                <node concept="37vLTw" id="13En2FvYvja" role="3K4Cdx">
+                  <ref role="3cqZAo" node="13En2FvW8Iz" resolve="considerUsedLanguages" />
                 </node>
               </node>
             </node>
           </node>
         </node>
       </node>
-    </node>
-    <node concept="2tJIrI" id="1Yf9e2l9isn" role="jymVt" />
-    <node concept="2YIFZL" id="1Yf9e2l9dIN" role="jymVt">
-      <property role="TrG5h" value="computeCyclesWithSize" />
-      <node concept="37vLTG" id="1Yf9e2l9dIO" role="3clF46">
-        <property role="TrG5h" value="modules" />
-        <node concept="_YKpA" id="1Yf9e2l9dIP" role="1tU5fm">
-          <node concept="3uibUv" id="1Yf9e2l9dIQ" role="_ZDj9">
-            <ref role="3uigEE" to="lui2:~SModule" resolve="SModule" />
-          </node>
+      <node concept="3Tm1VV" id="13En2FvVul5" role="1B3o_S" />
+      <node concept="3uibUv" id="13En2FvVLgw" role="3clF45">
+        <ref role="3uigEE" node="13En2Fv5upa" resolve="CyclicGenericDependenciesHelper" />
+        <node concept="3uibUv" id="13En2Fw8y8Y" role="11_B2D">
+          <ref role="3uigEE" to="lui2:~SModuleReference" resolve="SModuleReference" />
         </node>
       </node>
-      <node concept="37vLTG" id="1Yf9e2l9dIR" role="3clF46">
-        <property role="TrG5h" value="res" />
-        <node concept="_YKpA" id="1Yf9e2l9dIS" role="1tU5fm">
-          <node concept="17QB3L" id="1Yf9e2l9dIT" role="_ZDj9" />
-        </node>
-      </node>
-      <node concept="37vLTG" id="1SbpUw9TMIL" role="3clF46">
+      <node concept="37vLTG" id="13En2FvW8Iz" role="3clF46">
         <property role="TrG5h" value="considerUsedLanguages" />
-        <node concept="10P_77" id="1SbpUw9TOZx" role="1tU5fm" />
+        <node concept="10P_77" id="13En2FvW8Iy" role="1tU5fm" />
       </node>
-      <node concept="37vLTG" id="1Yf9e2l9dIU" role="3clF46">
-        <property role="TrG5h" value="cycleLength" />
-        <node concept="10Oyi0" id="1Yf9e2l9dIV" role="1tU5fm" />
-      </node>
-      <node concept="3cqZAl" id="1Yf9e2l9dIW" role="3clF45" />
-      <node concept="3clFbS" id="1Yf9e2l9dIX" role="3clF47">
-        <node concept="3cpWs8" id="1Yf9e2l9dIY" role="3cqZAp">
-          <node concept="3cpWsn" id="1Yf9e2l9dIZ" role="3cpWs9">
-            <property role="TrG5h" value="allCycles" />
-            <node concept="2hMVRd" id="1Yf9e2l9dJ0" role="1tU5fm">
-              <node concept="3uibUv" id="1Yf9e2l9dJ1" role="2hN53Y">
-                <ref role="3uigEE" to="33ny:~ArrayList" resolve="ArrayList" />
-                <node concept="3uibUv" id="1Yf9e2l9dJ2" role="11_B2D">
-                  <ref role="3uigEE" to="lui2:~SModule" resolve="SModule" />
-                </node>
-              </node>
-            </node>
-            <node concept="1rXfSq" id="1Yf9e2l9dJ3" role="33vP2m">
-              <ref role="37wK5l" node="47tbZooU$aK" resolve="computeAllCycles" />
-              <node concept="37vLTw" id="1Yf9e2l9dJ4" role="37wK5m">
-                <ref role="3cqZAo" node="1Yf9e2l9dIO" resolve="modules" />
-              </node>
-              <node concept="37vLTw" id="1SbpUw9U31P" role="37wK5m">
-                <ref role="3cqZAo" node="1SbpUw9TMIL" resolve="considerUsedLanguages" />
-              </node>
-              <node concept="37vLTw" id="1SbpUw9TKwI" role="37wK5m">
-                <ref role="3cqZAo" node="1Yf9e2l9dIU" resolve="cycleLength" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="2Gpval" id="1Yf9e2l9dJ5" role="3cqZAp">
-          <node concept="2GrKxI" id="1Yf9e2l9dJ6" role="2Gsz3X">
-            <property role="TrG5h" value="crtCycle" />
-          </node>
-          <node concept="37vLTw" id="1Yf9e2l9dJ7" role="2GsD0m">
-            <ref role="3cqZAo" node="1Yf9e2l9dIZ" resolve="allCycles" />
-          </node>
-          <node concept="3clFbS" id="1Yf9e2l9dJ8" role="2LFqv$">
-            <node concept="3cpWs8" id="1Yf9e2l9dJg" role="3cqZAp">
-              <node concept="3cpWsn" id="1Yf9e2l9dJh" role="3cpWs9">
-                <property role="TrG5h" value="msg" />
-                <node concept="17QB3L" id="1Yf9e2l9dJi" role="1tU5fm" />
-                <node concept="3cpWs3" id="1Yf9e2l9dJj" role="33vP2m">
-                  <node concept="3cpWs3" id="1Yf9e2l9dJk" role="3uHU7B">
-                    <node concept="3cpWs3" id="1Yf9e2l9dJl" role="3uHU7B">
-                      <node concept="Xl_RD" id="1Yf9e2l9dJm" role="3uHU7B">
-                        <property role="Xl_RC" value="Cyclic dependency with length " />
-                      </node>
-                      <node concept="2OqwBi" id="1Yf9e2l9dJn" role="3uHU7w">
-                        <node concept="2GrUjf" id="1Yf9e2l9dJo" role="2Oq$k0">
-                          <ref role="2Gs0qQ" node="1Yf9e2l9dJ6" resolve="crtCycle" />
-                        </node>
-                        <node concept="liA8E" id="1Yf9e2l9dJp" role="2OqNvi">
-                          <ref role="37wK5l" to="33ny:~ArrayList.size()" resolve="size" />
-                        </node>
-                      </node>
-                    </node>
-                    <node concept="Xl_RD" id="1Yf9e2l9dJq" role="3uHU7w">
-                      <property role="Xl_RC" value=" found: " />
-                    </node>
-                  </node>
-                  <node concept="1rXfSq" id="1Yf9e2l9dJr" role="3uHU7w">
-                    <ref role="37wK5l" node="1gULBtOgaIe" resolve="formatCycle" />
-                    <node concept="2GrUjf" id="1Yf9e2l9dJs" role="37wK5m">
-                      <ref role="2Gs0qQ" node="1Yf9e2l9dJ6" resolve="crtCycle" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3clFbF" id="1Yf9e2l9dJt" role="3cqZAp">
-              <node concept="2OqwBi" id="1Yf9e2l9dJu" role="3clFbG">
-                <node concept="37vLTw" id="1Yf9e2l9dJv" role="2Oq$k0">
-                  <ref role="3cqZAo" node="1Yf9e2l9dIR" resolve="res" />
-                </node>
-                <node concept="TSZUe" id="1Yf9e2l9dJw" role="2OqNvi">
-                  <node concept="37vLTw" id="1Yf9e2l9dJx" role="25WWJ7">
-                    <ref role="3cqZAo" node="1Yf9e2l9dJh" resolve="msg" />
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
+      <node concept="37vLTG" id="13En2Fw00za" role="3clF46">
+        <property role="TrG5h" value="repository" />
+        <node concept="3uibUv" id="13En2Fw05Ef" role="1tU5fm">
+          <ref role="3uigEE" to="lui2:~SRepository" resolve="SRepository" />
         </node>
       </node>
     </node>
     <node concept="2tJIrI" id="1gULBtOfCkN" role="jymVt" />
-    <node concept="2YIFZL" id="1gULBtOgaIe" role="jymVt">
-      <property role="TrG5h" value="formatCycle" />
-      <node concept="3clFbS" id="1gULBtOgaIf" role="3clF47">
-        <node concept="3cpWs8" id="1gULBtOgj0h" role="3cqZAp">
-          <node concept="3cpWsn" id="1gULBtOgj0k" role="3cpWs9">
-            <property role="TrG5h" value="firstModule" />
-            <node concept="10Oyi0" id="1gULBtOgj0f" role="1tU5fm" />
-            <node concept="3cmrfG" id="1gULBtOgITa" role="33vP2m">
-              <property role="3cmrfH" value="0" />
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbH" id="1gULBtOhuGj" role="3cqZAp" />
-        <node concept="1Dw8fO" id="1gULBtOgKQi" role="3cqZAp">
-          <node concept="3clFbS" id="1gULBtOgKQk" role="2LFqv$">
-            <node concept="3clFbJ" id="1gULBtOh72s" role="3cqZAp">
-              <node concept="3clFbS" id="1gULBtOh72u" role="3clFbx">
-                <node concept="3clFbF" id="1gULBtOk9Nb" role="3cqZAp">
-                  <node concept="37vLTI" id="1gULBtOkcr5" role="3clFbG">
-                    <node concept="37vLTw" id="1gULBtOkcWd" role="37vLTx">
-                      <ref role="3cqZAo" node="1gULBtOgKQl" resolve="i" />
-                    </node>
-                    <node concept="37vLTw" id="1gULBtOk9N9" role="37vLTJ">
-                      <ref role="3cqZAo" node="1gULBtOgj0k" resolve="firstModule" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-              <node concept="3eOSWO" id="1gULBtOk68M" role="3clFbw">
-                <node concept="3cmrfG" id="1gULBtOk6fO" role="3uHU7w">
-                  <property role="3cmrfH" value="0" />
-                </node>
-                <node concept="2OqwBi" id="1gULBtOjtE3" role="3uHU7B">
-                  <node concept="37vLTw" id="1gULBtOjryH" role="2Oq$k0">
-                    <ref role="3cqZAo" node="1gULBtOjnwD" resolve="COMPARE_MODULE_REFS" />
-                  </node>
-                  <node concept="liA8E" id="1gULBtOjw5k" role="2OqNvi">
-                    <ref role="37wK5l" to="33ny:~Comparator.compare(java.lang.Object,java.lang.Object)" resolve="compare" />
-                    <node concept="2OqwBi" id="1gULBtOjHua" role="37wK5m">
-                      <node concept="2OqwBi" id="1gULBtOj$6P" role="2Oq$k0">
-                        <node concept="37vLTw" id="1gULBtOjyFM" role="2Oq$k0">
-                          <ref role="3cqZAo" node="1gULBtOgaIm" resolve="cycle" />
-                        </node>
-                        <node concept="liA8E" id="1gULBtOjCbK" role="2OqNvi">
-                          <ref role="37wK5l" to="33ny:~ArrayList.get(int)" resolve="get" />
-                          <node concept="37vLTw" id="1gULBtOjFkW" role="37wK5m">
-                            <ref role="3cqZAo" node="1gULBtOgj0k" resolve="firstModule" />
-                          </node>
-                        </node>
-                      </node>
-                      <node concept="liA8E" id="1gULBtOjNVi" role="2OqNvi">
-                        <ref role="37wK5l" to="lui2:~SModule.getModuleReference()" resolve="getModuleReference" />
-                      </node>
-                    </node>
-                    <node concept="2OqwBi" id="1gULBtOk17R" role="37wK5m">
-                      <node concept="2OqwBi" id="1gULBtOjSye" role="2Oq$k0">
-                        <node concept="37vLTw" id="1gULBtOjR7u" role="2Oq$k0">
-                          <ref role="3cqZAo" node="1gULBtOgaIm" resolve="cycle" />
-                        </node>
-                        <node concept="liA8E" id="1gULBtOjWnz" role="2OqNvi">
-                          <ref role="37wK5l" to="33ny:~ArrayList.get(int)" resolve="get" />
-                          <node concept="37vLTw" id="1gULBtOjYS9" role="37wK5m">
-                            <ref role="3cqZAo" node="1gULBtOgKQl" resolve="i" />
-                          </node>
-                        </node>
-                      </node>
-                      <node concept="liA8E" id="1gULBtOk3Ne" role="2OqNvi">
-                        <ref role="37wK5l" to="lui2:~SModule.getModuleReference()" resolve="getModuleReference" />
-                      </node>
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-          <node concept="3cpWsn" id="1gULBtOgKQl" role="1Duv9x">
-            <property role="TrG5h" value="i" />
-            <node concept="10Oyi0" id="1gULBtOgMA8" role="1tU5fm" />
-            <node concept="3cmrfG" id="1gULBtOgOSy" role="33vP2m">
-              <property role="3cmrfH" value="1" />
-            </node>
-          </node>
-          <node concept="3eOVzh" id="1gULBtOgSWh" role="1Dwp0S">
-            <node concept="2OqwBi" id="1gULBtOgVbz" role="3uHU7w">
-              <node concept="37vLTw" id="1gULBtOgTok" role="2Oq$k0">
-                <ref role="3cqZAo" node="1gULBtOgaIm" resolve="cycle" />
-              </node>
-              <node concept="liA8E" id="1gULBtOgYGe" role="2OqNvi">
-                <ref role="37wK5l" to="33ny:~ArrayList.size()" resolve="size" />
-              </node>
-            </node>
-            <node concept="37vLTw" id="1gULBtOgQzo" role="3uHU7B">
-              <ref role="3cqZAo" node="1gULBtOgKQl" resolve="i" />
-            </node>
-          </node>
-          <node concept="3uNrnE" id="1gULBtOh2WL" role="1Dwrff">
-            <node concept="37vLTw" id="1gULBtOh2WN" role="2$L3a6">
-              <ref role="3cqZAo" node="1gULBtOgKQl" resolve="i" />
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbH" id="1gULBtOkIeW" role="3cqZAp" />
-        <node concept="3cpWs8" id="1gULBtOkM7W" role="3cqZAp">
-          <node concept="3cpWsn" id="1gULBtOkM7Z" role="3cpWs9">
-            <property role="TrG5h" value="firstAndAfter" />
-            <property role="3TUv4t" value="true" />
-            <node concept="A3Dl8" id="1gULBtOkM7T" role="1tU5fm">
-              <node concept="3uibUv" id="1gULBtOkOeL" role="A3Ik2">
-                <ref role="3uigEE" to="lui2:~SModule" resolve="SModule" />
-              </node>
-            </node>
-            <node concept="2OqwBi" id="1gULBtOkTWC" role="33vP2m">
-              <node concept="37vLTw" id="1gULBtOkS_5" role="2Oq$k0">
-                <ref role="3cqZAo" node="1gULBtOgaIm" resolve="cycle" />
-              </node>
-              <node concept="liA8E" id="1gULBtOkY1$" role="2OqNvi">
-                <ref role="37wK5l" to="33ny:~ArrayList.subList(int,int)" resolve="subList" />
-                <node concept="37vLTw" id="1gULBtOl16I" role="37wK5m">
-                  <ref role="3cqZAo" node="1gULBtOgj0k" resolve="firstModule" />
-                </node>
-                <node concept="2OqwBi" id="1gULBtOl7a2" role="37wK5m">
-                  <node concept="37vLTw" id="1gULBtOl5E3" role="2Oq$k0">
-                    <ref role="3cqZAo" node="1gULBtOgaIm" resolve="cycle" />
-                  </node>
-                  <node concept="liA8E" id="1gULBtOlaCH" role="2OqNvi">
-                    <ref role="37wK5l" to="33ny:~ArrayList.size()" resolve="size" />
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3cpWs8" id="1gULBtOlEZq" role="3cqZAp">
-          <node concept="3cpWsn" id="1gULBtOlEZt" role="3cpWs9">
-            <property role="TrG5h" value="beforeFirst" />
-            <property role="3TUv4t" value="true" />
-            <node concept="A3Dl8" id="1gULBtOlEZn" role="1tU5fm">
-              <node concept="3uibUv" id="1gULBtOlHvX" role="A3Ik2">
-                <ref role="3uigEE" to="lui2:~SModule" resolve="SModule" />
-              </node>
-            </node>
-            <node concept="2OqwBi" id="1gULBtOlO1n" role="33vP2m">
-              <node concept="37vLTw" id="1gULBtOlM$V" role="2Oq$k0">
-                <ref role="3cqZAo" node="1gULBtOgaIm" resolve="cycle" />
-              </node>
-              <node concept="liA8E" id="1gULBtOlUuj" role="2OqNvi">
-                <ref role="37wK5l" to="33ny:~ArrayList.subList(int,int)" resolve="subList" />
-                <node concept="3cmrfG" id="1gULBtOlX1X" role="37wK5m">
-                  <property role="3cmrfH" value="0" />
-                </node>
-                <node concept="37vLTw" id="1gULBtOm07f" role="37wK5m">
-                  <ref role="3cqZAo" node="1gULBtOgj0k" resolve="firstModule" />
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbH" id="1gULBtOnDy8" role="3cqZAp" />
-        <node concept="3cpWs6" id="1gULBtOm5uI" role="3cqZAp">
-          <node concept="2OqwBi" id="1gULBtOnL0z" role="3cqZAk">
-            <node concept="2OqwBi" id="1gULBtOo3gE" role="2Oq$k0">
-              <node concept="1eOMI4" id="1gULBtOojKm" role="2Oq$k0">
-                <node concept="2OqwBi" id="1gULBtOojKi" role="1eOMHV">
-                  <node concept="37vLTw" id="1gULBtOojKj" role="2Oq$k0">
-                    <ref role="3cqZAo" node="1gULBtOkM7Z" resolve="firstAndAfter" />
-                  </node>
-                  <node concept="3QWeyG" id="1gULBtOojKk" role="2OqNvi">
-                    <node concept="37vLTw" id="1gULBtOojKl" role="576Qk">
-                      <ref role="3cqZAo" node="1gULBtOlEZt" resolve="beforeFirst" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-              <node concept="3$u5V9" id="1gULBtOo5YI" role="2OqNvi">
-                <node concept="1bVj0M" id="1gULBtOo5YK" role="23t8la">
-                  <node concept="3clFbS" id="1gULBtOo5YL" role="1bW5cS">
-                    <node concept="3clFbF" id="1gULBtOo8sa" role="3cqZAp">
-                      <node concept="2OqwBi" id="1gULBtOo8XR" role="3clFbG">
-                        <node concept="37vLTw" id="1gULBtOo8s9" role="2Oq$k0">
-                          <ref role="3cqZAo" node="6T$NbgWIi03" resolve="it" />
-                        </node>
-                        <node concept="liA8E" id="1gULBtOobF3" role="2OqNvi">
-                          <ref role="37wK5l" to="wyt6:~Object.toString()" resolve="toString" />
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                  <node concept="gl6BB" id="6T$NbgWIi03" role="1bW2Oz">
-                    <property role="TrG5h" value="it" />
-                    <node concept="2jxLKc" id="6T$NbgWIi04" role="1tU5fm" />
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3uJxvA" id="1gULBtOnNo1" role="2OqNvi">
-              <node concept="Xl_RD" id="1gULBtOnRcW" role="3uJOhx">
-                <property role="Xl_RC" value=", " />
-              </node>
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="3Tm6S6" id="1gULBtOgaIk" role="1B3o_S" />
-      <node concept="17QB3L" id="1gULBtOgaIl" role="3clF45" />
-      <node concept="37vLTG" id="1gULBtOgaIm" role="3clF46">
-        <property role="TrG5h" value="cycle" />
-        <node concept="3uibUv" id="1gULBtOgaIn" role="1tU5fm">
-          <ref role="3uigEE" to="33ny:~ArrayList" resolve="ArrayList" />
-          <node concept="3uibUv" id="1gULBtOgaIo" role="11_B2D">
-            <ref role="3uigEE" to="lui2:~SModule" resolve="SModule" />
-          </node>
-        </node>
-      </node>
-      <node concept="P$JXv" id="1gULBtOnhmH" role="lGtFl">
-        <node concept="TZ5HA" id="1gULBtOnhmI" role="TZ5H$">
-          <node concept="1dT_AC" id="1gULBtOnhmJ" role="1dT_Ay">
-            <property role="1dT_AB" value="Format " />
-          </node>
-          <node concept="1dT_AA" id="1gULBtOnjXE" role="1dT_Ay">
-            <node concept="VVOAv" id="1gULBtOnjXW" role="qph3F">
-              <node concept="TZ5HA" id="1gULBtOnjXY" role="2Xj1qM">
-                <node concept="1dT_AC" id="1gULBtOnjYc" role="1dT_Ay">
-                  <property role="1dT_AB" value="cycle" />
-                </node>
-              </node>
-            </node>
-          </node>
-          <node concept="1dT_AC" id="1gULBtOnjXD" role="1dT_Ay">
-            <property role="1dT_AB" value=" deterministically." />
-          </node>
-        </node>
-        <node concept="TZ5HA" id="1gULBtOoSfH" role="TZ5H$">
-          <node concept="1dT_AC" id="1gULBtOoSfI" role="1dT_Ay">
-            <property role="1dT_AB" value="" />
-          </node>
-        </node>
-        <node concept="TZ5HA" id="1gULBtOoSg5" role="TZ5H$">
-          <node concept="1dT_AC" id="1gULBtOoSg6" role="1dT_Ay">
-            <property role="1dT_AB" value="Determinism is implemented by starting from the module whose reference comes first in alphabetical order." />
-          </node>
-        </node>
-        <node concept="TUZQ0" id="1gULBtOnhmK" role="3nqlJM">
-          <property role="TUZQ4" value="cycle to format" />
-          <node concept="zr_55" id="1gULBtOnhmM" role="zr_5Q">
-            <ref role="zr_51" node="1gULBtOgaIm" resolve="cycle" />
-          </node>
-        </node>
-        <node concept="x79VA" id="1gULBtOnhmN" role="3nqlJM">
-          <property role="x79VB" value="cycle deterministically formatted as text" />
-        </node>
-      </node>
-    </node>
-    <node concept="2tJIrI" id="47tbZooV4p4" role="jymVt" />
     <node concept="Wx3nA" id="1gULBtOjnwD" role="jymVt">
       <property role="TrG5h" value="COMPARE_MODULE_REFS" />
       <property role="3TUv4t" value="true" />
@@ -4667,1207 +4270,6 @@
       </node>
       <node concept="3Tm6S6" id="1gULBtOjnwF" role="1B3o_S" />
     </node>
-    <node concept="2tJIrI" id="47tbZooUKYV" role="jymVt" />
-    <node concept="2YIFZL" id="47tbZooU$aK" role="jymVt">
-      <property role="TrG5h" value="computeAllCycles" />
-      <node concept="3clFbS" id="47tbZooU$aN" role="3clF47">
-        <node concept="3cpWs8" id="4aEqBbb$7Vq" role="3cqZAp">
-          <node concept="3cpWsn" id="4aEqBbb$7Vt" role="3cpWs9">
-            <property role="TrG5h" value="module2DirectDependencies" />
-            <node concept="3rvAFt" id="4aEqBbb$7Vk" role="1tU5fm">
-              <node concept="3uibUv" id="4aEqBbb$7ZC" role="3rvQeY">
-                <ref role="3uigEE" to="lui2:~SModule" resolve="SModule" />
-              </node>
-              <node concept="2hMVRd" id="3b1aCyfHdO3" role="3rvSg0">
-                <node concept="3uibUv" id="3b1aCyfHdO5" role="2hN53Y">
-                  <ref role="3uigEE" to="lui2:~SModule" resolve="SModule" />
-                </node>
-              </node>
-            </node>
-            <node concept="2YIFZM" id="3b1aCyg4gt4" role="33vP2m">
-              <ref role="1Pybhc" node="4aEqBbbBtjF" resolve="CyclicModuleDependenciesHelper" />
-              <ref role="37wK5l" node="3b1aCyg4gsX" resolve="computeDirectModuleDependencies" />
-              <node concept="37vLTw" id="3b1aCyg4gt3" role="37wK5m">
-                <ref role="3cqZAo" node="47tbZooUAh$" resolve="modules" />
-              </node>
-              <node concept="37vLTw" id="1SbpUw9RiWL" role="37wK5m">
-                <ref role="3cqZAo" node="1SbpUw9R0LN" resolve="considerUsedLanguages" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbH" id="3b1aCyfE0Do" role="3cqZAp" />
-        <node concept="3cpWs8" id="3b1aCyfGZ7b" role="3cqZAp">
-          <node concept="3cpWsn" id="3b1aCyfGZ7c" role="3cpWs9">
-            <property role="TrG5h" value="module2IndirectDependencies" />
-            <node concept="3rvAFt" id="3b1aCyfGXST" role="1tU5fm">
-              <node concept="3uibUv" id="3b1aCyfGXT2" role="3rvQeY">
-                <ref role="3uigEE" to="lui2:~SModule" resolve="SModule" />
-              </node>
-              <node concept="2hMVRd" id="3b1aCyfGXT3" role="3rvSg0">
-                <node concept="3uibUv" id="3b1aCyfGXT4" role="2hN53Y">
-                  <ref role="3uigEE" to="lui2:~SModule" resolve="SModule" />
-                </node>
-              </node>
-            </node>
-            <node concept="1rXfSq" id="3b1aCyfGZ7d" role="33vP2m">
-              <ref role="37wK5l" node="3b1aCyfEME5" resolve="computeIndirectDependencies" />
-              <node concept="37vLTw" id="3b1aCyfGZ7e" role="37wK5m">
-                <ref role="3cqZAo" node="4aEqBbb$7Vt" resolve="module2DirectDependencies" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbH" id="4aEqBbb$tBI" role="3cqZAp" />
-        <node concept="3cpWs8" id="47tbZooUHyM" role="3cqZAp">
-          <node concept="3cpWsn" id="47tbZooUHyP" role="3cpWs9">
-            <property role="TrG5h" value="allCycles" />
-            <node concept="2hMVRd" id="5EjFUKYg4rz" role="1tU5fm">
-              <node concept="3uibUv" id="3b1aCyfTZ4P" role="2hN53Y">
-                <ref role="3uigEE" to="33ny:~ArrayList" resolve="ArrayList" />
-                <node concept="3uibUv" id="3b1aCyfU5B1" role="11_B2D">
-                  <ref role="3uigEE" to="lui2:~SModule" resolve="SModule" />
-                </node>
-              </node>
-            </node>
-            <node concept="2ShNRf" id="47tbZooUQfq" role="33vP2m">
-              <node concept="2i4dXS" id="5EjFUKYgiTr" role="2ShVmc">
-                <node concept="3uibUv" id="3b1aCyfU8XI" role="HW$YZ">
-                  <ref role="3uigEE" to="33ny:~ArrayList" resolve="ArrayList" />
-                  <node concept="3uibUv" id="3b1aCyfU8XJ" role="11_B2D">
-                    <ref role="3uigEE" to="lui2:~SModule" resolve="SModule" />
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3cpWs8" id="4aEqBbbC6Cq" role="3cqZAp">
-          <node concept="3cpWsn" id="4aEqBbbC6Ct" role="3cpWs9">
-            <property role="TrG5h" value="modulesForWhichAllCyclesHaveBeenFound" />
-            <node concept="2hMVRd" id="4aEqBbbC6Cm" role="1tU5fm">
-              <node concept="3uibUv" id="4aEqBbbC6LC" role="2hN53Y">
-                <ref role="3uigEE" to="lui2:~SModule" resolve="SModule" />
-              </node>
-            </node>
-            <node concept="2ShNRf" id="4aEqBbbC6TG" role="33vP2m">
-              <node concept="2i4dXS" id="4aEqBbbC7lS" role="2ShVmc">
-                <node concept="3uibUv" id="4aEqBbbC7BJ" role="HW$YZ">
-                  <ref role="3uigEE" to="lui2:~SModule" resolve="SModule" />
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="2Gpval" id="4aEqBbb$ikj" role="3cqZAp">
-          <node concept="2GrKxI" id="4aEqBbb$ikl" role="2Gsz3X">
-            <property role="TrG5h" value="module" />
-          </node>
-          <node concept="2OqwBi" id="4aEqBbb$iPp" role="2GsD0m">
-            <node concept="37vLTw" id="4aEqBbb$ixs" role="2Oq$k0">
-              <ref role="3cqZAo" node="4aEqBbb$7Vt" resolve="module2DirectDependencies" />
-            </node>
-            <node concept="3lbrtF" id="4aEqBbb$joJ" role="2OqNvi" />
-          </node>
-          <node concept="3clFbS" id="4aEqBbb$ikp" role="2LFqv$">
-            <node concept="3clFbJ" id="3b1aCyfWr6g" role="3cqZAp">
-              <node concept="3clFbS" id="3b1aCyfWr6i" role="3clFbx">
-                <node concept="3SKdUt" id="3b1aCyfXAcq" role="3cqZAp">
-                  <node concept="1PaTwC" id="3b1aCyfXAcr" role="1aUNEU">
-                    <node concept="3oM_SD" id="3b1aCyfXD8f" role="1PaTwD">
-                      <property role="3oM_SC" value="this" />
-                    </node>
-                    <node concept="3oM_SD" id="3b1aCyfXD8h" role="1PaTwD">
-                      <property role="3oM_SC" value="module" />
-                    </node>
-                    <node concept="3oM_SD" id="3b1aCyfXD8k" role="1PaTwD">
-                      <property role="3oM_SC" value="depends" />
-                    </node>
-                    <node concept="3oM_SD" id="3b1aCyfXD8o" role="1PaTwD">
-                      <property role="3oM_SC" value="on" />
-                    </node>
-                    <node concept="3oM_SD" id="3b1aCyfXD8E" role="1PaTwD">
-                      <property role="3oM_SC" value="itself" />
-                    </node>
-                    <node concept="3oM_SD" id="3b1aCyfXD8K" role="1PaTwD">
-                      <property role="3oM_SC" value="indirectly," />
-                    </node>
-                    <node concept="3oM_SD" id="3b1aCyfXD8R" role="1PaTwD">
-                      <property role="3oM_SC" value="so" />
-                    </node>
-                    <node concept="3oM_SD" id="3b1aCyfXD8Z" role="1PaTwD">
-                      <property role="3oM_SC" value="it" />
-                    </node>
-                    <node concept="3oM_SD" id="3b1aCyfXD98" role="1PaTwD">
-                      <property role="3oM_SC" value="is" />
-                    </node>
-                    <node concept="3oM_SD" id="3b1aCyfXD9i" role="1PaTwD">
-                      <property role="3oM_SC" value="involved" />
-                    </node>
-                    <node concept="3oM_SD" id="3b1aCyfXD9t" role="1PaTwD">
-                      <property role="3oM_SC" value="at" />
-                    </node>
-                    <node concept="3oM_SD" id="3b1aCyfXD9D" role="1PaTwD">
-                      <property role="3oM_SC" value="least" />
-                    </node>
-                    <node concept="3oM_SD" id="3b1aCyfXD9Q" role="1PaTwD">
-                      <property role="3oM_SC" value="in" />
-                    </node>
-                    <node concept="3oM_SD" id="3b1aCyfXDa4" role="1PaTwD">
-                      <property role="3oM_SC" value="one" />
-                    </node>
-                    <node concept="3oM_SD" id="3b1aCyfXDaj" role="1PaTwD">
-                      <property role="3oM_SC" value="cycle" />
-                    </node>
-                  </node>
-                </node>
-                <node concept="3cpWs8" id="6o7R8_1wBcm" role="3cqZAp">
-                  <node concept="3cpWsn" id="6o7R8_1wBcn" role="3cpWs9">
-                    <property role="TrG5h" value="crtPath" />
-                    <node concept="2ShNRf" id="6o7R8_1wBco" role="33vP2m">
-                      <node concept="Tc6Ow" id="7rvIjoqGSqV" role="2ShVmc">
-                        <node concept="3uibUv" id="7rvIjoqGSqX" role="HW$YZ">
-                          <ref role="3uigEE" to="lui2:~SModule" resolve="SModule" />
-                        </node>
-                        <node concept="2GrUjf" id="7rvIjoqGSqY" role="HW$Y0">
-                          <ref role="2Gs0qQ" node="4aEqBbb$ikl" resolve="module" />
-                        </node>
-                      </node>
-                    </node>
-                    <node concept="_YKpA" id="7rvIjoqGQ2J" role="1tU5fm">
-                      <node concept="3uibUv" id="7rvIjoqGQ2L" role="_ZDj9">
-                        <ref role="3uigEE" to="lui2:~SModule" resolve="SModule" />
-                      </node>
-                    </node>
-                  </node>
-                </node>
-                <node concept="3cpWs8" id="2IbNRxZy8cq" role="3cqZAp">
-                  <node concept="3cpWsn" id="2IbNRxZy8ct" role="3cpWs9">
-                    <property role="TrG5h" value="alreadyVisited" />
-                    <node concept="2hMVRd" id="2IbNRxZy8cm" role="1tU5fm">
-                      <node concept="3uibUv" id="2IbNRxZyaOk" role="2hN53Y">
-                        <ref role="3uigEE" to="lui2:~SModule" resolve="SModule" />
-                      </node>
-                    </node>
-                    <node concept="2ShNRf" id="2IbNRxZyr4l" role="33vP2m">
-                      <node concept="2i4dXS" id="2IbNRxZyvDY" role="2ShVmc">
-                        <node concept="3uibUv" id="2IbNRxZy_Wm" role="HW$YZ">
-                          <ref role="3uigEE" to="lui2:~SModule" resolve="SModule" />
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                </node>
-                <node concept="3clFbF" id="4aEqBbbBwvs" role="3cqZAp">
-                  <node concept="2YIFZM" id="4aEqBbbBw$Z" role="3clFbG">
-                    <ref role="1Pybhc" node="4aEqBbbBtjF" resolve="CyclicModuleDependenciesHelper" />
-                    <ref role="37wK5l" node="4aEqBbbBtrZ" resolve="computeTransitiveClosure" />
-                    <node concept="37vLTw" id="4aEqBbbBwDx" role="37wK5m">
-                      <ref role="3cqZAo" node="4aEqBbb$7Vt" resolve="module2DirectDependencies" />
-                    </node>
-                    <node concept="37vLTw" id="3b1aCyfIcN5" role="37wK5m">
-                      <ref role="3cqZAo" node="3b1aCyfGZ7c" resolve="module2IndirectDependencies" />
-                    </node>
-                    <node concept="2GrUjf" id="6wZTwtT02AG" role="37wK5m">
-                      <ref role="2Gs0qQ" node="4aEqBbb$ikl" resolve="module" />
-                    </node>
-                    <node concept="2GrUjf" id="2XcG3COV3Oz" role="37wK5m">
-                      <ref role="2Gs0qQ" node="4aEqBbb$ikl" resolve="module" />
-                    </node>
-                    <node concept="37vLTw" id="2IbNRxZy2vW" role="37wK5m">
-                      <ref role="3cqZAo" node="6o7R8_1wBcn" resolve="crtPath" />
-                    </node>
-                    <node concept="37vLTw" id="2IbNRxZyFGE" role="37wK5m">
-                      <ref role="3cqZAo" node="2IbNRxZy8ct" resolve="alreadyVisited" />
-                    </node>
-                    <node concept="37vLTw" id="4aEqBbbC7PD" role="37wK5m">
-                      <ref role="3cqZAo" node="4aEqBbbC6Ct" resolve="modulesForWhichAllCyclesHaveBeenFound" />
-                    </node>
-                    <node concept="37vLTw" id="47tbZooUXHt" role="37wK5m">
-                      <ref role="3cqZAo" node="47tbZooUHyP" resolve="allCycles" />
-                    </node>
-                    <node concept="37vLTw" id="1SbpUw9RFdJ" role="37wK5m">
-                      <ref role="3cqZAo" node="1SbpUw9RvMy" resolve="cycleSize" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-              <node concept="2OqwBi" id="3b1aCyfWGvG" role="3clFbw">
-                <node concept="3EllGN" id="3b1aCyfWzFW" role="2Oq$k0">
-                  <node concept="2GrUjf" id="3b1aCyfWCsM" role="3ElVtu">
-                    <ref role="2Gs0qQ" node="4aEqBbb$ikl" resolve="module" />
-                  </node>
-                  <node concept="37vLTw" id="3b1aCyfWuZu" role="3ElQJh">
-                    <ref role="3cqZAo" node="3b1aCyfGZ7c" resolve="module2IndirectDependencies" />
-                  </node>
-                </node>
-                <node concept="3JPx81" id="3b1aCyfWLZS" role="2OqNvi">
-                  <node concept="2GrUjf" id="3b1aCyfWQcK" role="25WWJ7">
-                    <ref role="2Gs0qQ" node="4aEqBbb$ikl" resolve="module" />
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3clFbF" id="1OhHxY4shgD" role="3cqZAp">
-              <node concept="2OqwBi" id="1OhHxY4sk5J" role="3clFbG">
-                <node concept="37vLTw" id="1OhHxY4shgB" role="2Oq$k0">
-                  <ref role="3cqZAo" node="4aEqBbbC6Ct" resolve="modulesForWhichAllCyclesHaveBeenFound" />
-                </node>
-                <node concept="TSZUe" id="1OhHxY4snfF" role="2OqNvi">
-                  <node concept="2GrUjf" id="1OhHxY4sqcb" role="25WWJ7">
-                    <ref role="2Gs0qQ" node="4aEqBbb$ikl" resolve="module" />
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbH" id="2_wFiA48S7m" role="3cqZAp" />
-        <node concept="3cpWs6" id="47tbZooVdRW" role="3cqZAp">
-          <node concept="37vLTw" id="47tbZooVfpu" role="3cqZAk">
-            <ref role="3cqZAo" node="47tbZooUHyP" resolve="allCycles" />
-          </node>
-        </node>
-      </node>
-      <node concept="37vLTG" id="47tbZooUAh$" role="3clF46">
-        <property role="TrG5h" value="modules" />
-        <node concept="_YKpA" id="47tbZooUAhy" role="1tU5fm">
-          <node concept="3uibUv" id="47tbZooUB8J" role="_ZDj9">
-            <ref role="3uigEE" to="lui2:~SModule" resolve="SModule" />
-          </node>
-        </node>
-      </node>
-      <node concept="2hMVRd" id="5EjFUKYg0p8" role="3clF45">
-        <node concept="3uibUv" id="3b1aCyfUc9W" role="2hN53Y">
-          <ref role="3uigEE" to="33ny:~ArrayList" resolve="ArrayList" />
-          <node concept="3uibUv" id="3b1aCyfUc9X" role="11_B2D">
-            <ref role="3uigEE" to="lui2:~SModule" resolve="SModule" />
-          </node>
-        </node>
-      </node>
-      <node concept="37vLTG" id="1SbpUw9R0LN" role="3clF46">
-        <property role="TrG5h" value="considerUsedLanguages" />
-        <node concept="10P_77" id="1SbpUw9R3z0" role="1tU5fm" />
-      </node>
-      <node concept="37vLTG" id="1SbpUw9RvMy" role="3clF46">
-        <property role="TrG5h" value="cycleSize" />
-        <node concept="10Oyi0" id="1SbpUw9Rzw7" role="1tU5fm" />
-      </node>
-    </node>
-    <node concept="2tJIrI" id="3b1aCyg4lGI" role="jymVt" />
-    <node concept="2YIFZL" id="3b1aCyg4gsX" role="jymVt">
-      <property role="TrG5h" value="computeDirectModuleDependencies" />
-      <node concept="3rvAFt" id="3b1aCyg4gsZ" role="3clF45">
-        <node concept="3uibUv" id="3b1aCyg4gt0" role="3rvQeY">
-          <ref role="3uigEE" to="lui2:~SModule" resolve="SModule" />
-        </node>
-        <node concept="2hMVRd" id="3b1aCyg4gt1" role="3rvSg0">
-          <node concept="3uibUv" id="3b1aCyg4gt2" role="2hN53Y">
-            <ref role="3uigEE" to="lui2:~SModule" resolve="SModule" />
-          </node>
-        </node>
-      </node>
-      <node concept="37vLTG" id="3b1aCyg4gsK" role="3clF46">
-        <property role="TrG5h" value="modules" />
-        <node concept="_YKpA" id="3b1aCyg4gsL" role="1tU5fm">
-          <node concept="3uibUv" id="3b1aCyg4gsM" role="_ZDj9">
-            <ref role="3uigEE" to="lui2:~SModule" resolve="SModule" />
-          </node>
-        </node>
-      </node>
-      <node concept="3clFbS" id="3b1aCyg4grO" role="3clF47">
-        <node concept="3cpWs8" id="3b1aCyg4grR" role="3cqZAp">
-          <node concept="3cpWsn" id="3b1aCyg4grS" role="3cpWs9">
-            <property role="TrG5h" value="module2DirectDependencies" />
-            <node concept="3rvAFt" id="3b1aCyg4grT" role="1tU5fm">
-              <node concept="3uibUv" id="3b1aCyg4grU" role="3rvQeY">
-                <ref role="3uigEE" to="lui2:~SModule" resolve="SModule" />
-              </node>
-              <node concept="2hMVRd" id="3b1aCyg4grV" role="3rvSg0">
-                <node concept="3uibUv" id="3b1aCyg4grW" role="2hN53Y">
-                  <ref role="3uigEE" to="lui2:~SModule" resolve="SModule" />
-                </node>
-              </node>
-            </node>
-            <node concept="2ShNRf" id="3b1aCyg4grX" role="33vP2m">
-              <node concept="3rGOSV" id="3b1aCyg4grY" role="2ShVmc">
-                <node concept="3uibUv" id="3b1aCyg4grZ" role="3rHrn6">
-                  <ref role="3uigEE" to="lui2:~SModule" resolve="SModule" />
-                </node>
-                <node concept="2hMVRd" id="3b1aCyg4gs0" role="3rHtpV">
-                  <node concept="3uibUv" id="3b1aCyg4gs1" role="2hN53Y">
-                    <ref role="3uigEE" to="lui2:~SModule" resolve="SModule" />
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="2Gpval" id="3b1aCyg4gs2" role="3cqZAp">
-          <node concept="2GrKxI" id="3b1aCyg4gs3" role="2Gsz3X">
-            <property role="TrG5h" value="module" />
-          </node>
-          <node concept="37vLTw" id="3b1aCyg4gsO" role="2GsD0m">
-            <ref role="3cqZAo" node="3b1aCyg4gsK" resolve="modules" />
-          </node>
-          <node concept="3clFbS" id="3b1aCyg4gs5" role="2LFqv$">
-            <node concept="3cpWs8" id="3b1aCyg4gs6" role="3cqZAp">
-              <node concept="3cpWsn" id="3b1aCyg4gs7" role="3cpWs9">
-                <property role="TrG5h" value="currentDependencies" />
-                <node concept="2hMVRd" id="3b1aCyg4gs8" role="1tU5fm">
-                  <node concept="3uibUv" id="3b1aCyg4gs9" role="2hN53Y">
-                    <ref role="3uigEE" to="lui2:~SModule" resolve="SModule" />
-                  </node>
-                </node>
-                <node concept="2ShNRf" id="3b1aCyg4gsa" role="33vP2m">
-                  <node concept="2i4dXS" id="3b1aCyg4gsb" role="2ShVmc">
-                    <node concept="3uibUv" id="3b1aCyg4gsc" role="HW$YZ">
-                      <ref role="3uigEE" to="lui2:~SModule" resolve="SModule" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="2Gpval" id="3b1aCyg4gsd" role="3cqZAp">
-              <node concept="2GrKxI" id="3b1aCyg4gse" role="2Gsz3X">
-                <property role="TrG5h" value="dep" />
-              </node>
-              <node concept="3clFbS" id="3b1aCyg4gsf" role="2LFqv$">
-                <node concept="3cpWs8" id="3b1aCyg4gsg" role="3cqZAp">
-                  <node concept="3cpWsn" id="3b1aCyg4gsh" role="3cpWs9">
-                    <property role="TrG5h" value="target" />
-                    <node concept="3uibUv" id="3b1aCyg4gsi" role="1tU5fm">
-                      <ref role="3uigEE" to="lui2:~SModule" resolve="SModule" />
-                    </node>
-                    <node concept="2OqwBi" id="3b1aCyg4gsj" role="33vP2m">
-                      <node concept="2GrUjf" id="3b1aCyg4gsk" role="2Oq$k0">
-                        <ref role="2Gs0qQ" node="3b1aCyg4gse" resolve="dep" />
-                      </node>
-                      <node concept="liA8E" id="3b1aCyg4gsl" role="2OqNvi">
-                        <ref role="37wK5l" to="lui2:~SDependency.getTarget()" resolve="getTarget" />
-                      </node>
-                    </node>
-                  </node>
-                </node>
-                <node concept="3clFbJ" id="3b1aCyg4gsm" role="3cqZAp">
-                  <node concept="1Wc70l" id="3b1aCyg4gsn" role="3clFbw">
-                    <node concept="2OqwBi" id="3b1aCyg4gso" role="3uHU7w">
-                      <node concept="37vLTw" id="3b1aCyg4gsN" role="2Oq$k0">
-                        <ref role="3cqZAo" node="3b1aCyg4gsK" resolve="modules" />
-                      </node>
-                      <node concept="3JPx81" id="3b1aCyg4gsq" role="2OqNvi">
-                        <node concept="37vLTw" id="3b1aCyg4gsr" role="25WWJ7">
-                          <ref role="3cqZAo" node="3b1aCyg4gsh" resolve="target" />
-                        </node>
-                      </node>
-                    </node>
-                    <node concept="3y3z36" id="3b1aCyg4gss" role="3uHU7B">
-                      <node concept="37vLTw" id="3b1aCyg4gst" role="3uHU7B">
-                        <ref role="3cqZAo" node="3b1aCyg4gsh" resolve="target" />
-                      </node>
-                      <node concept="10Nm6u" id="3b1aCyg4gsu" role="3uHU7w" />
-                    </node>
-                  </node>
-                  <node concept="3clFbS" id="3b1aCyg4gsv" role="3clFbx">
-                    <node concept="3clFbF" id="3b1aCyg4gsw" role="3cqZAp">
-                      <node concept="2OqwBi" id="3b1aCyg4gsx" role="3clFbG">
-                        <node concept="37vLTw" id="3b1aCyg4gsy" role="2Oq$k0">
-                          <ref role="3cqZAo" node="3b1aCyg4gs7" resolve="currentDependencies" />
-                        </node>
-                        <node concept="TSZUe" id="3b1aCyg4gsz" role="2OqNvi">
-                          <node concept="37vLTw" id="3b1aCyg4gs$" role="25WWJ7">
-                            <ref role="3cqZAo" node="3b1aCyg4gsh" resolve="target" />
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                </node>
-              </node>
-              <node concept="2OqwBi" id="3b1aCyg4gs_" role="2GsD0m">
-                <node concept="2GrUjf" id="3b1aCyg4gsA" role="2Oq$k0">
-                  <ref role="2Gs0qQ" node="3b1aCyg4gs3" resolve="module" />
-                </node>
-                <node concept="liA8E" id="3b1aCyg4gsB" role="2OqNvi">
-                  <ref role="37wK5l" to="lui2:~SModule.getDeclaredDependencies()" resolve="getDeclaredDependencies" />
-                </node>
-              </node>
-            </node>
-            <node concept="3clFbJ" id="1SbpUw9QKHI" role="3cqZAp">
-              <node concept="3clFbS" id="1SbpUw9QKHK" role="3clFbx">
-                <node concept="2Gpval" id="6bcxNvJJWDZ" role="3cqZAp">
-                  <node concept="2GrKxI" id="6bcxNvJJWE0" role="2Gsz3X">
-                    <property role="TrG5h" value="lang" />
-                  </node>
-                  <node concept="3clFbS" id="6bcxNvJJWE1" role="2LFqv$">
-                    <node concept="3cpWs8" id="6bcxNvJJWE2" role="3cqZAp">
-                      <node concept="3cpWsn" id="6bcxNvJJWE3" role="3cpWs9">
-                        <property role="TrG5h" value="target" />
-                        <node concept="3uibUv" id="6bcxNvJJWE4" role="1tU5fm">
-                          <ref role="3uigEE" to="lui2:~SModule" resolve="SModule" />
-                        </node>
-                        <node concept="2OqwBi" id="6bcxNvJJWE5" role="33vP2m">
-                          <node concept="2GrUjf" id="6bcxNvJJWE6" role="2Oq$k0">
-                            <ref role="2Gs0qQ" node="6bcxNvJJWE0" resolve="lang" />
-                          </node>
-                          <node concept="liA8E" id="6bcxNvJKp_W" role="2OqNvi">
-                            <ref role="37wK5l" to="c17a:~SLanguage.getSourceModule()" resolve="getSourceModule" />
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                    <node concept="3clFbJ" id="6bcxNvJJWE8" role="3cqZAp">
-                      <node concept="1Wc70l" id="6bcxNvJJWE9" role="3clFbw">
-                        <node concept="2OqwBi" id="6bcxNvJJWEa" role="3uHU7w">
-                          <node concept="37vLTw" id="6bcxNvJJWEb" role="2Oq$k0">
-                            <ref role="3cqZAo" node="3b1aCyg4gsK" resolve="modules" />
-                          </node>
-                          <node concept="3JPx81" id="6bcxNvJJWEc" role="2OqNvi">
-                            <node concept="37vLTw" id="6bcxNvJJWEd" role="25WWJ7">
-                              <ref role="3cqZAo" node="6bcxNvJJWE3" resolve="target" />
-                            </node>
-                          </node>
-                        </node>
-                        <node concept="3y3z36" id="6bcxNvJJWEe" role="3uHU7B">
-                          <node concept="37vLTw" id="6bcxNvJJWEf" role="3uHU7B">
-                            <ref role="3cqZAo" node="6bcxNvJJWE3" resolve="target" />
-                          </node>
-                          <node concept="10Nm6u" id="6bcxNvJJWEg" role="3uHU7w" />
-                        </node>
-                      </node>
-                      <node concept="3clFbS" id="6bcxNvJJWEh" role="3clFbx">
-                        <node concept="3clFbF" id="6bcxNvJJWEi" role="3cqZAp">
-                          <node concept="2OqwBi" id="6bcxNvJJWEj" role="3clFbG">
-                            <node concept="37vLTw" id="6bcxNvJJWEk" role="2Oq$k0">
-                              <ref role="3cqZAo" node="3b1aCyg4gs7" resolve="currentDependencies" />
-                            </node>
-                            <node concept="TSZUe" id="6bcxNvJJWEl" role="2OqNvi">
-                              <node concept="37vLTw" id="6bcxNvJJWEm" role="25WWJ7">
-                                <ref role="3cqZAo" node="6bcxNvJJWE3" resolve="target" />
-                              </node>
-                            </node>
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                  <node concept="2OqwBi" id="6bcxNvJJWEn" role="2GsD0m">
-                    <node concept="2GrUjf" id="6bcxNvJJWEo" role="2Oq$k0">
-                      <ref role="2Gs0qQ" node="3b1aCyg4gs3" resolve="module" />
-                    </node>
-                    <node concept="liA8E" id="6bcxNvJKaaW" role="2OqNvi">
-                      <ref role="37wK5l" to="lui2:~SModule.getUsedLanguages()" resolve="getUsedLanguages" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-              <node concept="37vLTw" id="1SbpUw9QP44" role="3clFbw">
-                <ref role="3cqZAo" node="1SbpUw9Qjw_" resolve="considerUsedLanguages" />
-              </node>
-            </node>
-            <node concept="3clFbH" id="6bcxNvJJTrM" role="3cqZAp" />
-            <node concept="3clFbF" id="3b1aCyg4gsC" role="3cqZAp">
-              <node concept="37vLTI" id="3b1aCyg4gsD" role="3clFbG">
-                <node concept="37vLTw" id="3b1aCyg4gsE" role="37vLTx">
-                  <ref role="3cqZAo" node="3b1aCyg4gs7" resolve="currentDependencies" />
-                </node>
-                <node concept="3EllGN" id="3b1aCyg4gsF" role="37vLTJ">
-                  <node concept="2GrUjf" id="3b1aCyg4gsG" role="3ElVtu">
-                    <ref role="2Gs0qQ" node="3b1aCyg4gs3" resolve="module" />
-                  </node>
-                  <node concept="37vLTw" id="3b1aCyg4gsH" role="3ElQJh">
-                    <ref role="3cqZAo" node="3b1aCyg4grS" resolve="module2DirectDependencies" />
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3cpWs6" id="3b1aCyg4gsI" role="3cqZAp">
-          <node concept="37vLTw" id="3b1aCyg4gsJ" role="3cqZAk">
-            <ref role="3cqZAo" node="3b1aCyg4grS" resolve="module2DirectDependencies" />
-          </node>
-        </node>
-      </node>
-      <node concept="37vLTG" id="1SbpUw9Qjw_" role="3clF46">
-        <property role="TrG5h" value="considerUsedLanguages" />
-        <node concept="10P_77" id="1SbpUw9Qoif" role="1tU5fm" />
-      </node>
-    </node>
-    <node concept="2tJIrI" id="63imCwJ$fFb" role="jymVt" />
-    <node concept="2tJIrI" id="63imCwJAExS" role="jymVt" />
-    <node concept="2YIFZL" id="4aEqBbbBtrZ" role="jymVt">
-      <property role="TrG5h" value="computeTransitiveClosure" />
-      <node concept="37vLTG" id="4aEqBbbBuzN" role="3clF46">
-        <property role="TrG5h" value="module2Dependencies" />
-        <node concept="3rvAFt" id="4aEqBbbBu$I" role="1tU5fm">
-          <node concept="3uibUv" id="4aEqBbbBu$J" role="3rvQeY">
-            <ref role="3uigEE" to="lui2:~SModule" resolve="SModule" />
-          </node>
-          <node concept="2hMVRd" id="3b1aCyfHEay" role="3rvSg0">
-            <node concept="3uibUv" id="3b1aCyfHEa$" role="2hN53Y">
-              <ref role="3uigEE" to="lui2:~SModule" resolve="SModule" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="37vLTG" id="3b1aCyfHUGC" role="3clF46">
-        <property role="TrG5h" value="module2IndirectDependencies" />
-        <node concept="3rvAFt" id="3b1aCyfHUGD" role="1tU5fm">
-          <node concept="3uibUv" id="3b1aCyfHUGE" role="3rvQeY">
-            <ref role="3uigEE" to="lui2:~SModule" resolve="SModule" />
-          </node>
-          <node concept="2hMVRd" id="3b1aCyfHUGF" role="3rvSg0">
-            <node concept="3uibUv" id="3b1aCyfHUGG" role="2hN53Y">
-              <ref role="3uigEE" to="lui2:~SModule" resolve="SModule" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="37vLTG" id="6wZTwtT05G8" role="3clF46">
-        <property role="TrG5h" value="seed" />
-        <node concept="3uibUv" id="6wZTwtT08bW" role="1tU5fm">
-          <ref role="3uigEE" to="lui2:~SModule" resolve="SModule" />
-        </node>
-      </node>
-      <node concept="37vLTG" id="2XcG3COTH2i" role="3clF46">
-        <property role="TrG5h" value="crtModule" />
-        <node concept="3uibUv" id="2XcG3COTK7T" role="1tU5fm">
-          <ref role="3uigEE" to="lui2:~SModule" resolve="SModule" />
-        </node>
-      </node>
-      <node concept="37vLTG" id="4aEqBbbBtsv" role="3clF46">
-        <property role="TrG5h" value="crtPath" />
-        <node concept="_YKpA" id="2IbNRxZyL3t" role="1tU5fm">
-          <node concept="3uibUv" id="2IbNRxZyL3v" role="_ZDj9">
-            <ref role="3uigEE" to="lui2:~SModule" resolve="SModule" />
-          </node>
-        </node>
-      </node>
-      <node concept="37vLTG" id="2IbNRxZyOpP" role="3clF46">
-        <property role="TrG5h" value="alreadyVisitedModules" />
-        <node concept="2hMVRd" id="2IbNRxZyRIb" role="1tU5fm">
-          <node concept="3uibUv" id="2IbNRxZyVzI" role="2hN53Y">
-            <ref role="3uigEE" to="lui2:~SModule" resolve="SModule" />
-          </node>
-        </node>
-      </node>
-      <node concept="37vLTG" id="4aEqBbbC1YB" role="3clF46">
-        <property role="TrG5h" value="modulesForWhichAllCyclesHaveBeenFound" />
-        <node concept="2hMVRd" id="4aEqBbbC23w" role="1tU5fm">
-          <node concept="3uibUv" id="4aEqBbbC27Q" role="2hN53Y">
-            <ref role="3uigEE" to="lui2:~SModule" resolve="SModule" />
-          </node>
-        </node>
-      </node>
-      <node concept="37vLTG" id="47tbZooUZde" role="3clF46">
-        <property role="TrG5h" value="allCycles" />
-        <node concept="2hMVRd" id="5EjFUKYgp8a" role="1tU5fm">
-          <node concept="3uibUv" id="3b1aCyfTl6q" role="2hN53Y">
-            <ref role="3uigEE" to="33ny:~ArrayList" resolve="ArrayList" />
-            <node concept="3uibUv" id="3b1aCyfTuIn" role="11_B2D">
-              <ref role="3uigEE" to="lui2:~SModule" resolve="SModule" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="3clFbS" id="4aEqBbbBts2" role="3clF47">
-        <node concept="3cpWs8" id="4aEqBbb$QOK" role="3cqZAp">
-          <node concept="3cpWsn" id="4aEqBbb$QOL" role="3cpWs9">
-            <property role="TrG5h" value="myDependencies" />
-            <node concept="2hMVRd" id="3b1aCyfHMXx" role="1tU5fm">
-              <node concept="3uibUv" id="3b1aCyfHMXz" role="2hN53Y">
-                <ref role="3uigEE" to="lui2:~SModule" resolve="SModule" />
-              </node>
-            </node>
-            <node concept="3EllGN" id="4aEqBbb$QOM" role="33vP2m">
-              <node concept="37vLTw" id="4aEqBbb$QOQ" role="3ElQJh">
-                <ref role="3cqZAo" node="4aEqBbbBuzN" resolve="module2Dependencies" />
-              </node>
-              <node concept="37vLTw" id="2XcG3COTXJ_" role="3ElVtu">
-                <ref role="3cqZAo" node="2XcG3COTH2i" resolve="crtModule" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbH" id="1le7Br1Ztkf" role="3cqZAp" />
-        <node concept="3clFbJ" id="1SbpUw9S74z" role="3cqZAp">
-          <node concept="3clFbS" id="1SbpUw9S74_" role="3clFbx">
-            <node concept="3cpWs6" id="1SbpUw9SviN" role="3cqZAp" />
-          </node>
-          <node concept="3clFbC" id="1SbpUw9Sekp" role="3clFbw">
-            <node concept="2OqwBi" id="1SbpUw9SmG9" role="3uHU7B">
-              <node concept="37vLTw" id="1SbpUw9ShZU" role="2Oq$k0">
-                <ref role="3cqZAo" node="4aEqBbbBtsv" resolve="crtPath" />
-              </node>
-              <node concept="34oBXx" id="1SbpUw9Srg1" role="2OqNvi" />
-            </node>
-            <node concept="3cpWs3" id="1SbpUwabx82" role="3uHU7w">
-              <node concept="3cmrfG" id="1SbpUwabxg3" role="3uHU7w">
-                <property role="3cmrfH" value="1" />
-              </node>
-              <node concept="37vLTw" id="1SbpUw9SaYd" role="3uHU7B">
-                <ref role="3cqZAo" node="1SbpUw9RHNO" resolve="cycleSize" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbH" id="1SbpUw9Symt" role="3cqZAp" />
-        <node concept="1DcWWT" id="1qtQC3GNBhj" role="3cqZAp">
-          <node concept="3clFbS" id="1qtQC3GNBhl" role="2LFqv$">
-            <node concept="3clFbJ" id="3cvDKPN9qn3" role="3cqZAp">
-              <node concept="3clFbS" id="3cvDKPN9qn5" role="3clFbx">
-                <node concept="3N13vt" id="3cvDKPN9BhI" role="3cqZAp" />
-              </node>
-              <node concept="3clFbC" id="3cvDKPN9vqS" role="3clFbw">
-                <node concept="37vLTw" id="3cvDKPN9yX0" role="3uHU7w">
-                  <ref role="3cqZAo" node="2XcG3COTH2i" resolve="crtModule" />
-                </node>
-                <node concept="37vLTw" id="1qtQC3GOhSH" role="3uHU7B">
-                  <ref role="3cqZAo" node="1qtQC3GNBhm" resolve="d" />
-                </node>
-              </node>
-            </node>
-            <node concept="3clFbJ" id="4aEqBbb$zsM" role="3cqZAp">
-              <node concept="2OqwBi" id="1qtQC3GPH_o" role="3clFbw">
-                <node concept="3S9uib" id="1qtQC3GPE18" role="2Oq$k0">
-                  <node concept="37vLTw" id="4aEqBbb$z_J" role="3S9DZi">
-                    <ref role="3cqZAo" node="2IbNRxZyOpP" resolve="alreadyVisitedModules" />
-                  </node>
-                </node>
-                <node concept="liA8E" id="1qtQC3GPLuy" role="2OqNvi">
-                  <ref role="37wK5l" to="33ny:~Set.contains(java.lang.Object)" resolve="contains" />
-                  <node concept="37vLTw" id="1qtQC3GPP02" role="37wK5m">
-                    <ref role="3cqZAo" node="1qtQC3GNBhm" resolve="d" />
-                  </node>
-                </node>
-              </node>
-              <node concept="3clFbS" id="4aEqBbb$zsO" role="3clFbx">
-                <node concept="3N13vt" id="4aEqBbbCn9J" role="3cqZAp" />
-              </node>
-            </node>
-            <node concept="3cpWs8" id="1SbpUw9PlNd" role="3cqZAp">
-              <node concept="3cpWsn" id="1SbpUw9PlNe" role="3cpWs9">
-                <property role="TrG5h" value="myIndirectDependencies" />
-                <node concept="3uibUv" id="1SbpUw9PfQ8" role="1tU5fm">
-                  <ref role="3uigEE" to="33ny:~Set" resolve="Set" />
-                  <node concept="3uibUv" id="1SbpUw9PfQb" role="11_B2D">
-                    <ref role="3uigEE" to="lui2:~SModule" resolve="SModule" />
-                  </node>
-                </node>
-                <node concept="2OqwBi" id="1SbpUw9PlNf" role="33vP2m">
-                  <node concept="3S9uib" id="1SbpUw9PlNg" role="2Oq$k0">
-                    <node concept="37vLTw" id="1SbpUw9PlNh" role="3S9DZi">
-                      <ref role="3cqZAo" node="3b1aCyfHUGC" resolve="module2IndirectDependencies" />
-                    </node>
-                  </node>
-                  <node concept="liA8E" id="1SbpUw9PlNi" role="2OqNvi">
-                    <ref role="37wK5l" to="33ny:~Map.get(java.lang.Object)" resolve="get" />
-                    <node concept="37vLTw" id="1SbpUw9PlNj" role="37wK5m">
-                      <ref role="3cqZAo" node="1qtQC3GNBhm" resolve="d" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3clFbJ" id="3b1aCyfIkSZ" role="3cqZAp">
-              <node concept="3clFbS" id="3b1aCyfIkT1" role="3clFbx">
-                <node concept="3N13vt" id="3b1aCyfIVzZ" role="3cqZAp" />
-              </node>
-              <node concept="3fqX7Q" id="3b1aCyfIQ8T" role="3clFbw">
-                <node concept="2OqwBi" id="1qtQC3GOOpe" role="3fr31v">
-                  <node concept="liA8E" id="1qtQC3GOSJh" role="2OqNvi">
-                    <ref role="37wK5l" to="33ny:~Set.contains(java.lang.Object)" resolve="contains" />
-                    <node concept="37vLTw" id="1qtQC3GOW_9" role="37wK5m">
-                      <ref role="3cqZAo" node="6wZTwtT05G8" resolve="seed" />
-                    </node>
-                  </node>
-                  <node concept="37vLTw" id="1SbpUw9PlNk" role="2Oq$k0">
-                    <ref role="3cqZAo" node="1SbpUw9PlNe" resolve="myIndirectDependencies" />
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3clFbJ" id="7VJF37wAj4Y" role="3cqZAp">
-              <node concept="3clFbS" id="7VJF37wAj50" role="3clFbx">
-                <node concept="3N13vt" id="7VJF37wAM9W" role="3cqZAp" />
-              </node>
-              <node concept="3fqX7Q" id="7VJF37wAmR0" role="3clFbw">
-                <node concept="2OqwBi" id="1qtQC3GP8yS" role="3fr31v">
-                  <node concept="liA8E" id="1qtQC3GPcg8" role="2OqNvi">
-                    <ref role="37wK5l" to="33ny:~Set.contains(java.lang.Object)" resolve="contains" />
-                    <node concept="37vLTw" id="1qtQC3GPfGK" role="37wK5m">
-                      <ref role="3cqZAo" node="1qtQC3GNBhm" resolve="d" />
-                    </node>
-                  </node>
-                  <node concept="37vLTw" id="1SbpUw9PlNl" role="2Oq$k0">
-                    <ref role="3cqZAo" node="1SbpUw9PlNe" resolve="myIndirectDependencies" />
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3clFbJ" id="4aEqBbbEg0e" role="3cqZAp">
-              <node concept="3clFbS" id="4aEqBbbEg0g" role="3clFbx">
-                <node concept="3N13vt" id="4aEqBbbEhco" role="3cqZAp" />
-              </node>
-              <node concept="2OqwBi" id="1qtQC3GPpSr" role="3clFbw">
-                <node concept="3S9uib" id="1qtQC3GPmJ6" role="2Oq$k0">
-                  <node concept="37vLTw" id="4aEqBbbEgaP" role="3S9DZi">
-                    <ref role="3cqZAo" node="4aEqBbbC1YB" resolve="modulesForWhichAllCyclesHaveBeenFound" />
-                  </node>
-                </node>
-                <node concept="liA8E" id="1qtQC3GPvE5" role="2OqNvi">
-                  <ref role="37wK5l" to="33ny:~Set.contains(java.lang.Object)" resolve="contains" />
-                  <node concept="37vLTw" id="1qtQC3GP$g3" role="37wK5m">
-                    <ref role="3cqZAo" node="1qtQC3GNBhm" resolve="d" />
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3clFbJ" id="6wZTwtSYwio" role="3cqZAp">
-              <node concept="3clFbS" id="6wZTwtSYwiq" role="3clFbx">
-                <node concept="3clFbJ" id="1SbpUw9SDyr" role="3cqZAp">
-                  <node concept="3clFbS" id="1SbpUw9SDyt" role="3clFbx">
-                    <node concept="3clFbF" id="47tbZooVGYZ" role="3cqZAp">
-                      <node concept="2OqwBi" id="47tbZooVIA3" role="3clFbG">
-                        <node concept="37vLTw" id="47tbZooVGYX" role="2Oq$k0">
-                          <ref role="3cqZAo" node="47tbZooUZde" resolve="allCycles" />
-                        </node>
-                        <node concept="TSZUe" id="47tbZooVL_T" role="2OqNvi">
-                          <node concept="2ShNRf" id="3b1aCyfQZqp" role="25WWJ7">
-                            <node concept="1pGfFk" id="3b1aCyfTEQ6" role="2ShVmc">
-                              <property role="373rjd" value="true" />
-                              <ref role="37wK5l" to="33ny:~ArrayList.&lt;init&gt;(java.util.Collection)" resolve="ArrayList" />
-                              <node concept="3uibUv" id="3b1aCyfTJyg" role="1pMfVU">
-                                <ref role="3uigEE" to="lui2:~SModule" resolve="SModule" />
-                              </node>
-                              <node concept="37vLTw" id="3b1aCyfTPSz" role="37wK5m">
-                                <ref role="3cqZAo" node="4aEqBbbBtsv" resolve="crtPath" />
-                              </node>
-                            </node>
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                  <node concept="22lmx$" id="1SbpUw9T2al" role="3clFbw">
-                    <node concept="3clFbC" id="1SbpUw9T94U" role="3uHU7B">
-                      <node concept="37vLTw" id="1SbpUw9T5RS" role="3uHU7B">
-                        <ref role="3cqZAo" node="1SbpUw9RHNO" resolve="cycleSize" />
-                      </node>
-                      <node concept="3cmrfG" id="1SbpUw9Tj8a" role="3uHU7w">
-                        <property role="3cmrfH" value="-1" />
-                      </node>
-                    </node>
-                    <node concept="3clFbC" id="1SbpUw9SUQu" role="3uHU7w">
-                      <node concept="37vLTw" id="1SbpUw9SYJl" role="3uHU7w">
-                        <ref role="3cqZAo" node="1SbpUw9RHNO" resolve="cycleSize" />
-                      </node>
-                      <node concept="2OqwBi" id="1SbpUw9SM0$" role="3uHU7B">
-                        <node concept="37vLTw" id="1SbpUw9SHsO" role="2Oq$k0">
-                          <ref role="3cqZAo" node="4aEqBbbBtsv" resolve="crtPath" />
-                        </node>
-                        <node concept="34oBXx" id="1SbpUw9SQ4C" role="2OqNvi" />
-                      </node>
-                    </node>
-                  </node>
-                </node>
-                <node concept="3N13vt" id="6wZTwtSZ2h4" role="3cqZAp" />
-              </node>
-              <node concept="3clFbC" id="6wZTwtSYNHU" role="3clFbw">
-                <node concept="37vLTw" id="1qtQC3GOvnn" role="3uHU7w">
-                  <ref role="3cqZAo" node="1qtQC3GNBhm" resolve="d" />
-                </node>
-                <node concept="37vLTw" id="6wZTwtT0fcC" role="3uHU7B">
-                  <ref role="3cqZAo" node="6wZTwtT05G8" resolve="seed" />
-                </node>
-              </node>
-            </node>
-            <node concept="3clFbH" id="1rjj7uKCFbR" role="3cqZAp" />
-            <node concept="3clFbF" id="4aEqBbbC3xa" role="3cqZAp">
-              <node concept="2OqwBi" id="7l6jS9D54Vr" role="3clFbG">
-                <node concept="3S9uib" id="7l6jS9D51J_" role="2Oq$k0">
-                  <node concept="37vLTw" id="4aEqBbbC3xc" role="3S9DZi">
-                    <ref role="3cqZAo" node="4aEqBbbBtsv" resolve="crtPath" />
-                  </node>
-                </node>
-                <node concept="liA8E" id="7l6jS9D59v1" role="2OqNvi">
-                  <ref role="37wK5l" to="33ny:~List.add(java.lang.Object)" resolve="add" />
-                  <node concept="37vLTw" id="1qtQC3GO_Ch" role="37wK5m">
-                    <ref role="3cqZAo" node="1qtQC3GNBhm" resolve="d" />
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3clFbF" id="2IbNRxZzcoe" role="3cqZAp">
-              <node concept="2OqwBi" id="7l6jS9D3NAO" role="3clFbG">
-                <node concept="3S9uib" id="7l6jS9D3IYO" role="2Oq$k0">
-                  <node concept="37vLTw" id="2IbNRxZzcoc" role="3S9DZi">
-                    <ref role="3cqZAo" node="2IbNRxZyOpP" resolve="alreadyVisitedModules" />
-                  </node>
-                </node>
-                <node concept="liA8E" id="7l6jS9D3T4H" role="2OqNvi">
-                  <ref role="37wK5l" to="33ny:~Set.add(java.lang.Object)" resolve="add" />
-                  <node concept="37vLTw" id="1qtQC3GO_Ck" role="37wK5m">
-                    <ref role="3cqZAo" node="1qtQC3GNBhm" resolve="d" />
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3clFbF" id="4aEqBbbC3xf" role="3cqZAp">
-              <node concept="1rXfSq" id="4aEqBbbC3xg" role="3clFbG">
-                <ref role="37wK5l" node="4aEqBbbBtrZ" resolve="computeTransitiveClosure" />
-                <node concept="37vLTw" id="4aEqBbbC3xh" role="37wK5m">
-                  <ref role="3cqZAo" node="4aEqBbbBuzN" resolve="module2Dependencies" />
-                </node>
-                <node concept="37vLTw" id="3b1aCyfJkdb" role="37wK5m">
-                  <ref role="3cqZAo" node="3b1aCyfHUGC" resolve="module2IndirectDependencies" />
-                </node>
-                <node concept="37vLTw" id="6wZTwtT0l32" role="37wK5m">
-                  <ref role="3cqZAo" node="6wZTwtT05G8" resolve="seed" />
-                </node>
-                <node concept="37vLTw" id="1qtQC3GO_Cn" role="37wK5m">
-                  <ref role="3cqZAo" node="1qtQC3GNBhm" resolve="d" />
-                </node>
-                <node concept="37vLTw" id="4aEqBbbC3xk" role="37wK5m">
-                  <ref role="3cqZAo" node="4aEqBbbBtsv" resolve="crtPath" />
-                </node>
-                <node concept="37vLTw" id="2IbNRxZzPZ5" role="37wK5m">
-                  <ref role="3cqZAo" node="2IbNRxZyOpP" resolve="alreadyVisitedModules" />
-                </node>
-                <node concept="37vLTw" id="4aEqBbbC3xl" role="37wK5m">
-                  <ref role="3cqZAo" node="4aEqBbbC1YB" resolve="modulesForWhichAllCyclesHaveBeenFound" />
-                </node>
-                <node concept="37vLTw" id="47tbZooQWXa" role="37wK5m">
-                  <ref role="3cqZAo" node="47tbZooUZde" resolve="allCycles" />
-                </node>
-                <node concept="37vLTw" id="1SbpUw9RZ1A" role="37wK5m">
-                  <ref role="3cqZAo" node="1SbpUw9RHNO" resolve="cycleSize" />
-                </node>
-              </node>
-            </node>
-            <node concept="3clFbF" id="4aEqBbbC3xm" role="3cqZAp">
-              <node concept="2OqwBi" id="3q0Hu9rky4C" role="3clFbG">
-                <node concept="3S9uib" id="3q0Hu9rkuwI" role="2Oq$k0">
-                  <node concept="37vLTw" id="4aEqBbbC3xo" role="3S9DZi">
-                    <ref role="3cqZAo" node="4aEqBbbBtsv" resolve="crtPath" />
-                  </node>
-                </node>
-                <node concept="liA8E" id="3q0Hu9rkArW" role="2OqNvi">
-                  <ref role="37wK5l" to="33ny:~List.remove(java.lang.Object)" resolve="remove" />
-                  <node concept="37vLTw" id="1qtQC3GOCKR" role="37wK5m">
-                    <ref role="3cqZAo" node="1qtQC3GNBhm" resolve="d" />
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3clFbF" id="2IbNRxZzwbD" role="3cqZAp">
-              <node concept="2OqwBi" id="2IbNRxZz$2j" role="3clFbG">
-                <node concept="3S9uib" id="7l6jS9D46zL" role="2Oq$k0">
-                  <node concept="37vLTw" id="2IbNRxZzwbB" role="3S9DZi">
-                    <ref role="3cqZAo" node="2IbNRxZyOpP" resolve="alreadyVisitedModules" />
-                  </node>
-                </node>
-                <node concept="liA8E" id="7l6jS9D49_H" role="2OqNvi">
-                  <ref role="37wK5l" to="33ny:~Set.remove(java.lang.Object)" resolve="remove" />
-                  <node concept="37vLTw" id="1qtQC3GOGEq" role="37wK5m">
-                    <ref role="3cqZAo" node="1qtQC3GNBhm" resolve="d" />
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-          <node concept="3cpWsn" id="1qtQC3GNBhm" role="1Duv9x">
-            <property role="TrG5h" value="d" />
-            <node concept="3uibUv" id="1qtQC3GNEEq" role="1tU5fm">
-              <ref role="3uigEE" to="lui2:~SModule" resolve="SModule" />
-            </node>
-          </node>
-          <node concept="37vLTw" id="1qtQC3GNMK0" role="1DdaDG">
-            <ref role="3cqZAo" node="4aEqBbb$QOL" resolve="myDependencies" />
-          </node>
-        </node>
-      </node>
-      <node concept="3cqZAl" id="4aEqBbbBtrN" role="3clF45" />
-      <node concept="37vLTG" id="1SbpUw9RHNO" role="3clF46">
-        <property role="TrG5h" value="cycleSize" />
-        <node concept="10Oyi0" id="1SbpUw9RLLj" role="1tU5fm" />
-      </node>
-      <node concept="P$JXv" id="1SbpUw9TxbD" role="lGtFl">
-        <node concept="TZ5HA" id="1SbpUw9TxbE" role="TZ5H$">
-          <node concept="1dT_AC" id="1SbpUw9TxbF" role="1dT_Ay" />
-        </node>
-        <node concept="TUZQ0" id="1SbpUw9Txc4" role="3nqlJM">
-          <property role="TUZQ4" value="is -1 if all cycles need to be computed, or a positive value if only cycles with a certain size have to be computed" />
-          <node concept="zr_55" id="1SbpUw9Txc6" role="zr_5Q">
-            <ref role="zr_51" node="1SbpUw9RHNO" resolve="cycleSize" />
-          </node>
-        </node>
-      </node>
-    </node>
-    <node concept="2tJIrI" id="3b1aCyfEJFr" role="jymVt" />
-    <node concept="2tJIrI" id="3b1aCyfK0KZ" role="jymVt" />
-    <node concept="2YIFZL" id="3b1aCyfEME5" role="jymVt">
-      <property role="TrG5h" value="computeIndirectDependencies" />
-      <node concept="37vLTG" id="3b1aCyfENJa" role="3clF46">
-        <property role="TrG5h" value="module2DirectDependencies" />
-        <node concept="3rvAFt" id="3b1aCyfEOlY" role="1tU5fm">
-          <node concept="3uibUv" id="3b1aCyfEOlZ" role="3rvQeY">
-            <ref role="3uigEE" to="lui2:~SModule" resolve="SModule" />
-          </node>
-          <node concept="2hMVRd" id="3b1aCyfEUKw" role="3rvSg0">
-            <node concept="3uibUv" id="3b1aCyfEUKy" role="2hN53Y">
-              <ref role="3uigEE" to="lui2:~SModule" resolve="SModule" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="3clFbS" id="3b1aCyfEME8" role="3clF47">
-        <node concept="3cpWs8" id="3b1aCyfEW7b" role="3cqZAp">
-          <node concept="3cpWsn" id="3b1aCyfEW7e" role="3cpWs9">
-            <property role="TrG5h" value="module2IndirectDependencies" />
-            <node concept="3rvAFt" id="3b1aCyfEW7g" role="1tU5fm">
-              <node concept="3uibUv" id="3b1aCyfEW7h" role="3rvQeY">
-                <ref role="3uigEE" to="lui2:~SModule" resolve="SModule" />
-              </node>
-              <node concept="2hMVRd" id="3b1aCyfEW7i" role="3rvSg0">
-                <node concept="3uibUv" id="3b1aCyfEW7j" role="2hN53Y">
-                  <ref role="3uigEE" to="lui2:~SModule" resolve="SModule" />
-                </node>
-              </node>
-            </node>
-            <node concept="2ShNRf" id="3b1aCyfEXVV" role="33vP2m">
-              <node concept="3rGOSV" id="3b1aCyfF7GI" role="2ShVmc">
-                <node concept="3uibUv" id="3b1aCyfF9ex" role="3rHrn6">
-                  <ref role="3uigEE" to="lui2:~SModule" resolve="SModule" />
-                </node>
-                <node concept="2hMVRd" id="3b1aCyfFa0X" role="3rHtpV">
-                  <node concept="3uibUv" id="3b1aCyfFaO0" role="2hN53Y">
-                    <ref role="3uigEE" to="lui2:~SModule" resolve="SModule" />
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbF" id="3b1aCyfFp40" role="3cqZAp">
-          <node concept="2OqwBi" id="3b1aCyfFqbZ" role="3clFbG">
-            <node concept="37vLTw" id="3b1aCyfFp3Y" role="2Oq$k0">
-              <ref role="3cqZAo" node="3b1aCyfENJa" resolve="module2DirectDependencies" />
-            </node>
-            <node concept="2es0OD" id="3b1aCyfFrQX" role="2OqNvi">
-              <node concept="1bVj0M" id="3b1aCyfFrQZ" role="23t8la">
-                <node concept="3clFbS" id="3b1aCyfFrR0" role="1bW5cS">
-                  <node concept="3clFbF" id="3b1aCyfFtcv" role="3cqZAp">
-                    <node concept="37vLTI" id="3b1aCyfFza4" role="3clFbG">
-                      <node concept="2ShNRf" id="3b1aCyfF$l7" role="37vLTx">
-                        <node concept="2i4dXS" id="3b1aCyfF$eQ" role="2ShVmc">
-                          <node concept="3uibUv" id="3b1aCyfF$eR" role="HW$YZ">
-                            <ref role="3uigEE" to="lui2:~SModule" resolve="SModule" />
-                          </node>
-                          <node concept="2OqwBi" id="3b1aCyfFB4Y" role="I$8f6">
-                            <node concept="37vLTw" id="3b1aCyfFAAW" role="2Oq$k0">
-                              <ref role="3cqZAo" node="6T$NbgWIi05" resolve="it" />
-                            </node>
-                            <node concept="3AV6Ez" id="3b1aCyfFDa9" role="2OqNvi" />
-                          </node>
-                        </node>
-                      </node>
-                      <node concept="3EllGN" id="3b1aCyfFuq9" role="37vLTJ">
-                        <node concept="2OqwBi" id="3b1aCyfFw_U" role="3ElVtu">
-                          <node concept="37vLTw" id="3b1aCyfFvth" role="2Oq$k0">
-                            <ref role="3cqZAo" node="6T$NbgWIi05" resolve="it" />
-                          </node>
-                          <node concept="3AY5_j" id="3b1aCyfFxOY" role="2OqNvi" />
-                        </node>
-                        <node concept="37vLTw" id="3b1aCyfFtcu" role="3ElQJh">
-                          <ref role="3cqZAo" node="3b1aCyfEW7e" resolve="module2IndirectDependencies" />
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                </node>
-                <node concept="gl6BB" id="6T$NbgWIi05" role="1bW2Oz">
-                  <property role="TrG5h" value="it" />
-                  <node concept="2jxLKc" id="6T$NbgWIi06" role="1tU5fm" />
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbH" id="3b1aCyfFo0T" role="3cqZAp" />
-        <node concept="3cpWs8" id="3b1aCyfFigN" role="3cqZAp">
-          <node concept="3cpWsn" id="3b1aCyfFigQ" role="3cpWs9">
-            <property role="TrG5h" value="changesRegistered" />
-            <node concept="10P_77" id="3b1aCyfFigL" role="1tU5fm" />
-            <node concept="3clFbT" id="3b1aCyfFkPU" role="33vP2m">
-              <property role="3clFbU" value="true" />
-            </node>
-          </node>
-        </node>
-        <node concept="2$JKZl" id="3b1aCyfFFA$" role="3cqZAp">
-          <node concept="3clFbS" id="3b1aCyfFFAA" role="2LFqv$">
-            <node concept="3clFbF" id="3b1aCyfFHNx" role="3cqZAp">
-              <node concept="37vLTI" id="3b1aCyfFISM" role="3clFbG">
-                <node concept="3clFbT" id="3b1aCyfFK8m" role="37vLTx" />
-                <node concept="37vLTw" id="3b1aCyfFHNw" role="37vLTJ">
-                  <ref role="3cqZAo" node="3b1aCyfFigQ" resolve="changesRegistered" />
-                </node>
-              </node>
-            </node>
-            <node concept="3clFbH" id="3b1aCyfFKSU" role="3cqZAp" />
-            <node concept="2Gpval" id="3b1aCyfFM2k" role="3cqZAp">
-              <node concept="2GrKxI" id="3b1aCyfFM2m" role="2Gsz3X">
-                <property role="TrG5h" value="crtModule" />
-              </node>
-              <node concept="2OqwBi" id="3b1aCyfFOWJ" role="2GsD0m">
-                <node concept="37vLTw" id="3b1aCyfFNZI" role="2Oq$k0">
-                  <ref role="3cqZAo" node="3b1aCyfEW7e" resolve="module2IndirectDependencies" />
-                </node>
-                <node concept="3lbrtF" id="3b1aCyfFQv_" role="2OqNvi" />
-              </node>
-              <node concept="3clFbS" id="3b1aCyfFM2q" role="2LFqv$">
-                <node concept="3cpWs8" id="3b1aCyfFYY9" role="3cqZAp">
-                  <node concept="3cpWsn" id="3b1aCyfFYYc" role="3cpWs9">
-                    <property role="TrG5h" value="newDependencies" />
-                    <node concept="2hMVRd" id="3b1aCyfFYY5" role="1tU5fm">
-                      <node concept="3uibUv" id="3b1aCyfFZL7" role="2hN53Y">
-                        <ref role="3uigEE" to="lui2:~SModule" resolve="SModule" />
-                      </node>
-                    </node>
-                    <node concept="2ShNRf" id="3b1aCyfG6up" role="33vP2m">
-                      <node concept="2i4dXS" id="3b1aCyfG8M_" role="2ShVmc">
-                        <node concept="3uibUv" id="3b1aCyfGaCz" role="HW$YZ">
-                          <ref role="3uigEE" to="lui2:~SModule" resolve="SModule" />
-                        </node>
-                        <node concept="3EllGN" id="3b1aCyfGcxZ" role="I$8f6">
-                          <node concept="2GrUjf" id="3b1aCyfGcy0" role="3ElVtu">
-                            <ref role="2Gs0qQ" node="3b1aCyfFM2m" resolve="crtModule" />
-                          </node>
-                          <node concept="37vLTw" id="3b1aCyfGcy1" role="3ElQJh">
-                            <ref role="3cqZAo" node="3b1aCyfEW7e" resolve="module2IndirectDependencies" />
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                </node>
-                <node concept="2Gpval" id="3b1aCyfFRF0" role="3cqZAp">
-                  <node concept="2GrKxI" id="3b1aCyfFRF1" role="2Gsz3X">
-                    <property role="TrG5h" value="crtDep" />
-                  </node>
-                  <node concept="3EllGN" id="3b1aCyfFUHZ" role="2GsD0m">
-                    <node concept="2GrUjf" id="3b1aCyfFWog" role="3ElVtu">
-                      <ref role="2Gs0qQ" node="3b1aCyfFM2m" resolve="crtModule" />
-                    </node>
-                    <node concept="37vLTw" id="3b1aCyfFTKY" role="3ElQJh">
-                      <ref role="3cqZAo" node="3b1aCyfEW7e" resolve="module2IndirectDependencies" />
-                    </node>
-                  </node>
-                  <node concept="3clFbS" id="3b1aCyfFRF3" role="2LFqv$">
-                    <node concept="2Gpval" id="3b1aCyfGv95" role="3cqZAp">
-                      <node concept="2GrKxI" id="3b1aCyfGv9c" role="2Gsz3X">
-                        <property role="TrG5h" value="crtIndirectDependency" />
-                      </node>
-                      <node concept="3clFbS" id="3b1aCyfGv9q" role="2LFqv$">
-                        <node concept="3clFbJ" id="3b1aCyfGzQz" role="3cqZAp">
-                          <node concept="3fqX7Q" id="3b1aCyfGEkj" role="3clFbw">
-                            <node concept="2OqwBi" id="3b1aCyfGEkl" role="3fr31v">
-                              <node concept="37vLTw" id="3b1aCyfGEkm" role="2Oq$k0">
-                                <ref role="3cqZAo" node="3b1aCyfFYYc" resolve="newDependencies" />
-                              </node>
-                              <node concept="3JPx81" id="3b1aCyfGEkn" role="2OqNvi">
-                                <node concept="2GrUjf" id="3b1aCyfGEko" role="25WWJ7">
-                                  <ref role="2Gs0qQ" node="3b1aCyfGv9c" resolve="crtIndirectDependency" />
-                                </node>
-                              </node>
-                            </node>
-                          </node>
-                          <node concept="3clFbS" id="3b1aCyfGzQ_" role="3clFbx">
-                            <node concept="3clFbF" id="3b1aCyfGFNZ" role="3cqZAp">
-                              <node concept="37vLTI" id="3b1aCyfGGVi" role="3clFbG">
-                                <node concept="3clFbT" id="3b1aCyfGI6F" role="37vLTx">
-                                  <property role="3clFbU" value="true" />
-                                </node>
-                                <node concept="37vLTw" id="3b1aCyfGFNY" role="37vLTJ">
-                                  <ref role="3cqZAo" node="3b1aCyfFigQ" resolve="changesRegistered" />
-                                </node>
-                              </node>
-                            </node>
-                            <node concept="3clFbF" id="3b1aCyfGKqI" role="3cqZAp">
-                              <node concept="2OqwBi" id="3b1aCyfGLr3" role="3clFbG">
-                                <node concept="37vLTw" id="3b1aCyfGKqG" role="2Oq$k0">
-                                  <ref role="3cqZAo" node="3b1aCyfFYYc" resolve="newDependencies" />
-                                </node>
-                                <node concept="TSZUe" id="3b1aCyfGMLt" role="2OqNvi">
-                                  <node concept="2GrUjf" id="3b1aCyfGOIa" role="25WWJ7">
-                                    <ref role="2Gs0qQ" node="3b1aCyfGv9c" resolve="crtIndirectDependency" />
-                                  </node>
-                                </node>
-                              </node>
-                            </node>
-                          </node>
-                        </node>
-                      </node>
-                      <node concept="3EllGN" id="3b1aCyfGrwy" role="2GsD0m">
-                        <node concept="2GrUjf" id="3b1aCyfGsNR" role="3ElVtu">
-                          <ref role="2Gs0qQ" node="3b1aCyfFRF1" resolve="crtDep" />
-                        </node>
-                        <node concept="37vLTw" id="3b1aCyfGquS" role="3ElQJh">
-                          <ref role="3cqZAo" node="3b1aCyfEW7e" resolve="module2IndirectDependencies" />
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                </node>
-                <node concept="3clFbF" id="3b1aCyfGeLc" role="3cqZAp">
-                  <node concept="37vLTI" id="3b1aCyfGirx" role="3clFbG">
-                    <node concept="37vLTw" id="3b1aCyfGkgL" role="37vLTx">
-                      <ref role="3cqZAo" node="3b1aCyfFYYc" resolve="newDependencies" />
-                    </node>
-                    <node concept="3EllGN" id="3b1aCyfGfJI" role="37vLTJ">
-                      <node concept="2GrUjf" id="3b1aCyfGhwP" role="3ElVtu">
-                        <ref role="2Gs0qQ" node="3b1aCyfFM2m" resolve="crtModule" />
-                      </node>
-                      <node concept="37vLTw" id="3b1aCyfGeLa" role="3ElQJh">
-                        <ref role="3cqZAo" node="3b1aCyfEW7e" resolve="module2IndirectDependencies" />
-                      </node>
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-          <node concept="37vLTw" id="3b1aCyfFGEj" role="2$JKZa">
-            <ref role="3cqZAo" node="3b1aCyfFigQ" resolve="changesRegistered" />
-          </node>
-        </node>
-        <node concept="3clFbH" id="3b1aCyfFElY" role="3cqZAp" />
-        <node concept="3clFbF" id="3b1aCyfFdIv" role="3cqZAp">
-          <node concept="37vLTw" id="3b1aCyfFdIt" role="3clFbG">
-            <ref role="3cqZAo" node="3b1aCyfEW7e" resolve="module2IndirectDependencies" />
-          </node>
-        </node>
-      </node>
-      <node concept="3rvAFt" id="3b1aCyfEM3p" role="3clF45">
-        <node concept="3uibUv" id="3b1aCyfESJB" role="3rvQeY">
-          <ref role="3uigEE" to="lui2:~SModule" resolve="SModule" />
-        </node>
-        <node concept="2hMVRd" id="3b1aCyfETqJ" role="3rvSg0">
-          <node concept="3uibUv" id="3b1aCyfEU60" role="2hN53Y">
-            <ref role="3uigEE" to="lui2:~SModule" resolve="SModule" />
-          </node>
-        </node>
-      </node>
-      <node concept="P$JXv" id="3b1aCyfK8YK" role="lGtFl">
-        <node concept="TZ5HA" id="3b1aCyfK8YL" role="TZ5H$">
-          <node concept="1dT_AC" id="3b1aCyfK8YM" role="1dT_Ay">
-            <property role="1dT_AB" value="Returns a map from a module to all its direct and indirect dependencies." />
-          </node>
-        </node>
-      </node>
-    </node>
-    <node concept="2tJIrI" id="3b1aCyfEJT4" role="jymVt" />
     <node concept="3Tm1VV" id="4aEqBbbBtjG" role="1B3o_S" />
   </node>
   <node concept="1MIHA_" id="7CQ_Wpsik$H">
@@ -6898,19 +5300,53 @@
         </node>
         <node concept="L3pyB" id="44nYoQPiwi4" role="3cqZAp">
           <node concept="3clFbS" id="44nYoQPiwi5" role="L3pyw">
-            <node concept="3clFbF" id="44nYoQPiwi6" role="3cqZAp">
-              <node concept="2YIFZM" id="44nYoQPlztg" role="3clFbG">
-                <ref role="37wK5l" node="44nYoQPiJ59" resolve="computeTooLargeStronglyConnectedComponents" />
-                <ref role="1Pybhc" node="4aEqBbbBtjF" resolve="CyclicModuleDependenciesHelper" />
-                <node concept="2OqwBi" id="44nYoQPlzth" role="37wK5m">
-                  <node concept="EzsRk" id="44nYoQPlzti" role="2Oq$k0" />
-                  <node concept="ANE8D" id="44nYoQPlztj" role="2OqNvi" />
+            <node concept="3clFbF" id="13En2Fw7X_F" role="3cqZAp">
+              <node concept="2OqwBi" id="13En2Fw8iWs" role="3clFbG">
+                <node concept="2YIFZM" id="13En2Fw7XZv" role="2Oq$k0">
+                  <ref role="37wK5l" node="13En2FvVD7A" resolve="getDependenciesHelper" />
+                  <ref role="1Pybhc" node="4aEqBbbBtjF" resolve="CyclicModuleDependenciesHelper" />
+                  <node concept="3clFbT" id="13En2Fw8h9N" role="37wK5m" />
+                  <node concept="2OqwBi" id="13En2Fw8hY7" role="37wK5m">
+                    <node concept="1MG55F" id="13En2Fw8hme" role="2Oq$k0" />
+                    <node concept="liA8E" id="13En2Fw8iLv" role="2OqNvi">
+                      <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                    </node>
+                  </node>
                 </node>
-                <node concept="37vLTw" id="44nYoQPlztk" role="37wK5m">
-                  <ref role="3cqZAo" node="44nYoQPiwhX" resolve="res" />
-                </node>
-                <node concept="2j1LYi" id="44nYoQPlztl" role="37wK5m">
-                  <ref role="2j1LYj" node="44nYoQPiwgH" resolve="stronglyConnectedComponentSize" />
+                <node concept="liA8E" id="13En2Fw8jsR" role="2OqNvi">
+                  <ref role="37wK5l" node="13En2Fvr$Iu" resolve="computeTooLargeStronglyConnectedComponents" />
+                  <node concept="2OqwBi" id="13En2Fw8jE$" role="37wK5m">
+                    <node concept="2OqwBi" id="13En2Fw8BT0" role="2Oq$k0">
+                      <node concept="EzsRk" id="13En2Fw8jE_" role="2Oq$k0" />
+                      <node concept="3$u5V9" id="13En2Fw8CCO" role="2OqNvi">
+                        <node concept="1bVj0M" id="13En2Fw8CCQ" role="23t8la">
+                          <node concept="3clFbS" id="13En2Fw8CCR" role="1bW5cS">
+                            <node concept="3clFbF" id="13En2Fw8CQG" role="3cqZAp">
+                              <node concept="2OqwBi" id="13En2Fw8D0e" role="3clFbG">
+                                <node concept="37vLTw" id="13En2Fw8CQF" role="2Oq$k0">
+                                  <ref role="3cqZAo" node="13En2Fw8CCS" resolve="it" />
+                                </node>
+                                <node concept="liA8E" id="13En2Fw8Drh" role="2OqNvi">
+                                  <ref role="37wK5l" to="lui2:~SModule.getModuleReference()" resolve="getModuleReference" />
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                          <node concept="gl6BB" id="13En2Fw8CCS" role="1bW2Oz">
+                            <property role="TrG5h" value="it" />
+                            <node concept="2jxLKc" id="13En2Fw8CCT" role="1tU5fm" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="ANE8D" id="13En2Fw8jEA" role="2OqNvi" />
+                  </node>
+                  <node concept="37vLTw" id="13En2Fw8jUN" role="37wK5m">
+                    <ref role="3cqZAo" node="44nYoQPiwhX" resolve="res" />
+                  </node>
+                  <node concept="2j1LYi" id="13En2Fw8kns" role="37wK5m">
+                    <ref role="2j1LYj" node="44nYoQPiwgH" resolve="stronglyConnectedComponentSize" />
+                  </node>
                 </node>
               </node>
             </node>
@@ -7538,22 +5974,65 @@
         <node concept="3clFbH" id="1Yf9e2l9xh7" role="3cqZAp" />
         <node concept="L3pyB" id="1Yf9e2l9xh8" role="3cqZAp">
           <node concept="3clFbS" id="1Yf9e2l9xh9" role="L3pyw">
-            <node concept="3clFbF" id="1Yf9e2l9xha" role="3cqZAp">
-              <node concept="2YIFZM" id="1Yf9e2l9yB8" role="3clFbG">
-                <ref role="37wK5l" node="1Yf9e2l9dIN" resolve="computeCyclesWithSize" />
-                <ref role="1Pybhc" node="4aEqBbbBtjF" resolve="CyclicModuleDependenciesHelper" />
-                <node concept="2OqwBi" id="1Yf9e2l9yB9" role="37wK5m">
-                  <node concept="EzsRk" id="1Yf9e2l9yBa" role="2Oq$k0" />
-                  <node concept="ANE8D" id="1Yf9e2l9yBb" role="2OqNvi" />
+            <node concept="3clFbF" id="13En2Fwehi1" role="3cqZAp">
+              <node concept="2OqwBi" id="13En2FwejG$" role="3clFbG">
+                <node concept="2YIFZM" id="13En2FwehIy" role="2Oq$k0">
+                  <ref role="37wK5l" node="13En2FvVD7A" resolve="getDependenciesHelper" />
+                  <ref role="1Pybhc" node="4aEqBbbBtjF" resolve="CyclicModuleDependenciesHelper" />
+                  <node concept="2j1LYi" id="13En2FwehPU" role="37wK5m">
+                    <ref role="2j1LYj" node="1SbpUw9U72h" resolve="considerUsedLanguages" />
+                  </node>
+                  <node concept="2OqwBi" id="13En2FweiGX" role="37wK5m">
+                    <node concept="1MG55F" id="13En2Fwei4S" role="2Oq$k0" />
+                    <node concept="liA8E" id="13En2Fwejv1" role="2OqNvi">
+                      <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
+                    </node>
+                  </node>
                 </node>
-                <node concept="37vLTw" id="1Yf9e2l9yBc" role="37wK5m">
-                  <ref role="3cqZAo" node="1Yf9e2l9xh1" resolve="res" />
-                </node>
-                <node concept="2j1LYi" id="1SbpUw9U7tq" role="37wK5m">
-                  <ref role="2j1LYj" node="1SbpUw9U72h" resolve="considerUsedLanguages" />
-                </node>
-                <node concept="2j1LYi" id="1Yf9e2l9yBd" role="37wK5m">
-                  <ref role="2j1LYj" node="1Yf9e2l9xfD" resolve="cycleLength" />
+                <node concept="liA8E" id="13En2Fwekf_" role="2OqNvi">
+                  <ref role="37wK5l" node="13En2FvuLfD" resolve="computeCyclesWithSize" />
+                  <node concept="2OqwBi" id="13En2FwenKa" role="37wK5m">
+                    <node concept="2OqwBi" id="13En2Fwelle" role="2Oq$k0">
+                      <node concept="EzsRk" id="13En2FweksP" role="2Oq$k0" />
+                      <node concept="3$u5V9" id="13En2Fwem6Y" role="2OqNvi">
+                        <node concept="1bVj0M" id="13En2Fwem70" role="23t8la">
+                          <node concept="3clFbS" id="13En2Fwem71" role="1bW5cS">
+                            <node concept="3clFbF" id="13En2FwemtB" role="3cqZAp">
+                              <node concept="2OqwBi" id="13En2Fwem_U" role="3clFbG">
+                                <node concept="37vLTw" id="13En2FwemtA" role="2Oq$k0">
+                                  <ref role="3cqZAo" node="13En2Fwem72" resolve="it" />
+                                </node>
+                                <node concept="liA8E" id="13En2FwemWa" role="2OqNvi">
+                                  <ref role="37wK5l" to="lui2:~SModule.getModuleReference()" resolve="getModuleReference" />
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                          <node concept="gl6BB" id="13En2Fwem72" role="1bW2Oz">
+                            <property role="TrG5h" value="it" />
+                            <node concept="2jxLKc" id="13En2Fwem73" role="1tU5fm" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="ANE8D" id="13En2FweoHt" role="2OqNvi" />
+                  </node>
+                  <node concept="37vLTw" id="13En2Fwepd_" role="37wK5m">
+                    <ref role="3cqZAo" node="1Yf9e2l9xh1" resolve="res" />
+                  </node>
+                  <node concept="3K4zz7" id="13En2Fwgw1i" role="37wK5m">
+                    <node concept="10M0yZ" id="13En2FwgwQ6" role="3K4E3e">
+                      <ref role="3cqZAo" node="13En2FvYTVe" resolve="CONSIDER_USED_LANGUAGES_OPTION" />
+                      <ref role="1PxDUh" node="4aEqBbbBtjF" resolve="CyclicModuleDependenciesHelper" />
+                    </node>
+                    <node concept="10Nm6u" id="13En2Fwgx6V" role="3K4GZi" />
+                    <node concept="2j1LYi" id="13En2Fwepyo" role="3K4Cdx">
+                      <ref role="2j1LYj" node="1SbpUw9U72h" resolve="considerUsedLanguages" />
+                    </node>
+                  </node>
+                  <node concept="2j1LYi" id="13En2FweqKE" role="37wK5m">
+                    <ref role="2j1LYj" node="1Yf9e2l9xfD" resolve="cycleLength" />
+                  </node>
                 </node>
               </node>
             </node>
@@ -7585,724 +6064,6 @@
       <property role="TrG5h" value="considerUsedLanguages" />
       <node concept="10P_77" id="1SbpUw9U72A" role="2j1LY4" />
     </node>
-  </node>
-  <node concept="312cEu" id="1u5Q3uAE36L">
-    <property role="3GE5qa" value="helpers" />
-    <property role="TrG5h" value="CyclicModuleDependenciesFromStartingPointHelper" />
-    <node concept="3Tm1VV" id="1u5Q3uAE36M" role="1B3o_S" />
-    <node concept="2tJIrI" id="1u5Q3uAEMW9" role="jymVt" />
-    <node concept="2YIFZL" id="4Y9rGZaeVz$" role="jymVt">
-      <property role="TrG5h" value="computeSomeCycles" />
-      <node concept="3clFbS" id="4Y9rGZaevzZ" role="3clF47">
-        <node concept="3cpWs8" id="4Y9rGZagHN_" role="3cqZAp">
-          <node concept="3cpWsn" id="4Y9rGZagHNA" role="3cpWs9">
-            <property role="TrG5h" value="startingModules" />
-            <node concept="_YKpA" id="4Y9rGZagHkB" role="1tU5fm">
-              <node concept="3uibUv" id="4Y9rGZagHkE" role="_ZDj9">
-                <ref role="3uigEE" to="lui2:~SModule" resolve="SModule" />
-              </node>
-            </node>
-            <node concept="2ShNRf" id="4Y9rGZagHNB" role="33vP2m">
-              <node concept="Tc6Ow" id="4Y9rGZagHNC" role="2ShVmc">
-                <node concept="3uibUv" id="4Y9rGZagHND" role="HW$YZ">
-                  <ref role="3uigEE" to="lui2:~SModule" resolve="SModule" />
-                </node>
-                <node concept="37vLTw" id="4Y9rGZagHNE" role="HW$Y0">
-                  <ref role="3cqZAo" node="4Y9rGZafqBr" resolve="startingModule" />
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3cpWs8" id="4Y9rGZafGxf" role="3cqZAp">
-          <node concept="3cpWsn" id="4Y9rGZafGxg" role="3cpWs9">
-            <property role="TrG5h" value="someCyclesStartingFrom" />
-            <node concept="2YIFZM" id="1u5Q3uAEtYv" role="33vP2m">
-              <ref role="37wK5l" node="63imCwJLCQe" resolve="findSomeCyclesStartingFrom" />
-              <ref role="1Pybhc" node="1u5Q3uAE36L" resolve="CyclicModuleDependenciesFromStartingPointHelper" />
-              <node concept="37vLTw" id="4Y9rGZag7Zh" role="37wK5m">
-                <ref role="3cqZAo" node="4Y9rGZaeQEX" resolve="modules" />
-              </node>
-              <node concept="37vLTw" id="4Y9rGZagkYk" role="37wK5m">
-                <ref role="3cqZAo" node="4Y9rGZagHNA" resolve="startingModules" />
-              </node>
-              <node concept="37vLTw" id="4Y9rGZahjIJ" role="37wK5m">
-                <ref role="3cqZAo" node="4Y9rGZaeQF3" resolve="includeUsedLanguages" />
-              </node>
-            </node>
-            <node concept="A3Dl8" id="4Y9rGZafGxv" role="1tU5fm">
-              <node concept="_YKpA" id="4Y9rGZafGxw" role="A3Ik2">
-                <node concept="3uibUv" id="4Y9rGZafGxx" role="_ZDj9">
-                  <ref role="3uigEE" to="lui2:~SModule" resolve="SModule" />
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="2Gpval" id="4Y9rGZafGxy" role="3cqZAp">
-          <node concept="2GrKxI" id="4Y9rGZafGxz" role="2Gsz3X">
-            <property role="TrG5h" value="crtCycle" />
-          </node>
-          <node concept="37vLTw" id="4Y9rGZafGx$" role="2GsD0m">
-            <ref role="3cqZAo" node="4Y9rGZafGxg" resolve="someCyclesStartingFrom" />
-          </node>
-          <node concept="3clFbS" id="4Y9rGZafGx_" role="2LFqv$">
-            <node concept="3cpWs8" id="4Y9rGZafGxU" role="3cqZAp">
-              <node concept="3cpWsn" id="4Y9rGZafGxV" role="3cpWs9">
-                <property role="TrG5h" value="msg" />
-                <node concept="17QB3L" id="4Y9rGZafGxW" role="1tU5fm" />
-                <node concept="3cpWs3" id="4Y9rGZafGxX" role="33vP2m">
-                  <node concept="3cpWs3" id="4Y9rGZafGxY" role="3uHU7B">
-                    <node concept="3cpWs3" id="4Y9rGZafGxZ" role="3uHU7B">
-                      <node concept="Xl_RD" id="4Y9rGZafGy0" role="3uHU7B">
-                        <property role="Xl_RC" value="Cyclic dependency with length " />
-                      </node>
-                      <node concept="2OqwBi" id="4Y9rGZafGy1" role="3uHU7w">
-                        <node concept="2GrUjf" id="4Y9rGZafGy2" role="2Oq$k0">
-                          <ref role="2Gs0qQ" node="4Y9rGZafGxz" resolve="crtCycle" />
-                        </node>
-                        <node concept="34oBXx" id="4Y9rGZafGy3" role="2OqNvi" />
-                      </node>
-                    </node>
-                    <node concept="Xl_RD" id="4Y9rGZafGy4" role="3uHU7w">
-                      <property role="Xl_RC" value=" found: " />
-                    </node>
-                  </node>
-                  <node concept="2OqwBi" id="7MmUcJi$Bqs" role="3uHU7w">
-                    <node concept="2OqwBi" id="7MmUcJi$fZp" role="2Oq$k0">
-                      <node concept="2GrUjf" id="7MmUcJi$bGD" role="2Oq$k0">
-                        <ref role="2Gs0qQ" node="4Y9rGZafGxz" resolve="crtCycle" />
-                      </node>
-                      <node concept="3$u5V9" id="7MmUcJi$lB2" role="2OqNvi">
-                        <node concept="1bVj0M" id="7MmUcJi$lB4" role="23t8la">
-                          <node concept="3clFbS" id="7MmUcJi$lB5" role="1bW5cS">
-                            <node concept="3clFbF" id="7MmUcJi$qVE" role="3cqZAp">
-                              <node concept="2OqwBi" id="7MmUcJi$v6E" role="3clFbG">
-                                <node concept="37vLTw" id="7MmUcJi$qVD" role="2Oq$k0">
-                                  <ref role="3cqZAo" node="k7wBuATO4c" resolve="it" />
-                                </node>
-                                <node concept="liA8E" id="7MmUcJi_0QV" role="2OqNvi">
-                                  <ref role="37wK5l" to="wyt6:~Object.toString()" resolve="toString" />
-                                </node>
-                              </node>
-                            </node>
-                          </node>
-                          <node concept="gl6BB" id="k7wBuATO4c" role="1bW2Oz">
-                            <property role="TrG5h" value="it" />
-                            <node concept="2jxLKc" id="k7wBuATO4d" role="1tU5fm" />
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                    <node concept="3uJxvA" id="7MmUcJi$Ggt" role="2OqNvi">
-                      <node concept="Xl_RD" id="7MmUcJi$OUY" role="3uJOhx">
-                        <property role="Xl_RC" value=", " />
-                      </node>
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-            <node concept="3clFbF" id="4Y9rGZafGy7" role="3cqZAp">
-              <node concept="2OqwBi" id="4Y9rGZafGy8" role="3clFbG">
-                <node concept="37vLTw" id="4Y9rGZafGy9" role="2Oq$k0">
-                  <ref role="3cqZAo" node="7MmUcJioAwf" resolve="res" />
-                </node>
-                <node concept="TSZUe" id="4Y9rGZafGya" role="2OqNvi">
-                  <node concept="37vLTw" id="4Y9rGZafGyb" role="25WWJ7">
-                    <ref role="3cqZAo" node="4Y9rGZafGxV" resolve="msg" />
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="37vLTG" id="4Y9rGZaeQEX" role="3clF46">
-        <property role="TrG5h" value="modules" />
-        <node concept="_YKpA" id="4Y9rGZaeQEY" role="1tU5fm">
-          <node concept="3uibUv" id="4Y9rGZaeQEZ" role="_ZDj9">
-            <ref role="3uigEE" to="lui2:~SModule" resolve="SModule" />
-          </node>
-        </node>
-      </node>
-      <node concept="37vLTG" id="4Y9rGZafqBr" role="3clF46">
-        <property role="TrG5h" value="startingModule" />
-        <node concept="3uibUv" id="4Y9rGZafCLY" role="1tU5fm">
-          <ref role="3uigEE" to="lui2:~SModule" resolve="SModule" />
-        </node>
-      </node>
-      <node concept="37vLTG" id="7MmUcJioAwf" role="3clF46">
-        <property role="TrG5h" value="res" />
-        <node concept="_YKpA" id="7MmUcJioAwg" role="1tU5fm">
-          <node concept="17QB3L" id="7MmUcJioAwh" role="_ZDj9" />
-        </node>
-      </node>
-      <node concept="37vLTG" id="4Y9rGZaeQF3" role="3clF46">
-        <property role="TrG5h" value="includeUsedLanguages" />
-        <node concept="10P_77" id="4Y9rGZaf3jz" role="1tU5fm" />
-      </node>
-      <node concept="3cqZAl" id="7MmUcJioS$y" role="3clF45" />
-      <node concept="3Tm1VV" id="7MmUcJiw0MX" role="1B3o_S" />
-    </node>
-    <node concept="2tJIrI" id="1u5Q3uAFvG6" role="jymVt" />
-    <node concept="2YIFZL" id="63imCwJM1NN" role="jymVt">
-      <property role="TrG5h" value="DFSRecursive" />
-      <node concept="3clFbS" id="63imCwJlpcA" role="3clF47">
-        <node concept="3clFbF" id="63imCwJlqvh" role="3cqZAp">
-          <node concept="2OqwBi" id="63imCwJn690" role="3clFbG">
-            <node concept="37vLTw" id="63imCwJn4Rw" role="2Oq$k0">
-              <ref role="3cqZAo" node="63imCwJlpzx" resolve="visited" />
-            </node>
-            <node concept="TSZUe" id="63imCwJn7lI" role="2OqNvi">
-              <node concept="37vLTw" id="63imCwJn8c8" role="25WWJ7">
-                <ref role="3cqZAo" node="63imCwJlprG" resolve="currentModule" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbF" id="63imCwJqeQZ" role="3cqZAp">
-          <node concept="2OqwBi" id="63imCwJqg9X" role="3clFbG">
-            <node concept="37vLTw" id="63imCwJqeQX" role="2Oq$k0">
-              <ref role="3cqZAo" node="63imCwJqbwu" resolve="path" />
-            </node>
-            <node concept="TSZUe" id="63imCwJqhDo" role="2OqNvi">
-              <node concept="37vLTw" id="63imCwJqih3" role="25WWJ7">
-                <ref role="3cqZAo" node="63imCwJlprG" resolve="currentModule" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="2Gpval" id="63imCwJlJRI" role="3cqZAp">
-          <node concept="2GrKxI" id="63imCwJlJRK" role="2Gsz3X">
-            <property role="TrG5h" value="dependency" />
-          </node>
-          <node concept="3EllGN" id="63imCwJlLcA" role="2GsD0m">
-            <node concept="37vLTw" id="63imCwJlLzj" role="3ElVtu">
-              <ref role="3cqZAo" node="63imCwJlprG" resolve="currentModule" />
-            </node>
-            <node concept="37vLTw" id="63imCwJ_xVe" role="3ElQJh">
-              <ref role="3cqZAo" node="63imCwJ$O0W" resolve="directDependencies" />
-            </node>
-          </node>
-          <node concept="3clFbS" id="63imCwJlJRO" role="2LFqv$">
-            <node concept="3clFbF" id="63imCwJlQEy" role="3cqZAp">
-              <node concept="2Sg_IR" id="63imCwJlQZi" role="3clFbG">
-                <node concept="37vLTw" id="63imCwJlQZj" role="2SgG2M">
-                  <ref role="3cqZAo" node="63imCwJlN$y" resolve="action" />
-                </node>
-                <node concept="2GrUjf" id="63imCwJulnX" role="2SgHGx">
-                  <ref role="2Gs0qQ" node="63imCwJlJRK" resolve="dependency" />
-                </node>
-                <node concept="2OqwBi" id="63imCwJE_nC" role="2SgHGx">
-                  <node concept="3EllGN" id="63imCwJqI39" role="2Oq$k0">
-                    <node concept="2GrUjf" id="63imCwJum4Z" role="3ElVtu">
-                      <ref role="2Gs0qQ" node="63imCwJlJRK" resolve="dependency" />
-                    </node>
-                    <node concept="37vLTw" id="63imCwJ_Dex" role="3ElQJh">
-                      <ref role="3cqZAo" node="63imCwJ$O0W" resolve="directDependencies" />
-                    </node>
-                  </node>
-                  <node concept="ANE8D" id="63imCwJEE39" role="2OqNvi" />
-                </node>
-                <node concept="37vLTw" id="63imCwJoStS" role="2SgHGx">
-                  <ref role="3cqZAo" node="63imCwJlpzx" resolve="visited" />
-                </node>
-                <node concept="37vLTw" id="63imCwJqsXM" role="2SgHGx">
-                  <ref role="3cqZAo" node="63imCwJqbwu" resolve="path" />
-                </node>
-              </node>
-            </node>
-            <node concept="3clFbJ" id="63imCwJlw_c" role="3cqZAp">
-              <node concept="3fqX7Q" id="63imCwJlw_d" role="3clFbw">
-                <node concept="2OqwBi" id="63imCwJnbkc" role="3fr31v">
-                  <node concept="37vLTw" id="63imCwJnaTG" role="2Oq$k0">
-                    <ref role="3cqZAo" node="63imCwJlpzx" resolve="visited" />
-                  </node>
-                  <node concept="3JPx81" id="63imCwJnbLF" role="2OqNvi">
-                    <node concept="2GrUjf" id="63imCwJnc8y" role="25WWJ7">
-                      <ref role="2Gs0qQ" node="63imCwJlJRK" resolve="dependency" />
-                    </node>
-                  </node>
-                </node>
-              </node>
-              <node concept="3clFbS" id="63imCwJlw_h" role="3clFbx">
-                <node concept="3clFbF" id="63imCwJlw_i" role="3cqZAp">
-                  <node concept="1rXfSq" id="1u5Q3uAEtYr" role="3clFbG">
-                    <ref role="37wK5l" node="63imCwJM1NN" resolve="DFSRecursive" />
-                    <node concept="2GrUjf" id="63imCwJlNd5" role="37wK5m">
-                      <ref role="2Gs0qQ" node="63imCwJlJRK" resolve="dependency" />
-                    </node>
-                    <node concept="37vLTw" id="63imCwJFLPz" role="37wK5m">
-                      <ref role="3cqZAo" node="63imCwJ$O0W" resolve="directDependencies" />
-                    </node>
-                    <node concept="37vLTw" id="63imCwJlSYX" role="37wK5m">
-                      <ref role="3cqZAo" node="63imCwJlN$y" resolve="action" />
-                    </node>
-                    <node concept="37vLTw" id="63imCwJlw_l" role="37wK5m">
-                      <ref role="3cqZAo" node="63imCwJlpzx" resolve="visited" />
-                    </node>
-                    <node concept="2ShNRf" id="63imCwJqm$p" role="37wK5m">
-                      <node concept="Tc6Ow" id="63imCwJqmxK" role="2ShVmc">
-                        <node concept="3uibUv" id="63imCwJF53j" role="HW$YZ">
-                          <ref role="3uigEE" to="lui2:~SModule" resolve="SModule" />
-                        </node>
-                        <node concept="2OqwBi" id="63imCwJFyu7" role="I$8f6">
-                          <node concept="37vLTw" id="63imCwJqo9q" role="2Oq$k0">
-                            <ref role="3cqZAo" node="63imCwJqbwu" resolve="path" />
-                          </node>
-                          <node concept="ANE8D" id="63imCwJFBLU" role="2OqNvi" />
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="37vLTG" id="63imCwJlprG" role="3clF46">
-        <property role="TrG5h" value="currentModule" />
-        <node concept="3uibUv" id="63imCwJ$qr3" role="1tU5fm">
-          <ref role="3uigEE" to="lui2:~SModule" resolve="SModule" />
-        </node>
-      </node>
-      <node concept="37vLTG" id="63imCwJ$O0W" role="3clF46">
-        <property role="TrG5h" value="directDependencies" />
-        <node concept="3rvAFt" id="63imCwJ$RIm" role="1tU5fm">
-          <node concept="3uibUv" id="63imCwJ$Vlz" role="3rvQeY">
-            <ref role="3uigEE" to="lui2:~SModule" resolve="SModule" />
-          </node>
-          <node concept="2hMVRd" id="63imCwJ_mWw" role="3rvSg0">
-            <node concept="3uibUv" id="63imCwJ_q$d" role="2hN53Y">
-              <ref role="3uigEE" to="lui2:~SModule" resolve="SModule" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="37vLTG" id="63imCwJlN$y" role="3clF46">
-        <property role="TrG5h" value="action" />
-        <node concept="1ajhzC" id="63imCwJlO5K" role="1tU5fm">
-          <node concept="3cqZAl" id="63imCwJlP5A" role="1ajl9A" />
-          <node concept="3uibUv" id="63imCwJ$umD" role="1ajw0F">
-            <ref role="3uigEE" to="lui2:~SModule" resolve="SModule" />
-          </node>
-          <node concept="_YKpA" id="63imCwJqCqD" role="1ajw0F">
-            <node concept="3uibUv" id="63imCwJ$xTC" role="_ZDj9">
-              <ref role="3uigEE" to="lui2:~SModule" resolve="SModule" />
-            </node>
-          </node>
-          <node concept="2hMVRd" id="63imCwJoR9$" role="1ajw0F">
-            <node concept="3uibUv" id="63imCwJ$_sA" role="2hN53Y">
-              <ref role="3uigEE" to="lui2:~SModule" resolve="SModule" />
-            </node>
-          </node>
-          <node concept="_YKpA" id="63imCwJqr6D" role="1ajw0F">
-            <node concept="3uibUv" id="63imCwJ$CXH" role="_ZDj9">
-              <ref role="3uigEE" to="lui2:~SModule" resolve="SModule" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="37vLTG" id="63imCwJlpzx" role="3clF46">
-        <property role="TrG5h" value="visited" />
-        <node concept="2hMVRd" id="63imCwJn2io" role="1tU5fm">
-          <node concept="3uibUv" id="63imCwJ$Gt2" role="2hN53Y">
-            <ref role="3uigEE" to="lui2:~SModule" resolve="SModule" />
-          </node>
-        </node>
-      </node>
-      <node concept="37vLTG" id="63imCwJqbwu" role="3clF46">
-        <property role="TrG5h" value="path" />
-        <node concept="_YKpA" id="63imCwJqcmk" role="1tU5fm">
-          <node concept="3uibUv" id="63imCwJ$JYt" role="_ZDj9">
-            <ref role="3uigEE" to="lui2:~SModule" resolve="SModule" />
-          </node>
-        </node>
-      </node>
-      <node concept="3cqZAl" id="63imCwJloTr" role="3clF45" />
-    </node>
-    <node concept="2tJIrI" id="63imCwJ_GWT" role="jymVt" />
-    <node concept="2YIFZL" id="63imCwJLTCL" role="jymVt">
-      <property role="TrG5h" value="DFS" />
-      <node concept="3clFbS" id="63imCwJlVcG" role="3clF47">
-        <node concept="3clFbF" id="63imCwJlYxO" role="3cqZAp">
-          <node concept="1rXfSq" id="1u5Q3uAEtYs" role="3clFbG">
-            <ref role="37wK5l" node="63imCwJM1NN" resolve="DFSRecursive" />
-            <node concept="37vLTw" id="63imCwJlYTB" role="37wK5m">
-              <ref role="3cqZAo" node="63imCwJlVEq" resolve="startNode" />
-            </node>
-            <node concept="37vLTw" id="63imCwJFV2Y" role="37wK5m">
-              <ref role="3cqZAo" node="63imCwJAndC" resolve="directDependencies" />
-            </node>
-            <node concept="37vLTw" id="63imCwJm3uJ" role="37wK5m">
-              <ref role="3cqZAo" node="63imCwJlWY1" resolve="action" />
-            </node>
-            <node concept="2ShNRf" id="63imCwJlZEz" role="37wK5m">
-              <node concept="2i4dXS" id="63imCwJndEJ" role="2ShVmc">
-                <node concept="3uibUv" id="63imCwJAc1S" role="HW$YZ">
-                  <ref role="3uigEE" to="lui2:~SModule" resolve="SModule" />
-                </node>
-              </node>
-            </node>
-            <node concept="2ShNRf" id="63imCwJqpBD" role="37wK5m">
-              <node concept="Tc6Ow" id="63imCwJqp_0" role="2ShVmc">
-                <node concept="3uibUv" id="63imCwJAfIE" role="HW$YZ">
-                  <ref role="3uigEE" to="lui2:~SModule" resolve="SModule" />
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="37vLTG" id="63imCwJlVEq" role="3clF46">
-        <property role="TrG5h" value="startNode" />
-        <node concept="3uibUv" id="63imCwJ_PVe" role="1tU5fm">
-          <ref role="3uigEE" to="lui2:~SModule" resolve="SModule" />
-        </node>
-      </node>
-      <node concept="37vLTG" id="63imCwJAndC" role="3clF46">
-        <property role="TrG5h" value="directDependencies" />
-        <node concept="3rvAFt" id="63imCwJAndD" role="1tU5fm">
-          <node concept="3uibUv" id="63imCwJAndE" role="3rvQeY">
-            <ref role="3uigEE" to="lui2:~SModule" resolve="SModule" />
-          </node>
-          <node concept="2hMVRd" id="63imCwJAndF" role="3rvSg0">
-            <node concept="3uibUv" id="63imCwJAndG" role="2hN53Y">
-              <ref role="3uigEE" to="lui2:~SModule" resolve="SModule" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="37vLTG" id="63imCwJlWY1" role="3clF46">
-        <property role="TrG5h" value="action" />
-        <node concept="1ajhzC" id="63imCwJlXx$" role="1tU5fm">
-          <node concept="3cqZAl" id="63imCwJlY03" role="1ajl9A" />
-          <node concept="3uibUv" id="63imCwJ_V01" role="1ajw0F">
-            <ref role="3uigEE" to="lui2:~SModule" resolve="SModule" />
-          </node>
-          <node concept="_YKpA" id="63imCwJqFLT" role="1ajw0F">
-            <node concept="3uibUv" id="63imCwJ_Zud" role="_ZDj9">
-              <ref role="3uigEE" to="lui2:~SModule" resolve="SModule" />
-            </node>
-          </node>
-          <node concept="2hMVRd" id="63imCwJoPZz" role="1ajw0F">
-            <node concept="3uibUv" id="63imCwJA3dq" role="2hN53Y">
-              <ref role="3uigEE" to="lui2:~SModule" resolve="SModule" />
-            </node>
-          </node>
-          <node concept="_YKpA" id="63imCwJquqB" role="1ajw0F">
-            <node concept="3uibUv" id="63imCwJA78a" role="_ZDj9">
-              <ref role="3uigEE" to="lui2:~SModule" resolve="SModule" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="3cqZAl" id="63imCwJlV77" role="3clF45" />
-    </node>
-    <node concept="2tJIrI" id="63imCwJBdsl" role="jymVt" />
-    <node concept="2YIFZL" id="63imCwJLLYC" role="jymVt">
-      <property role="TrG5h" value="DFS" />
-      <node concept="3clFbS" id="63imCwJBoip" role="3clF47">
-        <node concept="3cpWs8" id="63imCwJDa80" role="3cqZAp">
-          <node concept="3cpWsn" id="63imCwJDa81" role="3cpWs9">
-            <property role="TrG5h" value="directModuleDependencies" />
-            <node concept="3rvAFt" id="63imCwJD6hp" role="1tU5fm">
-              <node concept="3uibUv" id="63imCwJD6h$" role="3rvQeY">
-                <ref role="3uigEE" to="lui2:~SModule" resolve="SModule" />
-              </node>
-              <node concept="2hMVRd" id="63imCwJD6hy" role="3rvSg0">
-                <node concept="3uibUv" id="63imCwJD6hz" role="2hN53Y">
-                  <ref role="3uigEE" to="lui2:~SModule" resolve="SModule" />
-                </node>
-              </node>
-            </node>
-            <node concept="2YIFZM" id="1u5Q3uAFgwa" role="33vP2m">
-              <ref role="37wK5l" node="3b1aCyg4gsX" resolve="computeDirectModuleDependencies" />
-              <ref role="1Pybhc" node="4aEqBbbBtjF" resolve="CyclicModuleDependenciesHelper" />
-              <node concept="37vLTw" id="1u5Q3uAELys" role="37wK5m">
-                <ref role="3cqZAo" node="63imCwJBsmg" resolve="modules" />
-              </node>
-              <node concept="37vLTw" id="1u5Q3uAELyt" role="37wK5m">
-                <ref role="3cqZAo" node="63imCwJBZTS" resolve="includeUsedLanguages" />
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbF" id="63imCwJCp6L" role="3cqZAp">
-          <node concept="2OqwBi" id="63imCwJCtHO" role="3clFbG">
-            <node concept="37vLTw" id="63imCwJCp6J" role="2Oq$k0">
-              <ref role="3cqZAo" node="63imCwJB$bt" resolve="startingModules" />
-            </node>
-            <node concept="2es0OD" id="63imCwJCzv$" role="2OqNvi">
-              <node concept="1bVj0M" id="63imCwJCzvA" role="23t8la">
-                <node concept="3clFbS" id="63imCwJCzvB" role="1bW5cS">
-                  <node concept="3clFbF" id="63imCwJCRGN" role="3cqZAp">
-                    <node concept="1rXfSq" id="1u5Q3uAEtYt" role="3clFbG">
-                      <ref role="37wK5l" node="63imCwJLTCL" resolve="DFS" />
-                      <node concept="37vLTw" id="63imCwJCWaP" role="37wK5m">
-                        <ref role="3cqZAo" node="k7wBuATO4e" resolve="startingMod" />
-                      </node>
-                      <node concept="37vLTw" id="63imCwJDxE5" role="37wK5m">
-                        <ref role="3cqZAo" node="63imCwJDa81" resolve="directModuleDependencies" />
-                      </node>
-                      <node concept="37vLTw" id="63imCwJDB83" role="37wK5m">
-                        <ref role="3cqZAo" node="63imCwJCNf5" resolve="action" />
-                      </node>
-                    </node>
-                  </node>
-                </node>
-                <node concept="gl6BB" id="k7wBuATO4e" role="1bW2Oz">
-                  <property role="TrG5h" value="startingMod" />
-                  <node concept="2jxLKc" id="k7wBuATO4f" role="1tU5fm" />
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="37vLTG" id="63imCwJBsmg" role="3clF46">
-        <property role="TrG5h" value="modules" />
-        <node concept="_YKpA" id="63imCwJBsme" role="1tU5fm">
-          <node concept="3uibUv" id="63imCwJBwlS" role="_ZDj9">
-            <ref role="3uigEE" to="lui2:~SModule" resolve="SModule" />
-          </node>
-        </node>
-      </node>
-      <node concept="37vLTG" id="63imCwJB$bt" role="3clF46">
-        <property role="TrG5h" value="startingModules" />
-        <node concept="_YKpA" id="63imCwJBHj5" role="1tU5fm">
-          <node concept="3uibUv" id="63imCwJBHj6" role="_ZDj9">
-            <ref role="3uigEE" to="lui2:~SModule" resolve="SModule" />
-          </node>
-        </node>
-      </node>
-      <node concept="37vLTG" id="63imCwJCNf5" role="3clF46">
-        <property role="TrG5h" value="action" />
-        <node concept="1ajhzC" id="63imCwJCNf6" role="1tU5fm">
-          <node concept="3cqZAl" id="63imCwJCNf7" role="1ajl9A" />
-          <node concept="3uibUv" id="63imCwJCNf8" role="1ajw0F">
-            <ref role="3uigEE" to="lui2:~SModule" resolve="SModule" />
-          </node>
-          <node concept="_YKpA" id="63imCwJCNf9" role="1ajw0F">
-            <node concept="3uibUv" id="63imCwJCNfa" role="_ZDj9">
-              <ref role="3uigEE" to="lui2:~SModule" resolve="SModule" />
-            </node>
-          </node>
-          <node concept="2hMVRd" id="63imCwJCNfb" role="1ajw0F">
-            <node concept="3uibUv" id="63imCwJCNfc" role="2hN53Y">
-              <ref role="3uigEE" to="lui2:~SModule" resolve="SModule" />
-            </node>
-          </node>
-          <node concept="_YKpA" id="63imCwJCNfd" role="1ajw0F">
-            <node concept="3uibUv" id="63imCwJCNfe" role="_ZDj9">
-              <ref role="3uigEE" to="lui2:~SModule" resolve="SModule" />
-            </node>
-          </node>
-        </node>
-      </node>
-      <node concept="37vLTG" id="63imCwJBZTS" role="3clF46">
-        <property role="TrG5h" value="includeUsedLanguages" />
-        <node concept="10P_77" id="63imCwJC44o" role="1tU5fm" />
-      </node>
-      <node concept="3cqZAl" id="63imCwJBlQD" role="3clF45" />
-    </node>
-    <node concept="2tJIrI" id="63imCwJS1VE" role="jymVt" />
-    <node concept="2YIFZL" id="63imCwJLCQe" role="jymVt">
-      <property role="TrG5h" value="findSomeCyclesStartingFrom" />
-      <node concept="3clFbS" id="63imCwJGTng" role="3clF47">
-        <node concept="3cpWs8" id="63imCwJxTiw" role="3cqZAp">
-          <node concept="3cpWsn" id="63imCwJxTix" role="3cpWs9">
-            <property role="TrG5h" value="cycles" />
-            <node concept="_YKpA" id="63imCwJxTiy" role="1tU5fm">
-              <node concept="_YKpA" id="63imCwJxTiz" role="_ZDj9">
-                <node concept="3uibUv" id="63imCwJxTi$" role="_ZDj9">
-                  <ref role="3uigEE" to="lui2:~SModule" resolve="SModule" />
-                </node>
-              </node>
-            </node>
-            <node concept="2ShNRf" id="63imCwJxTi_" role="33vP2m">
-              <node concept="Tc6Ow" id="63imCwJxTiA" role="2ShVmc">
-                <node concept="_YKpA" id="63imCwJxTiB" role="HW$YZ">
-                  <node concept="3uibUv" id="63imCwJxTiC" role="_ZDj9">
-                    <ref role="3uigEE" to="lui2:~SModule" resolve="SModule" />
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3cpWs8" id="63imCwJIzzV" role="3cqZAp">
-          <node concept="3cpWsn" id="63imCwJIzzW" role="3cpWs9">
-            <property role="TrG5h" value="addToCycles" />
-            <node concept="1ajhzC" id="63imCwJIzzM" role="1tU5fm">
-              <node concept="3uibUv" id="63imCwJIzzN" role="1ajw0F">
-                <ref role="3uigEE" to="lui2:~SModule" resolve="SModule" />
-              </node>
-              <node concept="_YKpA" id="63imCwJIzzO" role="1ajw0F">
-                <node concept="3uibUv" id="63imCwJIzzP" role="_ZDj9">
-                  <ref role="3uigEE" to="lui2:~SModule" resolve="SModule" />
-                </node>
-              </node>
-              <node concept="2hMVRd" id="63imCwJIzzQ" role="1ajw0F">
-                <node concept="3uibUv" id="63imCwJIzzR" role="2hN53Y">
-                  <ref role="3uigEE" to="lui2:~SModule" resolve="SModule" />
-                </node>
-              </node>
-              <node concept="_YKpA" id="63imCwJIzzS" role="1ajw0F">
-                <node concept="3uibUv" id="63imCwJIzzT" role="_ZDj9">
-                  <ref role="3uigEE" to="lui2:~SModule" resolve="SModule" />
-                </node>
-              </node>
-              <node concept="3cqZAl" id="63imCwJIzzU" role="1ajl9A" />
-            </node>
-            <node concept="1bVj0M" id="63imCwJIzzX" role="33vP2m">
-              <node concept="37vLTG" id="63imCwJIzzY" role="1bW2Oz">
-                <property role="TrG5h" value="current" />
-                <node concept="3uibUv" id="63imCwJIzzZ" role="1tU5fm">
-                  <ref role="3uigEE" to="lui2:~SModule" resolve="SModule" />
-                </node>
-              </node>
-              <node concept="37vLTG" id="63imCwJIz$0" role="1bW2Oz">
-                <property role="TrG5h" value="adjacents" />
-                <node concept="_YKpA" id="63imCwJIz$1" role="1tU5fm">
-                  <node concept="3uibUv" id="63imCwJIz$2" role="_ZDj9">
-                    <ref role="3uigEE" to="lui2:~SModule" resolve="SModule" />
-                  </node>
-                </node>
-              </node>
-              <node concept="37vLTG" id="63imCwJIz$3" role="1bW2Oz">
-                <property role="TrG5h" value="visited" />
-                <node concept="2hMVRd" id="63imCwJIz$4" role="1tU5fm">
-                  <node concept="3uibUv" id="63imCwJIz$5" role="2hN53Y">
-                    <ref role="3uigEE" to="lui2:~SModule" resolve="SModule" />
-                  </node>
-                </node>
-              </node>
-              <node concept="37vLTG" id="63imCwJIz$6" role="1bW2Oz">
-                <property role="TrG5h" value="currentPath" />
-                <node concept="_YKpA" id="63imCwJIz$7" role="1tU5fm">
-                  <node concept="3uibUv" id="63imCwJIz$8" role="_ZDj9">
-                    <ref role="3uigEE" to="lui2:~SModule" resolve="SModule" />
-                  </node>
-                </node>
-              </node>
-              <node concept="3clFbS" id="63imCwJIz$9" role="1bW5cS">
-                <node concept="3clFbJ" id="63imCwJIz$a" role="3cqZAp">
-                  <node concept="1Wc70l" id="63imCwJIz$n" role="3clFbw">
-                    <node concept="3eOSWO" id="63imCwJIz$o" role="3uHU7B">
-                      <node concept="2OqwBi" id="63imCwJIz$p" role="3uHU7B">
-                        <node concept="37vLTw" id="63imCwJIz$q" role="2Oq$k0">
-                          <ref role="3cqZAo" node="63imCwJIz$6" resolve="currentPath" />
-                        </node>
-                        <node concept="34oBXx" id="63imCwJIz$r" role="2OqNvi" />
-                      </node>
-                      <node concept="3cmrfG" id="63imCwJIz$s" role="3uHU7w">
-                        <property role="3cmrfH" value="1" />
-                      </node>
-                    </node>
-                    <node concept="17R0WA" id="63imCwJVRB9" role="3uHU7w">
-                      <node concept="37vLTw" id="63imCwJVW2E" role="3uHU7w">
-                        <ref role="3cqZAo" node="63imCwJIzzY" resolve="current" />
-                      </node>
-                      <node concept="2OqwBi" id="63imCwJIz$t" role="3uHU7B">
-                        <node concept="37vLTw" id="63imCwJIz$u" role="2Oq$k0">
-                          <ref role="3cqZAo" node="63imCwJIz$6" resolve="currentPath" />
-                        </node>
-                        <node concept="1uHKPH" id="63imCwJVNap" role="2OqNvi" />
-                      </node>
-                    </node>
-                  </node>
-                  <node concept="3clFbS" id="63imCwJIz$x" role="3clFbx">
-                    <node concept="3clFbF" id="63imCwJIz$y" role="3cqZAp">
-                      <node concept="2OqwBi" id="63imCwJIz$z" role="3clFbG">
-                        <node concept="37vLTw" id="63imCwJIz$$" role="2Oq$k0">
-                          <ref role="3cqZAo" node="63imCwJxTix" resolve="cycles" />
-                        </node>
-                        <node concept="TSZUe" id="63imCwJIz$_" role="2OqNvi">
-                          <node concept="2OqwBi" id="63imCwJIz$A" role="25WWJ7">
-                            <node concept="2OqwBi" id="63imCwJIz$B" role="2Oq$k0">
-                              <node concept="37vLTw" id="63imCwJIz$D" role="2Oq$k0">
-                                <ref role="3cqZAo" node="63imCwJIz$6" resolve="currentPath" />
-                              </node>
-                              <node concept="3QWeyG" id="63imCwJIz$M" role="2OqNvi">
-                                <node concept="2ShNRf" id="63imCwJIz$N" role="576Qk">
-                                  <node concept="2HTt$P" id="63imCwJIz$O" role="2ShVmc">
-                                    <node concept="3uibUv" id="63imCwJIz$P" role="2HTBi0">
-                                      <ref role="3uigEE" to="lui2:~SModule" resolve="SModule" />
-                                    </node>
-                                    <node concept="37vLTw" id="63imCwJIz$Q" role="2HTEbv">
-                                      <ref role="3cqZAo" node="63imCwJIzzY" resolve="current" />
-                                    </node>
-                                  </node>
-                                </node>
-                              </node>
-                            </node>
-                            <node concept="ANE8D" id="63imCwJIz$R" role="2OqNvi" />
-                          </node>
-                        </node>
-                      </node>
-                    </node>
-                  </node>
-                </node>
-              </node>
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbF" id="63imCwJHVKu" role="3cqZAp">
-          <node concept="1rXfSq" id="1u5Q3uAEtYu" role="3clFbG">
-            <ref role="37wK5l" node="63imCwJLLYC" resolve="DFS" />
-            <node concept="37vLTw" id="63imCwJI36A" role="37wK5m">
-              <ref role="3cqZAo" node="63imCwJH0dG" resolve="modules" />
-            </node>
-            <node concept="37vLTw" id="63imCwJIeT$" role="37wK5m">
-              <ref role="3cqZAo" node="63imCwJHdv8" resolve="startingModules" />
-            </node>
-            <node concept="37vLTw" id="63imCwJIYNB" role="37wK5m">
-              <ref role="3cqZAo" node="63imCwJIzzW" resolve="addToCycles" />
-            </node>
-            <node concept="37vLTw" id="63imCwJJoLa" role="37wK5m">
-              <ref role="3cqZAo" node="63imCwJJ3Pv" resolve="includeUsedLanguages" />
-            </node>
-          </node>
-        </node>
-        <node concept="3clFbF" id="63imCwJWMFQ" role="3cqZAp">
-          <node concept="37vLTw" id="63imCwJWMFO" role="3clFbG">
-            <ref role="3cqZAo" node="63imCwJxTix" resolve="cycles" />
-          </node>
-        </node>
-      </node>
-      <node concept="37vLTG" id="63imCwJH0dG" role="3clF46">
-        <property role="TrG5h" value="modules" />
-        <node concept="_YKpA" id="63imCwJH0dH" role="1tU5fm">
-          <node concept="3uibUv" id="63imCwJH0dI" role="_ZDj9">
-            <ref role="3uigEE" to="lui2:~SModule" resolve="SModule" />
-          </node>
-        </node>
-      </node>
-      <node concept="37vLTG" id="63imCwJHdv8" role="3clF46">
-        <property role="TrG5h" value="startingModules" />
-        <node concept="_YKpA" id="63imCwJI8eA" role="1tU5fm">
-          <node concept="3uibUv" id="63imCwJI8eB" role="_ZDj9">
-            <ref role="3uigEE" to="lui2:~SModule" resolve="SModule" />
-          </node>
-        </node>
-      </node>
-      <node concept="37vLTG" id="63imCwJJ3Pv" role="3clF46">
-        <property role="TrG5h" value="includeUsedLanguages" />
-        <node concept="10P_77" id="63imCwJJ9cz" role="1tU5fm" />
-      </node>
-      <node concept="3Tm1VV" id="63imCwJGJJ8" role="1B3o_S" />
-      <node concept="A3Dl8" id="63imCwJPn8Z" role="3clF45">
-        <node concept="_YKpA" id="63imCwJNEqQ" role="A3Ik2">
-          <node concept="3uibUv" id="63imCwJNHZk" role="_ZDj9">
-            <ref role="3uigEE" to="lui2:~SModule" resolve="SModule" />
-          </node>
-        </node>
-      </node>
-    </node>
-    <node concept="2tJIrI" id="1u5Q3uAFjFv" role="jymVt" />
   </node>
   <node concept="1MIHA_" id="4Y9rGZa7XxM">
     <property role="TrG5h" value="cyclic_module_dependencies_with_starting_point" />
@@ -8352,33 +6113,55 @@
         <node concept="3clFbH" id="1u5Q3uAE2oX" role="3cqZAp" />
         <node concept="L3pyB" id="4Y9rGZadtFx" role="3cqZAp">
           <node concept="3clFbS" id="4Y9rGZadtFz" role="L3pyw">
-            <node concept="3clFbF" id="4Y9rGZajldA" role="3cqZAp">
-              <node concept="2YIFZM" id="1u5Q3uAE_9n" role="3clFbG">
-                <ref role="37wK5l" node="4Y9rGZaeVz$" resolve="computeSomeCycles" />
-                <ref role="1Pybhc" node="1u5Q3uAE36L" resolve="CyclicModuleDependenciesFromStartingPointHelper" />
-                <node concept="2OqwBi" id="4Y9rGZajnq5" role="37wK5m">
-                  <node concept="EzsRk" id="4Y9rGZajmVz" role="2Oq$k0" />
-                  <node concept="ANE8D" id="4Y9rGZajnRm" role="2OqNvi" />
-                </node>
-                <node concept="2OqwBi" id="4Y9rGZajoFA" role="37wK5m">
-                  <node concept="2j1LYi" id="4Y9rGZajolD" role="2Oq$k0">
-                    <ref role="2j1LYj" node="4Y9rGZa7XDu" resolve="startingModuleRef" />
+            <node concept="3clFbF" id="13En2Fwi4Yw" role="3cqZAp">
+              <node concept="2OqwBi" id="13En2Fwi6Su" role="3clFbG">
+                <node concept="2YIFZM" id="13En2Fwi5f1" role="2Oq$k0">
+                  <ref role="37wK5l" node="13En2Fw73pu" resolve="getStartingPointHelper" />
+                  <ref role="1Pybhc" node="4aEqBbbBtjF" resolve="CyclicModuleDependenciesHelper" />
+                  <node concept="2j1LYi" id="13En2Fwi5hh" role="37wK5m">
+                    <ref role="2j1LYj" node="4Y9rGZacsxt" resolve="includeUsedLanguages" />
                   </node>
-                  <node concept="liA8E" id="4Y9rGZajp7m" role="2OqNvi">
-                    <ref role="37wK5l" to="lui2:~SModuleReference.resolve(org.jetbrains.mps.openapi.module.SRepository)" resolve="resolve" />
-                    <node concept="2OqwBi" id="4Y9rGZajpQ1" role="37wK5m">
-                      <node concept="1MG55F" id="4Y9rGZajpeX" role="2Oq$k0" />
-                      <node concept="liA8E" id="4Y9rGZajqoE" role="2OqNvi">
-                        <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
-                      </node>
+                  <node concept="2OqwBi" id="13En2Fwi60h" role="37wK5m">
+                    <node concept="1MG55F" id="13En2Fwi5m$" role="2Oq$k0" />
+                    <node concept="liA8E" id="13En2Fwi6Jn" role="2OqNvi">
+                      <ref role="37wK5l" to="z1c3:~Project.getRepository()" resolve="getRepository" />
                     </node>
                   </node>
                 </node>
-                <node concept="37vLTw" id="7MmUcJipm58" role="37wK5m">
-                  <ref role="3cqZAo" node="4Y9rGZadqg6" resolve="res" />
-                </node>
-                <node concept="2j1LYi" id="4Y9rGZajqUk" role="37wK5m">
-                  <ref role="2j1LYj" node="4Y9rGZacsxt" resolve="includeUsedLanguages" />
+                <node concept="liA8E" id="13En2Fwi7qP" role="2OqNvi">
+                  <ref role="37wK5l" node="13En2FvIP8Y" resolve="computeSomeCycles" />
+                  <node concept="2OqwBi" id="13En2Fwibom" role="37wK5m">
+                    <node concept="2OqwBi" id="13En2Fwi8$b" role="2Oq$k0">
+                      <node concept="EzsRk" id="13En2Fwi9Iv" role="2Oq$k0" />
+                      <node concept="3$u5V9" id="13En2Fwi9nA" role="2OqNvi">
+                        <node concept="1bVj0M" id="13En2Fwi9nC" role="23t8la">
+                          <node concept="3clFbS" id="13En2Fwi9nD" role="1bW5cS">
+                            <node concept="3clFbF" id="13En2Fwi9RZ" role="3cqZAp">
+                              <node concept="2OqwBi" id="13En2FwiaeE" role="3clFbG">
+                                <node concept="37vLTw" id="13En2Fwi9RY" role="2Oq$k0">
+                                  <ref role="3cqZAo" node="13En2Fwi9nE" resolve="it" />
+                                </node>
+                                <node concept="liA8E" id="13En2Fwia$j" role="2OqNvi">
+                                  <ref role="37wK5l" to="lui2:~SModule.getModuleReference()" resolve="getModuleReference" />
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                          <node concept="gl6BB" id="13En2Fwi9nE" role="1bW2Oz">
+                            <property role="TrG5h" value="it" />
+                            <node concept="2jxLKc" id="13En2Fwi9nF" role="1tU5fm" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="ANE8D" id="13En2Fwicm7" role="2OqNvi" />
+                  </node>
+                  <node concept="2j1LYi" id="13En2FwicUm" role="37wK5m">
+                    <ref role="2j1LYj" node="4Y9rGZa7XDu" resolve="startingModuleRef" />
+                  </node>
+                  <node concept="37vLTw" id="13En2FwmaTz" role="37wK5m">
+                    <ref role="3cqZAo" node="4Y9rGZadqg6" resolve="res" />
+                  </node>
                 </node>
               </node>
             </node>
@@ -8850,6 +6633,2863 @@
           <property role="3oM_SC" value="" />
         </node>
       </node>
+    </node>
+  </node>
+  <node concept="312cEu" id="13En2FvI8nj">
+    <property role="3GE5qa" value="helpers" />
+    <property role="TrG5h" value="CyclicComponentDependenciesFromStartingPointHelper" />
+    <node concept="3Tm1VV" id="13En2FvI8nk" role="1B3o_S" />
+    <node concept="312cEg" id="13En2FvQ26l" role="jymVt">
+      <property role="TrG5h" value="dependenciesHelper" />
+      <node concept="3uibUv" id="13En2FvPXiL" role="1tU5fm">
+        <ref role="3uigEE" node="13En2Fv5upa" resolve="CyclicGenericDependenciesHelper" />
+        <node concept="16syzq" id="13En2FvSp0p" role="11_B2D">
+          <ref role="16sUi3" node="13En2FvIxxl" resolve="Component" />
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="13En2FvI8nl" role="jymVt" />
+    <node concept="3clFbW" id="13En2FvQ$NN" role="jymVt">
+      <node concept="3cqZAl" id="13En2FvQ$NO" role="3clF45" />
+      <node concept="3clFbS" id="13En2FvQ$NQ" role="3clF47">
+        <node concept="3clFbF" id="13En2FvRARK" role="3cqZAp">
+          <node concept="37vLTI" id="13En2FvRJo8" role="3clFbG">
+            <node concept="2OqwBi" id="13En2FvRB0U" role="37vLTJ">
+              <node concept="Xjq3P" id="13En2FvRARJ" role="2Oq$k0" />
+              <node concept="2OwXpG" id="13En2FvRF7Z" role="2OqNvi">
+                <ref role="2Oxat5" node="13En2FvQ26l" resolve="dependenciesHelper" />
+              </node>
+            </node>
+            <node concept="37vLTw" id="13En2Fw5E5s" role="37vLTx">
+              <ref role="3cqZAo" node="13En2Fw5uPk" resolve="dependenciesHelper" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="13En2FvQ$NR" role="1B3o_S" />
+      <node concept="37vLTG" id="13En2Fw5uPk" role="3clF46">
+        <property role="TrG5h" value="dependenciesHelper" />
+        <node concept="3uibUv" id="13En2Fw5uPj" role="1tU5fm">
+          <ref role="3uigEE" node="13En2Fv5upa" resolve="CyclicGenericDependenciesHelper" />
+          <node concept="16syzq" id="13En2Fw5yx4" role="11_B2D">
+            <ref role="16sUi3" node="13En2FvIxxl" resolve="Component" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="13En2FvQm9f" role="jymVt" />
+    <node concept="2tJIrI" id="13En2FvPSu_" role="jymVt" />
+    <node concept="3clFb_" id="13En2FvIP8Y" role="jymVt">
+      <property role="TrG5h" value="computeSomeCycles" />
+      <node concept="3clFbS" id="13En2FvIP90" role="3clF47">
+        <node concept="3cpWs8" id="13En2FvIP91" role="3cqZAp">
+          <node concept="3cpWsn" id="13En2FvIP92" role="3cpWs9">
+            <property role="TrG5h" value="startingComponents" />
+            <node concept="_YKpA" id="13En2FvIP93" role="1tU5fm">
+              <node concept="16syzq" id="13En2FvJ7qY" role="_ZDj9">
+                <ref role="16sUi3" node="13En2FvIxxl" resolve="Component" />
+              </node>
+            </node>
+            <node concept="2ShNRf" id="13En2FvIP95" role="33vP2m">
+              <node concept="Tc6Ow" id="13En2FvIP96" role="2ShVmc">
+                <node concept="16syzq" id="13En2FvJm4a" role="HW$YZ">
+                  <ref role="16sUi3" node="13En2FvIxxl" resolve="Component" />
+                </node>
+                <node concept="37vLTw" id="13En2FvIP98" role="HW$Y0">
+                  <ref role="3cqZAo" node="13En2FvIP9R" resolve="startingModule" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="13En2FvIP99" role="3cqZAp">
+          <node concept="3cpWsn" id="13En2FvIP9a" role="3cpWs9">
+            <property role="TrG5h" value="someCyclesStartingFrom" />
+            <node concept="A3Dl8" id="13En2FvIP9f" role="1tU5fm">
+              <node concept="_YKpA" id="13En2FvIP9g" role="A3Ik2">
+                <node concept="16syzq" id="13En2FvJp__" role="_ZDj9">
+                  <ref role="16sUi3" node="13En2FvIxxl" resolve="Component" />
+                </node>
+              </node>
+            </node>
+            <node concept="1rXfSq" id="13En2FvSz3i" role="33vP2m">
+              <ref role="37wK5l" node="13En2FvNZeg" resolve="findSomeCyclesStartingFrom" />
+              <node concept="37vLTw" id="13En2FvSGXh" role="37wK5m">
+                <ref role="3cqZAo" node="13En2FvIP9O" resolve="components" />
+              </node>
+              <node concept="37vLTw" id="13En2FvST$f" role="37wK5m">
+                <ref role="3cqZAo" node="13En2FvIP92" resolve="startingComponents" />
+              </node>
+              <node concept="2OqwBi" id="13En2FwiIqm" role="37wK5m">
+                <node concept="2OqwBi" id="13En2FwiCoY" role="2Oq$k0">
+                  <node concept="Xjq3P" id="13En2FwiAPT" role="2Oq$k0" />
+                  <node concept="2OwXpG" id="13En2FwiH9d" role="2OqNvi">
+                    <ref role="2Oxat5" node="13En2FvQ26l" resolve="dependenciesHelper" />
+                  </node>
+                </node>
+                <node concept="liA8E" id="13En2FwlY_o" role="2OqNvi">
+                  <ref role="37wK5l" node="13En2FwlozC" resolve="getOption" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="2Gpval" id="13En2FvIP9i" role="3cqZAp">
+          <node concept="2GrKxI" id="13En2FvIP9j" role="2Gsz3X">
+            <property role="TrG5h" value="crtCycle" />
+          </node>
+          <node concept="37vLTw" id="13En2FvIP9k" role="2GsD0m">
+            <ref role="3cqZAo" node="13En2FvIP9a" resolve="someCyclesStartingFrom" />
+          </node>
+          <node concept="3clFbS" id="13En2FvIP9l" role="2LFqv$">
+            <node concept="3cpWs8" id="13En2FvIP9m" role="3cqZAp">
+              <node concept="3cpWsn" id="13En2FvIP9n" role="3cpWs9">
+                <property role="TrG5h" value="msg" />
+                <node concept="17QB3L" id="13En2FvIP9o" role="1tU5fm" />
+                <node concept="3cpWs3" id="13En2FvIP9p" role="33vP2m">
+                  <node concept="3cpWs3" id="13En2FvIP9q" role="3uHU7B">
+                    <node concept="3cpWs3" id="13En2FvIP9r" role="3uHU7B">
+                      <node concept="Xl_RD" id="13En2FvIP9s" role="3uHU7B">
+                        <property role="Xl_RC" value="Cyclic dependency with length " />
+                      </node>
+                      <node concept="2OqwBi" id="13En2FvIP9t" role="3uHU7w">
+                        <node concept="2GrUjf" id="13En2FvIP9u" role="2Oq$k0">
+                          <ref role="2Gs0qQ" node="13En2FvIP9j" resolve="crtCycle" />
+                        </node>
+                        <node concept="34oBXx" id="13En2FvIP9v" role="2OqNvi" />
+                      </node>
+                    </node>
+                    <node concept="Xl_RD" id="13En2FvIP9w" role="3uHU7w">
+                      <property role="Xl_RC" value=" found: " />
+                    </node>
+                  </node>
+                  <node concept="2OqwBi" id="13En2FvIP9x" role="3uHU7w">
+                    <node concept="2OqwBi" id="13En2FvIP9y" role="2Oq$k0">
+                      <node concept="2GrUjf" id="13En2FvIP9z" role="2Oq$k0">
+                        <ref role="2Gs0qQ" node="13En2FvIP9j" resolve="crtCycle" />
+                      </node>
+                      <node concept="3$u5V9" id="13En2FvIP9$" role="2OqNvi">
+                        <node concept="1bVj0M" id="13En2FvIP9_" role="23t8la">
+                          <node concept="3clFbS" id="13En2FvIP9A" role="1bW5cS">
+                            <node concept="3clFbF" id="13En2FvIP9B" role="3cqZAp">
+                              <node concept="2OqwBi" id="13En2FvIP9C" role="3clFbG">
+                                <node concept="37vLTw" id="13En2FvIP9D" role="2Oq$k0">
+                                  <ref role="3cqZAo" node="13En2FvIP9F" resolve="it" />
+                                </node>
+                                <node concept="liA8E" id="13En2FvIP9E" role="2OqNvi">
+                                  <ref role="37wK5l" to="wyt6:~Object.toString()" resolve="toString" />
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                          <node concept="gl6BB" id="13En2FvIP9F" role="1bW2Oz">
+                            <property role="TrG5h" value="it" />
+                            <node concept="2jxLKc" id="13En2FvIP9G" role="1tU5fm" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="3uJxvA" id="13En2FvIP9H" role="2OqNvi">
+                      <node concept="Xl_RD" id="13En2FvIP9I" role="3uJOhx">
+                        <property role="Xl_RC" value=", " />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbF" id="13En2FvIP9J" role="3cqZAp">
+              <node concept="2OqwBi" id="13En2FvIP9K" role="3clFbG">
+                <node concept="37vLTw" id="13En2FvIP9L" role="2Oq$k0">
+                  <ref role="3cqZAo" node="13En2FvIP9T" resolve="res" />
+                </node>
+                <node concept="TSZUe" id="13En2FvIP9M" role="2OqNvi">
+                  <node concept="37vLTw" id="13En2FvIP9N" role="25WWJ7">
+                    <ref role="3cqZAo" node="13En2FvIP9n" resolve="msg" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3cqZAl" id="13En2FvIP9Y" role="3clF45" />
+      <node concept="37vLTG" id="13En2FvIP9O" role="3clF46">
+        <property role="TrG5h" value="components" />
+        <node concept="_YKpA" id="13En2FvIP9P" role="1tU5fm">
+          <node concept="16syzq" id="13En2FvITo3" role="_ZDj9">
+            <ref role="16sUi3" node="13En2FvIxxl" resolve="Component" />
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="13En2FvIP9R" role="3clF46">
+        <property role="TrG5h" value="startingComponent" />
+        <node concept="16syzq" id="13En2FvJ0oI" role="1tU5fm">
+          <ref role="16sUi3" node="13En2FvIxxl" resolve="Component" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="13En2FvIP9T" role="3clF46">
+        <property role="TrG5h" value="res" />
+        <node concept="_YKpA" id="13En2FvIP9U" role="1tU5fm">
+          <node concept="17QB3L" id="13En2FvIP9V" role="_ZDj9" />
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="13En2FvIP9Z" role="1B3o_S" />
+    </node>
+    <node concept="2tJIrI" id="13En2FvI8on" role="jymVt" />
+    <node concept="3clFb_" id="13En2FvJE3I" role="jymVt">
+      <property role="TrG5h" value="DFSRecursive" />
+      <node concept="3clFbS" id="13En2FvJE3K" role="3clF47">
+        <node concept="3clFbF" id="13En2FvJE3L" role="3cqZAp">
+          <node concept="2OqwBi" id="13En2FvJE3M" role="3clFbG">
+            <node concept="37vLTw" id="13En2FvJE3N" role="2Oq$k0">
+              <ref role="3cqZAo" node="13En2FvJE4K" resolve="visited" />
+            </node>
+            <node concept="TSZUe" id="13En2FvJE3O" role="2OqNvi">
+              <node concept="37vLTw" id="13En2FvJE3P" role="25WWJ7">
+                <ref role="3cqZAo" node="13En2FvJE4v" resolve="currentModule" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="13En2FvJE3Q" role="3cqZAp">
+          <node concept="2OqwBi" id="13En2FvJE3R" role="3clFbG">
+            <node concept="37vLTw" id="13En2FvJE3S" role="2Oq$k0">
+              <ref role="3cqZAo" node="13En2FvJE4N" resolve="path" />
+            </node>
+            <node concept="TSZUe" id="13En2FvJE3T" role="2OqNvi">
+              <node concept="37vLTw" id="13En2FvJE3U" role="25WWJ7">
+                <ref role="3cqZAo" node="13En2FvJE4v" resolve="currentModule" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="2Gpval" id="13En2FvJE3V" role="3cqZAp">
+          <node concept="2GrKxI" id="13En2FvJE3W" role="2Gsz3X">
+            <property role="TrG5h" value="dependency" />
+          </node>
+          <node concept="3EllGN" id="13En2FvJE3X" role="2GsD0m">
+            <node concept="37vLTw" id="13En2FvJE3Y" role="3ElVtu">
+              <ref role="3cqZAo" node="13En2FvJE4v" resolve="currentModule" />
+            </node>
+            <node concept="37vLTw" id="13En2FvJE3Z" role="3ElQJh">
+              <ref role="3cqZAo" node="13En2FvJE4x" resolve="directDependencies" />
+            </node>
+          </node>
+          <node concept="3clFbS" id="13En2FvJE40" role="2LFqv$">
+            <node concept="3clFbF" id="13En2FvJE41" role="3cqZAp">
+              <node concept="2Sg_IR" id="13En2FvJE42" role="3clFbG">
+                <node concept="37vLTw" id="13En2FvJE43" role="2SgG2M">
+                  <ref role="3cqZAo" node="13En2FvJE4A" resolve="action" />
+                </node>
+                <node concept="2GrUjf" id="13En2FvJE44" role="2SgHGx">
+                  <ref role="2Gs0qQ" node="13En2FvJE3W" resolve="dependency" />
+                </node>
+                <node concept="2OqwBi" id="13En2FvJE45" role="2SgHGx">
+                  <node concept="3EllGN" id="13En2FvJE46" role="2Oq$k0">
+                    <node concept="2GrUjf" id="13En2FvJE47" role="3ElVtu">
+                      <ref role="2Gs0qQ" node="13En2FvJE3W" resolve="dependency" />
+                    </node>
+                    <node concept="37vLTw" id="13En2FvJE48" role="3ElQJh">
+                      <ref role="3cqZAo" node="13En2FvJE4x" resolve="directDependencies" />
+                    </node>
+                  </node>
+                  <node concept="ANE8D" id="13En2FvJE49" role="2OqNvi" />
+                </node>
+                <node concept="37vLTw" id="13En2FvJE4a" role="2SgHGx">
+                  <ref role="3cqZAo" node="13En2FvJE4K" resolve="visited" />
+                </node>
+                <node concept="37vLTw" id="13En2FvJE4b" role="2SgHGx">
+                  <ref role="3cqZAo" node="13En2FvJE4N" resolve="path" />
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbJ" id="13En2FvJE4c" role="3cqZAp">
+              <node concept="3fqX7Q" id="13En2FvJE4d" role="3clFbw">
+                <node concept="2OqwBi" id="13En2FvJE4e" role="3fr31v">
+                  <node concept="37vLTw" id="13En2FvJE4f" role="2Oq$k0">
+                    <ref role="3cqZAo" node="13En2FvJE4K" resolve="visited" />
+                  </node>
+                  <node concept="3JPx81" id="13En2FvJE4g" role="2OqNvi">
+                    <node concept="2GrUjf" id="13En2FvJE4h" role="25WWJ7">
+                      <ref role="2Gs0qQ" node="13En2FvJE3W" resolve="dependency" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3clFbS" id="13En2FvJE4i" role="3clFbx">
+                <node concept="3clFbF" id="13En2FvJQ5r" role="3cqZAp">
+                  <node concept="1rXfSq" id="13En2FvJQ5p" role="3clFbG">
+                    <ref role="37wK5l" node="13En2FvJE3I" resolve="DFSRecursive" />
+                    <node concept="2GrUjf" id="13En2FvJU7q" role="37wK5m">
+                      <ref role="2Gs0qQ" node="13En2FvJE3W" resolve="dependency" />
+                    </node>
+                    <node concept="37vLTw" id="13En2FvK2Fx" role="37wK5m">
+                      <ref role="3cqZAo" node="13En2FvJE4x" resolve="directDependencies" />
+                    </node>
+                    <node concept="37vLTw" id="13En2FvKaEE" role="37wK5m">
+                      <ref role="3cqZAo" node="13En2FvJE4A" resolve="action" />
+                    </node>
+                    <node concept="37vLTw" id="13En2FvKeOa" role="37wK5m">
+                      <ref role="3cqZAo" node="13En2FvJE4K" resolve="visited" />
+                    </node>
+                    <node concept="2ShNRf" id="13En2FvKiK9" role="37wK5m">
+                      <node concept="Tc6Ow" id="13En2FvKiKa" role="2ShVmc">
+                        <node concept="16syzq" id="13En2FvL65t" role="HW$YZ">
+                          <ref role="16sUi3" node="13En2FvIxxl" resolve="Component" />
+                        </node>
+                        <node concept="2OqwBi" id="13En2FvKiKc" role="I$8f6">
+                          <node concept="37vLTw" id="13En2FvKiKd" role="2Oq$k0">
+                            <ref role="3cqZAo" node="13En2FvJE4N" resolve="path" />
+                          </node>
+                          <node concept="ANE8D" id="13En2FvKiKe" role="2OqNvi" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3cqZAl" id="13En2FvJE4Q" role="3clF45" />
+      <node concept="37vLTG" id="13En2FvJE4v" role="3clF46">
+        <property role="TrG5h" value="currentComponent" />
+        <node concept="16syzq" id="13En2FvKqxe" role="1tU5fm">
+          <ref role="16sUi3" node="13En2FvIxxl" resolve="Component" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="13En2FvJE4x" role="3clF46">
+        <property role="TrG5h" value="directDependencies" />
+        <node concept="3rvAFt" id="13En2FvJE4y" role="1tU5fm">
+          <node concept="16syzq" id="13En2FvK_Yz" role="3rvQeY">
+            <ref role="16sUi3" node="13En2FvIxxl" resolve="Component" />
+          </node>
+          <node concept="2hMVRd" id="13En2FvJE4$" role="3rvSg0">
+            <node concept="16syzq" id="13En2FvKE4L" role="2hN53Y">
+              <ref role="16sUi3" node="13En2FvIxxl" resolve="Component" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="13En2FvJE4A" role="3clF46">
+        <property role="TrG5h" value="action" />
+        <node concept="1ajhzC" id="13En2FvJE4B" role="1tU5fm">
+          <node concept="3cqZAl" id="13En2FvJE4C" role="1ajl9A" />
+          <node concept="16syzq" id="13En2FvKIJC" role="1ajw0F">
+            <ref role="16sUi3" node="13En2FvIxxl" resolve="Component" />
+          </node>
+          <node concept="_YKpA" id="13En2FvJE4E" role="1ajw0F">
+            <node concept="16syzq" id="13En2FvKMzo" role="_ZDj9">
+              <ref role="16sUi3" node="13En2FvIxxl" resolve="Component" />
+            </node>
+          </node>
+          <node concept="2hMVRd" id="13En2FvJE4G" role="1ajw0F">
+            <node concept="16syzq" id="13En2FvKQo9" role="2hN53Y">
+              <ref role="16sUi3" node="13En2FvIxxl" resolve="Component" />
+            </node>
+          </node>
+          <node concept="_YKpA" id="13En2FvJE4I" role="1ajw0F">
+            <node concept="16syzq" id="13En2FvKUet" role="_ZDj9">
+              <ref role="16sUi3" node="13En2FvIxxl" resolve="Component" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="13En2FvJE4K" role="3clF46">
+        <property role="TrG5h" value="visited" />
+        <node concept="2hMVRd" id="13En2FvJE4L" role="1tU5fm">
+          <node concept="16syzq" id="13En2FvKY5e" role="2hN53Y">
+            <ref role="16sUi3" node="13En2FvIxxl" resolve="Component" />
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="13En2FvJE4N" role="3clF46">
+        <property role="TrG5h" value="path" />
+        <node concept="_YKpA" id="13En2FvJE4O" role="1tU5fm">
+          <node concept="16syzq" id="13En2FvL1Y1" role="_ZDj9">
+            <ref role="16sUi3" node="13En2FvIxxl" resolve="Component" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="13En2FvI8pw" role="jymVt" />
+    <node concept="3clFb_" id="13En2FvLiUk" role="jymVt">
+      <property role="TrG5h" value="DFS" />
+      <node concept="3clFbS" id="13En2FvLiUm" role="3clF47">
+        <node concept="3clFbF" id="13En2FvLiUn" role="3cqZAp">
+          <node concept="1rXfSq" id="13En2FvLiUo" role="3clFbG">
+            <ref role="37wK5l" node="13En2FvJE3I" resolve="DFSRecursive" />
+            <node concept="37vLTw" id="13En2FvLiUp" role="37wK5m">
+              <ref role="3cqZAo" node="13En2FvLiUy" resolve="startNode" />
+            </node>
+            <node concept="37vLTw" id="13En2FvLiUq" role="37wK5m">
+              <ref role="3cqZAo" node="13En2FvLiU$" resolve="directDependencies" />
+            </node>
+            <node concept="37vLTw" id="13En2FvLiUr" role="37wK5m">
+              <ref role="3cqZAo" node="13En2FvLiUD" resolve="action" />
+            </node>
+            <node concept="2ShNRf" id="13En2FvLiUs" role="37wK5m">
+              <node concept="2i4dXS" id="13En2FvLiUt" role="2ShVmc">
+                <node concept="16syzq" id="13En2FvLRux" role="HW$YZ">
+                  <ref role="16sUi3" node="13En2FvIxxl" resolve="Component" />
+                </node>
+              </node>
+            </node>
+            <node concept="2ShNRf" id="13En2FvLiUv" role="37wK5m">
+              <node concept="Tc6Ow" id="13En2FvLiUw" role="2ShVmc">
+                <node concept="16syzq" id="13En2FvLWqc" role="HW$YZ">
+                  <ref role="16sUi3" node="13En2FvIxxl" resolve="Component" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3cqZAl" id="13En2FvLiUN" role="3clF45" />
+      <node concept="37vLTG" id="13En2FvLiUy" role="3clF46">
+        <property role="TrG5h" value="startNode" />
+        <node concept="16syzq" id="13En2FvLrEf" role="1tU5fm">
+          <ref role="16sUi3" node="13En2FvIxxl" resolve="Component" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="13En2FvLiU$" role="3clF46">
+        <property role="TrG5h" value="directDependencies" />
+        <node concept="3rvAFt" id="13En2FvLiU_" role="1tU5fm">
+          <node concept="16syzq" id="13En2FvLv$B" role="3rvQeY">
+            <ref role="16sUi3" node="13En2FvIxxl" resolve="Component" />
+          </node>
+          <node concept="2hMVRd" id="13En2FvLiUB" role="3rvSg0">
+            <node concept="16syzq" id="13En2FvLzN0" role="2hN53Y">
+              <ref role="16sUi3" node="13En2FvIxxl" resolve="Component" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="13En2FvLiUD" role="3clF46">
+        <property role="TrG5h" value="action" />
+        <node concept="1ajhzC" id="13En2FvLiUE" role="1tU5fm">
+          <node concept="3cqZAl" id="13En2FvLiUF" role="1ajl9A" />
+          <node concept="16syzq" id="13En2FvLBHz" role="1ajw0F">
+            <ref role="16sUi3" node="13En2FvIxxl" resolve="Component" />
+          </node>
+          <node concept="_YKpA" id="13En2FvLiUH" role="1ajw0F">
+            <node concept="16syzq" id="13En2FvLFCD" role="_ZDj9">
+              <ref role="16sUi3" node="13En2FvIxxl" resolve="Component" />
+            </node>
+          </node>
+          <node concept="2hMVRd" id="13En2FvLiUJ" role="1ajw0F">
+            <node concept="16syzq" id="13En2FvLJ$r" role="2hN53Y">
+              <ref role="16sUi3" node="13En2FvIxxl" resolve="Component" />
+            </node>
+          </node>
+          <node concept="_YKpA" id="13En2FvLiUL" role="1ajw0F">
+            <node concept="16syzq" id="13En2FvLNx_" role="_ZDj9">
+              <ref role="16sUi3" node="13En2FvIxxl" resolve="Component" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="13En2FvI8q0" role="jymVt" />
+    <node concept="3clFb_" id="13En2FvM0mw" role="jymVt">
+      <property role="TrG5h" value="DFS" />
+      <node concept="3clFbS" id="13En2FvM0my" role="3clF47">
+        <node concept="3cpWs8" id="13En2FvM0mz" role="3cqZAp">
+          <node concept="3cpWsn" id="13En2FvM0m$" role="3cpWs9">
+            <property role="TrG5h" value="directComponentDependencies" />
+            <node concept="3rvAFt" id="13En2FvM0m_" role="1tU5fm">
+              <node concept="16syzq" id="13En2FvU1ae" role="3rvQeY">
+                <ref role="16sUi3" node="13En2FvIxxl" resolve="Component" />
+              </node>
+              <node concept="2hMVRd" id="13En2FvM0mB" role="3rvSg0">
+                <node concept="16syzq" id="13En2FvU62J" role="2hN53Y">
+                  <ref role="16sUi3" node="13En2FvIxxl" resolve="Component" />
+                </node>
+              </node>
+            </node>
+            <node concept="2OqwBi" id="13En2FvTv3O" role="33vP2m">
+              <node concept="37vLTw" id="13En2FvTq5U" role="2Oq$k0">
+                <ref role="3cqZAo" node="13En2FvQ26l" resolve="dependenciesHelper" />
+              </node>
+              <node concept="liA8E" id="13En2FvTzWP" role="2OqNvi">
+                <ref role="37wK5l" node="13En2FvyssI" resolve="computeDirectComponentDependencies" />
+                <node concept="37vLTw" id="13En2FvTEN2" role="37wK5m">
+                  <ref role="3cqZAo" node="13En2FvM0mT" resolve="components" />
+                </node>
+                <node concept="37vLTw" id="13En2FvTKx6" role="37wK5m">
+                  <ref role="3cqZAo" node="13En2FvNhxZ" resolve="option" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="13En2FvM0mG" role="3cqZAp">
+          <node concept="2OqwBi" id="13En2FvM0mH" role="3clFbG">
+            <node concept="37vLTw" id="13En2FvM0mI" role="2Oq$k0">
+              <ref role="3cqZAo" node="13En2FvM0mW" resolve="startingModules" />
+            </node>
+            <node concept="2es0OD" id="13En2FvM0mJ" role="2OqNvi">
+              <node concept="1bVj0M" id="13En2FvM0mK" role="23t8la">
+                <node concept="3clFbS" id="13En2FvM0mL" role="1bW5cS">
+                  <node concept="3clFbF" id="13En2FvMcNx" role="3cqZAp">
+                    <node concept="1rXfSq" id="13En2FvMcNv" role="3clFbG">
+                      <ref role="37wK5l" node="13En2FvLiUk" resolve="DFS" />
+                      <node concept="37vLTw" id="13En2FvMgZo" role="37wK5m">
+                        <ref role="3cqZAo" node="13En2FvM0mR" resolve="startingMod" />
+                      </node>
+                      <node concept="37vLTw" id="13En2FvMpjR" role="37wK5m">
+                        <ref role="3cqZAo" node="13En2FvM0m$" resolve="directModuleDependencies" />
+                      </node>
+                      <node concept="37vLTw" id="13En2FvMxTX" role="37wK5m">
+                        <ref role="3cqZAo" node="13En2FvM0mZ" resolve="action" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="gl6BB" id="13En2FvM0mR" role="1bW2Oz">
+                  <property role="TrG5h" value="startingMod" />
+                  <node concept="2jxLKc" id="13En2FvM0mS" role="1tU5fm" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3cqZAl" id="13En2FvM0nb" role="3clF45" />
+      <node concept="37vLTG" id="13En2FvM0mT" role="3clF46">
+        <property role="TrG5h" value="components" />
+        <node concept="_YKpA" id="13En2FvM0mU" role="1tU5fm">
+          <node concept="16syzq" id="13En2FvMIXo" role="_ZDj9">
+            <ref role="16sUi3" node="13En2FvIxxl" resolve="Component" />
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="13En2FvM0mW" role="3clF46">
+        <property role="TrG5h" value="startingComponents" />
+        <node concept="_YKpA" id="13En2FvM0mX" role="1tU5fm">
+          <node concept="16syzq" id="13En2FvMQRg" role="_ZDj9">
+            <ref role="16sUi3" node="13En2FvIxxl" resolve="Component" />
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="13En2FvM0mZ" role="3clF46">
+        <property role="TrG5h" value="action" />
+        <node concept="1ajhzC" id="13En2FvM0n0" role="1tU5fm">
+          <node concept="3cqZAl" id="13En2FvM0n1" role="1ajl9A" />
+          <node concept="16syzq" id="13En2FvN1wF" role="1ajw0F">
+            <ref role="16sUi3" node="13En2FvIxxl" resolve="Component" />
+          </node>
+          <node concept="_YKpA" id="13En2FvM0n3" role="1ajw0F">
+            <node concept="16syzq" id="13En2FvN5vO" role="_ZDj9">
+              <ref role="16sUi3" node="13En2FvIxxl" resolve="Component" />
+            </node>
+          </node>
+          <node concept="2hMVRd" id="13En2FvM0n5" role="1ajw0F">
+            <node concept="16syzq" id="13En2FvN9vF" role="2hN53Y">
+              <ref role="16sUi3" node="13En2FvIxxl" resolve="Component" />
+            </node>
+          </node>
+          <node concept="_YKpA" id="13En2FvM0n7" role="1ajw0F">
+            <node concept="16syzq" id="13En2FvNdwW" role="_ZDj9">
+              <ref role="16sUi3" node="13En2FvIxxl" resolve="Component" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="13En2FvNhxZ" role="3clF46">
+        <property role="TrG5h" value="option" />
+        <node concept="3uibUv" id="13En2FvNm0m" role="1tU5fm">
+          <ref role="3uigEE" node="13En2FvhV7b" resolve="CyclicGenericDependenciesHelper.Option" />
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="13En2FvI8qG" role="jymVt" />
+    <node concept="3clFb_" id="13En2FvNZeg" role="jymVt">
+      <property role="TrG5h" value="findSomeCyclesStartingFrom" />
+      <node concept="3clFbS" id="13En2FvNZei" role="3clF47">
+        <node concept="3cpWs8" id="13En2FvNZej" role="3cqZAp">
+          <node concept="3cpWsn" id="13En2FvNZek" role="3cpWs9">
+            <property role="TrG5h" value="cycles" />
+            <node concept="_YKpA" id="13En2FvNZel" role="1tU5fm">
+              <node concept="_YKpA" id="13En2FvNZem" role="_ZDj9">
+                <node concept="16syzq" id="13En2FvOJBC" role="_ZDj9">
+                  <ref role="16sUi3" node="13En2FvIxxl" resolve="Component" />
+                </node>
+              </node>
+            </node>
+            <node concept="2ShNRf" id="13En2FvNZeo" role="33vP2m">
+              <node concept="Tc6Ow" id="13En2FvNZep" role="2ShVmc">
+                <node concept="_YKpA" id="13En2FvNZeq" role="HW$YZ">
+                  <node concept="16syzq" id="13En2FvONHo" role="_ZDj9">
+                    <ref role="16sUi3" node="13En2FvIxxl" resolve="Component" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="13En2FvNZes" role="3cqZAp">
+          <node concept="3cpWsn" id="13En2FvNZet" role="3cpWs9">
+            <property role="TrG5h" value="addToCycles" />
+            <node concept="1ajhzC" id="13En2FvNZeu" role="1tU5fm">
+              <node concept="16syzq" id="13En2FvOVYx" role="1ajw0F">
+                <ref role="16sUi3" node="13En2FvIxxl" resolve="Component" />
+              </node>
+              <node concept="_YKpA" id="13En2FvNZew" role="1ajw0F">
+                <node concept="16syzq" id="13En2FvP02v" role="_ZDj9">
+                  <ref role="16sUi3" node="13En2FvIxxl" resolve="Component" />
+                </node>
+              </node>
+              <node concept="2hMVRd" id="13En2FvNZey" role="1ajw0F">
+                <node concept="16syzq" id="13En2FvP46t" role="2hN53Y">
+                  <ref role="16sUi3" node="13En2FvIxxl" resolve="Component" />
+                </node>
+              </node>
+              <node concept="_YKpA" id="13En2FvNZe$" role="1ajw0F">
+                <node concept="16syzq" id="13En2FvP8ar" role="_ZDj9">
+                  <ref role="16sUi3" node="13En2FvIxxl" resolve="Component" />
+                </node>
+              </node>
+              <node concept="3cqZAl" id="13En2FvNZeA" role="1ajl9A" />
+            </node>
+            <node concept="1bVj0M" id="13En2FvNZeB" role="33vP2m">
+              <node concept="37vLTG" id="13En2FvNZeC" role="1bW2Oz">
+                <property role="TrG5h" value="current" />
+                <node concept="16syzq" id="13En2FvPcdv" role="1tU5fm">
+                  <ref role="16sUi3" node="13En2FvIxxl" resolve="Component" />
+                </node>
+              </node>
+              <node concept="37vLTG" id="13En2FvNZeE" role="1bW2Oz">
+                <property role="TrG5h" value="adjacents" />
+                <node concept="_YKpA" id="13En2FvNZeF" role="1tU5fm">
+                  <node concept="16syzq" id="13En2FvPggz" role="_ZDj9">
+                    <ref role="16sUi3" node="13En2FvIxxl" resolve="Component" />
+                  </node>
+                </node>
+              </node>
+              <node concept="37vLTG" id="13En2FvNZeH" role="1bW2Oz">
+                <property role="TrG5h" value="visited" />
+                <node concept="2hMVRd" id="13En2FvNZeI" role="1tU5fm">
+                  <node concept="16syzq" id="13En2FvPkjB" role="2hN53Y">
+                    <ref role="16sUi3" node="13En2FvIxxl" resolve="Component" />
+                  </node>
+                </node>
+              </node>
+              <node concept="37vLTG" id="13En2FvNZeK" role="1bW2Oz">
+                <property role="TrG5h" value="currentPath" />
+                <node concept="_YKpA" id="13En2FvNZeL" role="1tU5fm">
+                  <node concept="16syzq" id="13En2FvPomF" role="_ZDj9">
+                    <ref role="16sUi3" node="13En2FvIxxl" resolve="Component" />
+                  </node>
+                </node>
+              </node>
+              <node concept="3clFbS" id="13En2FvNZeN" role="1bW5cS">
+                <node concept="3clFbJ" id="13En2FvNZeO" role="3cqZAp">
+                  <node concept="1Wc70l" id="13En2FvNZeP" role="3clFbw">
+                    <node concept="3eOSWO" id="13En2FvNZeQ" role="3uHU7B">
+                      <node concept="2OqwBi" id="13En2FvNZeR" role="3uHU7B">
+                        <node concept="37vLTw" id="13En2FvNZeS" role="2Oq$k0">
+                          <ref role="3cqZAo" node="13En2FvNZeK" resolve="currentPath" />
+                        </node>
+                        <node concept="34oBXx" id="13En2FvNZeT" role="2OqNvi" />
+                      </node>
+                      <node concept="3cmrfG" id="13En2FvNZeU" role="3uHU7w">
+                        <property role="3cmrfH" value="1" />
+                      </node>
+                    </node>
+                    <node concept="17R0WA" id="13En2FvNZeV" role="3uHU7w">
+                      <node concept="37vLTw" id="13En2FvNZeW" role="3uHU7w">
+                        <ref role="3cqZAo" node="13En2FvNZeC" resolve="current" />
+                      </node>
+                      <node concept="2OqwBi" id="13En2FvNZeX" role="3uHU7B">
+                        <node concept="37vLTw" id="13En2FvNZeY" role="2Oq$k0">
+                          <ref role="3cqZAo" node="13En2FvNZeK" resolve="currentPath" />
+                        </node>
+                        <node concept="1uHKPH" id="13En2FvNZeZ" role="2OqNvi" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3clFbS" id="13En2FvNZf0" role="3clFbx">
+                    <node concept="3clFbF" id="13En2FvNZf1" role="3cqZAp">
+                      <node concept="2OqwBi" id="13En2FvNZf2" role="3clFbG">
+                        <node concept="37vLTw" id="13En2FvNZf3" role="2Oq$k0">
+                          <ref role="3cqZAo" node="13En2FvNZek" resolve="cycles" />
+                        </node>
+                        <node concept="TSZUe" id="13En2FvNZf4" role="2OqNvi">
+                          <node concept="2OqwBi" id="13En2FvNZf5" role="25WWJ7">
+                            <node concept="2OqwBi" id="13En2FvNZf6" role="2Oq$k0">
+                              <node concept="37vLTw" id="13En2FvNZf7" role="2Oq$k0">
+                                <ref role="3cqZAo" node="13En2FvNZeK" resolve="currentPath" />
+                              </node>
+                              <node concept="3QWeyG" id="13En2FvNZf8" role="2OqNvi">
+                                <node concept="2ShNRf" id="13En2FvNZf9" role="576Qk">
+                                  <node concept="2HTt$P" id="13En2FvNZfa" role="2ShVmc">
+                                    <node concept="16syzq" id="13En2FvPspJ" role="2HTBi0">
+                                      <ref role="16sUi3" node="13En2FvIxxl" resolve="Component" />
+                                    </node>
+                                    <node concept="37vLTw" id="13En2FvNZfc" role="2HTEbv">
+                                      <ref role="3cqZAo" node="13En2FvNZeC" resolve="current" />
+                                    </node>
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                            <node concept="ANE8D" id="13En2FvNZfd" role="2OqNvi" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="13En2FvNZfe" role="3cqZAp">
+          <node concept="1rXfSq" id="13En2FvNZff" role="3clFbG">
+            <ref role="37wK5l" node="13En2FvM0mw" resolve="DFS" />
+            <node concept="37vLTw" id="13En2FvNZfg" role="37wK5m">
+              <ref role="3cqZAo" node="13En2FvNZfm" resolve="modules" />
+            </node>
+            <node concept="37vLTw" id="13En2FvNZfh" role="37wK5m">
+              <ref role="3cqZAo" node="13En2FvNZfp" resolve="startingModules" />
+            </node>
+            <node concept="37vLTw" id="13En2FvNZfi" role="37wK5m">
+              <ref role="3cqZAo" node="13En2FvNZet" resolve="addToCycles" />
+            </node>
+            <node concept="37vLTw" id="13En2FvNZfj" role="37wK5m">
+              <ref role="3cqZAo" node="13En2FvOyc3" resolve="option" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="13En2FvNZfk" role="3cqZAp">
+          <node concept="37vLTw" id="13En2FvNZfl" role="3clFbG">
+            <ref role="3cqZAo" node="13En2FvNZek" resolve="cycles" />
+          </node>
+        </node>
+      </node>
+      <node concept="A3Dl8" id="13En2FvNZfv" role="3clF45">
+        <node concept="_YKpA" id="13En2FvNZfw" role="A3Ik2">
+          <node concept="16syzq" id="13En2FvO59F" role="_ZDj9">
+            <ref role="16sUi3" node="13En2FvIxxl" resolve="Component" />
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="13En2FvNZfm" role="3clF46">
+        <property role="TrG5h" value="components" />
+        <node concept="_YKpA" id="13En2FvNZfn" role="1tU5fm">
+          <node concept="16syzq" id="13En2FvO9bn" role="_ZDj9">
+            <ref role="16sUi3" node="13En2FvIxxl" resolve="Component" />
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="13En2FvNZfp" role="3clF46">
+        <property role="TrG5h" value="startingComponents" />
+        <node concept="_YKpA" id="13En2FvNZfq" role="1tU5fm">
+          <node concept="16syzq" id="13En2FvOhVv" role="_ZDj9">
+            <ref role="16sUi3" node="13En2FvIxxl" resolve="Component" />
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="13En2FvOyc3" role="3clF46">
+        <property role="TrG5h" value="option" />
+        <node concept="3uibUv" id="13En2FvOArq" role="1tU5fm">
+          <ref role="3uigEE" node="13En2FvhV7b" resolve="CyclicGenericDependenciesHelper.Option" />
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="13En2FvNZfu" role="1B3o_S" />
+    </node>
+    <node concept="2tJIrI" id="13En2FvI8rY" role="jymVt" />
+    <node concept="16euLQ" id="13En2FvIxxl" role="16eVyc">
+      <property role="TrG5h" value="Component" />
+    </node>
+  </node>
+  <node concept="312cEu" id="13En2Fv5upa">
+    <property role="TrG5h" value="CyclicGenericDependenciesHelper" />
+    <property role="3GE5qa" value="helpers" />
+    <node concept="2tJIrI" id="13En2Fv5upb" role="jymVt" />
+    <node concept="312cEg" id="13En2FvqIXu" role="jymVt">
+      <property role="TrG5h" value="dependencyResolver" />
+      <node concept="3Tm6S6" id="13En2FvqIXv" role="1B3o_S" />
+      <node concept="1ajhzC" id="13En2Fvf4kK" role="1tU5fm">
+        <node concept="A3Dl8" id="13En2Fvfg4I" role="1ajl9A">
+          <node concept="16syzq" id="13En2FvhciG" role="A3Ik2">
+            <ref role="16sUi3" node="13En2Fv6yo$" resolve="Component" />
+          </node>
+        </node>
+        <node concept="_YKpA" id="13En2Fw2dnV" role="1ajw0F">
+          <node concept="16syzq" id="13En2Fw2dnW" role="_ZDj9">
+            <ref role="16sUi3" node="13En2Fv6yo$" resolve="Component" />
+          </node>
+        </node>
+        <node concept="16syzq" id="13En2Fvf9BQ" role="1ajw0F">
+          <ref role="16sUi3" node="13En2Fv6yo$" resolve="Component" />
+        </node>
+        <node concept="3uibUv" id="13En2FvEIms" role="1ajw0F">
+          <ref role="3uigEE" node="13En2FvhV7b" resolve="CyclicGenericDependenciesHelper.Option" />
+        </node>
+      </node>
+    </node>
+    <node concept="312cEg" id="13En2FvvVYi" role="jymVt">
+      <property role="TrG5h" value="componentComparator" />
+      <node concept="3Tm6S6" id="13En2FvvVYj" role="1B3o_S" />
+      <node concept="3uibUv" id="13En2FvvVYl" role="1tU5fm">
+        <ref role="3uigEE" to="33ny:~Comparator" resolve="Comparator" />
+        <node concept="16syzq" id="13En2FvvVYm" role="11_B2D">
+          <ref role="16sUi3" node="13En2Fv6yo$" resolve="Component" />
+        </node>
+      </node>
+    </node>
+    <node concept="312cEg" id="13En2Fw8U7C" role="jymVt">
+      <property role="TrG5h" value="componentNameResolver" />
+      <node concept="3Tm6S6" id="13En2Fw8U7D" role="1B3o_S" />
+      <node concept="1ajhzC" id="13En2Fvr$ID" role="1tU5fm">
+        <node concept="17QB3L" id="13En2Fvr$IE" role="1ajl9A" />
+        <node concept="16syzq" id="13En2Fwde53" role="1ajw0F">
+          <ref role="16sUi3" node="13En2Fv6yo$" resolve="Component" />
+        </node>
+      </node>
+    </node>
+    <node concept="312cEg" id="13En2FwkzNh" role="jymVt">
+      <property role="TrG5h" value="option" />
+      <node concept="3Tm6S6" id="13En2FwkmYy" role="1B3o_S" />
+      <node concept="3uibUv" id="13En2FwkvEw" role="1tU5fm">
+        <ref role="3uigEE" node="13En2FvhV7b" resolve="CyclicGenericDependenciesHelper.Option" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="13En2FvqAOi" role="jymVt" />
+    <node concept="3clFbW" id="13En2FvqZ5e" role="jymVt">
+      <node concept="37vLTG" id="13En2FveY_o" role="3clF46">
+        <property role="TrG5h" value="dependencyResolver" />
+        <node concept="1ajhzC" id="13En2Fvr79e" role="1tU5fm">
+          <node concept="A3Dl8" id="13En2Fvr79f" role="1ajl9A">
+            <node concept="16syzq" id="13En2Fvr79g" role="A3Ik2">
+              <ref role="16sUi3" node="13En2Fv6yo$" resolve="Component" />
+            </node>
+          </node>
+          <node concept="_YKpA" id="13En2Fw24ti" role="1ajw0F">
+            <node concept="16syzq" id="13En2Fw28Uz" role="_ZDj9">
+              <ref role="16sUi3" node="13En2Fv6yo$" resolve="Component" />
+            </node>
+          </node>
+          <node concept="16syzq" id="13En2Fvr79h" role="1ajw0F">
+            <ref role="16sUi3" node="13En2Fv6yo$" resolve="Component" />
+          </node>
+          <node concept="3uibUv" id="13En2FvEUvC" role="1ajw0F">
+            <ref role="3uigEE" node="13En2FvhV7b" resolve="CyclicGenericDependenciesHelper.Option" />
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="13En2FvwjDs" role="3clF46">
+        <property role="TrG5h" value="componentComparator" />
+        <node concept="3uibUv" id="13En2Fvwovu" role="1tU5fm">
+          <ref role="3uigEE" to="33ny:~Comparator" resolve="Comparator" />
+          <node concept="16syzq" id="13En2Fvwovv" role="11_B2D">
+            <ref role="16sUi3" node="13En2Fv6yo$" resolve="Component" />
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="13En2Fvr$IC" role="3clF46">
+        <property role="TrG5h" value="componentNameResolver" />
+        <node concept="1ajhzC" id="13En2Fw9iXe" role="1tU5fm">
+          <node concept="17QB3L" id="13En2Fw9iXf" role="1ajl9A" />
+          <node concept="16syzq" id="13En2Fwd953" role="1ajw0F">
+            <ref role="16sUi3" node="13En2Fv6yo$" resolve="Component" />
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="13En2Fvt4qt" role="3clF46">
+        <property role="TrG5h" value="option" />
+        <node concept="3uibUv" id="13En2Fvt96M" role="1tU5fm">
+          <ref role="3uigEE" node="13En2FvhV7b" resolve="CyclicGenericDependenciesHelper.Option" />
+        </node>
+      </node>
+      <node concept="3cqZAl" id="13En2FvqZ5f" role="3clF45" />
+      <node concept="3clFbS" id="13En2FvqZ5h" role="3clF47">
+        <node concept="3clFbF" id="13En2Fvrc7q" role="3cqZAp">
+          <node concept="37vLTI" id="13En2FvrlQr" role="3clFbG">
+            <node concept="37vLTw" id="13En2FvrqjO" role="37vLTx">
+              <ref role="3cqZAo" node="13En2FveY_o" resolve="dependencyResolver" />
+            </node>
+            <node concept="2OqwBi" id="13En2Fvrcg$" role="37vLTJ">
+              <node concept="Xjq3P" id="13En2Fvrc7p" role="2Oq$k0" />
+              <node concept="2OwXpG" id="13En2FvrgTh" role="2OqNvi">
+                <ref role="2Oxat5" node="13En2FvqIXu" resolve="dependencyResolver" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="13En2Fvww14" role="3cqZAp">
+          <node concept="37vLTI" id="13En2FvwFvS" role="3clFbG">
+            <node concept="37vLTw" id="13En2FvwICh" role="37vLTx">
+              <ref role="3cqZAo" node="13En2FvwjDs" resolve="componentComparator" />
+            </node>
+            <node concept="2OqwBi" id="13En2Fvwwea" role="37vLTJ">
+              <node concept="Xjq3P" id="13En2Fvww12" role="2Oq$k0" />
+              <node concept="2OwXpG" id="13En2Fvw_qI" role="2OqNvi">
+                <ref role="2Oxat5" node="13En2FvvVYi" resolve="componentComparator" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="13En2Fw9xqY" role="3cqZAp">
+          <node concept="37vLTI" id="13En2Fw9FjG" role="3clFbG">
+            <node concept="37vLTw" id="13En2Fw9JK9" role="37vLTx">
+              <ref role="3cqZAo" node="13En2Fvr$IC" resolve="componentNameResolver" />
+            </node>
+            <node concept="2OqwBi" id="13En2Fw9xF0" role="37vLTJ">
+              <node concept="Xjq3P" id="13En2Fw9xqW" role="2Oq$k0" />
+              <node concept="2OwXpG" id="13En2Fw9Apf" role="2OqNvi">
+                <ref role="2Oxat5" node="13En2Fw8U7C" resolve="componentNameResolver" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="13En2FwkIYp" role="3cqZAp">
+          <node concept="37vLTI" id="13En2FwkSRU" role="3clFbG">
+            <node concept="37vLTw" id="13En2FwkXoB" role="37vLTx">
+              <ref role="3cqZAo" node="13En2Fvt4qt" resolve="option" />
+            </node>
+            <node concept="2OqwBi" id="13En2FwkJg7" role="37vLTJ">
+              <node concept="Xjq3P" id="13En2FwkIYn" role="2Oq$k0" />
+              <node concept="2OwXpG" id="13En2FwkO6j" role="2OqNvi">
+                <ref role="2Oxat5" node="13En2FwkzNh" resolve="option" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="13En2FvqZ5i" role="1B3o_S" />
+    </node>
+    <node concept="2tJIrI" id="13En2FvqAOj" role="jymVt" />
+    <node concept="312cEu" id="13En2FvhV7b" role="jymVt">
+      <property role="TrG5h" value="Option" />
+      <node concept="3Tm1VV" id="13En2FvhHK6" role="1B3o_S" />
+    </node>
+    <node concept="2tJIrI" id="13En2Fvh$C2" role="jymVt" />
+    <node concept="3clFb_" id="13En2FwlozC" role="jymVt">
+      <property role="TrG5h" value="getOption" />
+      <node concept="3clFbS" id="13En2FwlozF" role="3clF47">
+        <node concept="3clFbF" id="13En2Fwlygn" role="3cqZAp">
+          <node concept="2OqwBi" id="13En2FwlE0S" role="3clFbG">
+            <node concept="Xjq3P" id="13En2Fwlygm" role="2Oq$k0" />
+            <node concept="2OwXpG" id="13En2FwlLiZ" role="2OqNvi">
+              <ref role="2Oxat5" node="13En2FwkzNh" resolve="option" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="13En2Fwlb$G" role="1B3o_S" />
+      <node concept="3uibUv" id="13En2FwlknV" role="3clF45">
+        <ref role="3uigEE" node="13En2FvhV7b" resolve="CyclicGenericDependenciesHelper.Option" />
+      </node>
+    </node>
+    <node concept="2tJIrI" id="13En2Fwl1Lk" role="jymVt" />
+    <node concept="3clFb_" id="13En2Fvr$Iu" role="jymVt">
+      <property role="TrG5h" value="computeTooLargeStronglyConnectedComponents" />
+      <node concept="3clFbS" id="13En2Fvr$IH" role="3clF47">
+        <node concept="3clFbH" id="13En2Fvr$II" role="3cqZAp" />
+        <node concept="3cpWs8" id="13En2Fvr$IJ" role="3cqZAp">
+          <node concept="3cpWsn" id="13En2Fvr$IK" role="3cpWs9">
+            <property role="TrG5h" value="directDependencies" />
+            <node concept="3rvAFt" id="13En2Fvr$IL" role="1tU5fm">
+              <node concept="16syzq" id="13En2Fvr$IM" role="3rvQeY">
+                <ref role="16sUi3" node="13En2Fv6yo$" resolve="Component" />
+              </node>
+              <node concept="2hMVRd" id="13En2Fvr$IN" role="3rvSg0">
+                <node concept="16syzq" id="13En2Fvr$IO" role="2hN53Y">
+                  <ref role="16sUi3" node="13En2Fv6yo$" resolve="Component" />
+                </node>
+              </node>
+            </node>
+            <node concept="1rXfSq" id="13En2Fvr$IP" role="33vP2m">
+              <ref role="37wK5l" node="13En2FvyssI" resolve="computeDirectComponentDependencies" />
+              <node concept="37vLTw" id="13En2Fvr$IQ" role="37wK5m">
+                <ref role="3cqZAo" node="13En2Fvr$Iw" resolve="components" />
+              </node>
+              <node concept="10Nm6u" id="13En2FvtWqn" role="37wK5m" />
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="13En2Fvr$IS" role="3cqZAp">
+          <node concept="3cpWsn" id="13En2Fvr$IT" role="3cpWs9">
+            <property role="TrG5h" value="indirectDependencies" />
+            <node concept="3rvAFt" id="13En2Fvr$IU" role="1tU5fm">
+              <node concept="16syzq" id="13En2Fvr$IV" role="3rvQeY">
+                <ref role="16sUi3" node="13En2Fv6yo$" resolve="Component" />
+              </node>
+              <node concept="2hMVRd" id="13En2Fvr$IW" role="3rvSg0">
+                <node concept="16syzq" id="13En2Fvr$IX" role="2hN53Y">
+                  <ref role="16sUi3" node="13En2Fv6yo$" resolve="Component" />
+                </node>
+              </node>
+            </node>
+            <node concept="1rXfSq" id="13En2Fvr$IY" role="33vP2m">
+              <ref role="37wK5l" node="13En2FvA768" resolve="computeIndirectDependencies" />
+              <node concept="37vLTw" id="13En2Fvr$IZ" role="37wK5m">
+                <ref role="3cqZAo" node="13En2Fvr$IK" resolve="directDependencies" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="13En2Fvr$J0" role="3cqZAp" />
+        <node concept="3cpWs8" id="13En2Fvr$J1" role="3cqZAp">
+          <node concept="3cpWsn" id="13En2Fvr$J2" role="3cpWs9">
+            <property role="TrG5h" value="listOfStronglyConnectedComponents" />
+            <node concept="_YKpA" id="13En2Fvr$J3" role="1tU5fm">
+              <node concept="2hMVRd" id="13En2Fvr$J4" role="_ZDj9">
+                <node concept="16syzq" id="13En2Fvr$J5" role="2hN53Y">
+                  <ref role="16sUi3" node="13En2Fv6yo$" resolve="Component" />
+                </node>
+              </node>
+            </node>
+            <node concept="2ShNRf" id="13En2Fvr$J6" role="33vP2m">
+              <node concept="Tc6Ow" id="13En2Fvr$J7" role="2ShVmc">
+                <node concept="2hMVRd" id="13En2Fvr$J8" role="HW$YZ">
+                  <node concept="16syzq" id="13En2Fvr$J9" role="2hN53Y">
+                    <ref role="16sUi3" node="13En2Fv6yo$" resolve="Component" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="13En2Fvr$Ja" role="3cqZAp" />
+        <node concept="3cpWs8" id="13En2Fvr$Jb" role="3cqZAp">
+          <node concept="3cpWsn" id="13En2Fvr$Jc" role="3cpWs9">
+            <property role="TrG5h" value="tmp" />
+            <node concept="_YKpA" id="13En2Fvr$Jd" role="1tU5fm">
+              <node concept="16syzq" id="13En2Fvr$Je" role="_ZDj9">
+                <ref role="16sUi3" node="13En2Fv6yo$" resolve="Component" />
+              </node>
+            </node>
+            <node concept="2ShNRf" id="13En2Fvr$Jf" role="33vP2m">
+              <node concept="Tc6Ow" id="13En2Fvr$Jg" role="2ShVmc">
+                <node concept="16syzq" id="13En2Fvr$Jh" role="HW$YZ">
+                  <ref role="16sUi3" node="13En2Fv6yo$" resolve="Component" />
+                </node>
+                <node concept="37vLTw" id="13En2Fvr$Ji" role="I$8f6">
+                  <ref role="3cqZAo" node="13En2Fvr$Iw" resolve="components" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1Dw8fO" id="13En2Fvr$Jj" role="3cqZAp">
+          <node concept="3clFbS" id="13En2Fvr$Jk" role="2LFqv$">
+            <node concept="3cpWs8" id="13En2Fvr$Jl" role="3cqZAp">
+              <node concept="3cpWsn" id="13En2Fvr$Jm" role="3cpWs9">
+                <property role="TrG5h" value="crtStronglyConnectedComponent" />
+                <node concept="2hMVRd" id="13En2Fvr$Jn" role="1tU5fm">
+                  <node concept="16syzq" id="13En2Fvr$Jo" role="2hN53Y">
+                    <ref role="16sUi3" node="13En2Fv6yo$" resolve="Component" />
+                  </node>
+                </node>
+                <node concept="2ShNRf" id="13En2Fvr$Jp" role="33vP2m">
+                  <node concept="2i4dXS" id="13En2Fvr$Jq" role="2ShVmc">
+                    <node concept="16syzq" id="13En2Fvr$Jr" role="HW$YZ">
+                      <ref role="16sUi3" node="13En2Fv6yo$" resolve="Component" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbF" id="13En2Fvr$Js" role="3cqZAp">
+              <node concept="2OqwBi" id="13En2Fvr$Jt" role="3clFbG">
+                <node concept="37vLTw" id="13En2Fvr$Ju" role="2Oq$k0">
+                  <ref role="3cqZAo" node="13En2Fvr$J2" resolve="listOfStronglyConnectedComponents" />
+                </node>
+                <node concept="TSZUe" id="13En2Fvr$Jv" role="2OqNvi">
+                  <node concept="37vLTw" id="13En2Fvr$Jw" role="25WWJ7">
+                    <ref role="3cqZAo" node="13En2Fvr$Jm" resolve="crtStronglyConnectedComponent" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3cpWs8" id="13En2Fvr$Jx" role="3cqZAp">
+              <node concept="3cpWsn" id="13En2Fvr$Jy" role="3cpWs9">
+                <property role="TrG5h" value="crtComponent" />
+                <node concept="16syzq" id="13En2Fvr$Jz" role="1tU5fm">
+                  <ref role="16sUi3" node="13En2Fv6yo$" resolve="Component" />
+                </node>
+                <node concept="2OqwBi" id="13En2Fvr$J$" role="33vP2m">
+                  <node concept="37vLTw" id="13En2Fvr$J_" role="2Oq$k0">
+                    <ref role="3cqZAo" node="13En2Fvr$Jc" resolve="tmp" />
+                  </node>
+                  <node concept="34jXtK" id="13En2Fvr$JA" role="2OqNvi">
+                    <node concept="37vLTw" id="13En2Fvr$JB" role="25WWJ7">
+                      <ref role="3cqZAo" node="13En2Fvr$K5" resolve="i" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbF" id="13En2Fvr$JC" role="3cqZAp">
+              <node concept="2OqwBi" id="13En2Fvr$JD" role="3clFbG">
+                <node concept="37vLTw" id="13En2Fvr$JE" role="2Oq$k0">
+                  <ref role="3cqZAo" node="13En2Fvr$Jm" resolve="crtStronglyConnectedComponent" />
+                </node>
+                <node concept="TSZUe" id="13En2Fvr$JF" role="2OqNvi">
+                  <node concept="37vLTw" id="13En2Fvr$JG" role="25WWJ7">
+                    <ref role="3cqZAo" node="13En2Fvr$Jy" resolve="crtComponent" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="2Gpval" id="13En2Fvr$JH" role="3cqZAp">
+              <node concept="2GrKxI" id="13En2Fvr$JI" role="2Gsz3X">
+                <property role="TrG5h" value="dep" />
+              </node>
+              <node concept="3EllGN" id="13En2Fvr$JJ" role="2GsD0m">
+                <node concept="37vLTw" id="13En2Fvr$JK" role="3ElVtu">
+                  <ref role="3cqZAo" node="13En2Fvr$Jy" resolve="crtComponent" />
+                </node>
+                <node concept="37vLTw" id="13En2Fvr$JL" role="3ElQJh">
+                  <ref role="3cqZAo" node="13En2Fvr$IT" resolve="indirectDependencies" />
+                </node>
+              </node>
+              <node concept="3clFbS" id="13En2Fvr$JM" role="2LFqv$">
+                <node concept="3clFbJ" id="13En2Fvr$JN" role="3cqZAp">
+                  <node concept="2OqwBi" id="13En2Fvr$JO" role="3clFbw">
+                    <node concept="3EllGN" id="13En2Fvr$JP" role="2Oq$k0">
+                      <node concept="2GrUjf" id="13En2Fvr$JQ" role="3ElVtu">
+                        <ref role="2Gs0qQ" node="13En2Fvr$JI" resolve="dep" />
+                      </node>
+                      <node concept="37vLTw" id="13En2Fvr$JR" role="3ElQJh">
+                        <ref role="3cqZAo" node="13En2Fvr$IT" resolve="indirectDependencies" />
+                      </node>
+                    </node>
+                    <node concept="3JPx81" id="13En2Fvr$JS" role="2OqNvi">
+                      <node concept="37vLTw" id="13En2Fvr$JT" role="25WWJ7">
+                        <ref role="3cqZAo" node="13En2Fvr$Jy" resolve="crtComponent" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="3clFbS" id="13En2Fvr$JU" role="3clFbx">
+                    <node concept="3clFbF" id="13En2Fvr$JV" role="3cqZAp">
+                      <node concept="2OqwBi" id="13En2Fvr$JW" role="3clFbG">
+                        <node concept="37vLTw" id="13En2Fvr$JX" role="2Oq$k0">
+                          <ref role="3cqZAo" node="13En2Fvr$Jm" resolve="crtStronglyConnectedComponent" />
+                        </node>
+                        <node concept="TSZUe" id="13En2Fvr$JY" role="2OqNvi">
+                          <node concept="2GrUjf" id="13En2Fvr$JZ" role="25WWJ7">
+                            <ref role="2Gs0qQ" node="13En2Fvr$JI" resolve="dep" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="3clFbF" id="13En2Fvr$K0" role="3cqZAp">
+                      <node concept="2OqwBi" id="13En2Fvr$K1" role="3clFbG">
+                        <node concept="37vLTw" id="13En2Fvr$K2" role="2Oq$k0">
+                          <ref role="3cqZAo" node="13En2Fvr$Jc" resolve="tmp" />
+                        </node>
+                        <node concept="3dhRuq" id="13En2Fvr$K3" role="2OqNvi">
+                          <node concept="2GrUjf" id="13En2Fvr$K4" role="25WWJ7">
+                            <ref role="2Gs0qQ" node="13En2Fvr$JI" resolve="dep" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3cpWsn" id="13En2Fvr$K5" role="1Duv9x">
+            <property role="TrG5h" value="i" />
+            <node concept="10Oyi0" id="13En2Fvr$K6" role="1tU5fm" />
+            <node concept="3cmrfG" id="13En2Fvr$K7" role="33vP2m">
+              <property role="3cmrfH" value="0" />
+            </node>
+          </node>
+          <node concept="3eOVzh" id="13En2Fvr$K8" role="1Dwp0S">
+            <node concept="2OqwBi" id="13En2Fvr$K9" role="3uHU7w">
+              <node concept="37vLTw" id="13En2Fvr$Ka" role="2Oq$k0">
+                <ref role="3cqZAo" node="13En2Fvr$Jc" resolve="tmp" />
+              </node>
+              <node concept="34oBXx" id="13En2Fvr$Kb" role="2OqNvi" />
+            </node>
+            <node concept="37vLTw" id="13En2Fvr$Kc" role="3uHU7B">
+              <ref role="3cqZAo" node="13En2Fvr$K5" resolve="i" />
+            </node>
+          </node>
+          <node concept="3uNrnE" id="13En2Fvr$Kd" role="1Dwrff">
+            <node concept="37vLTw" id="13En2Fvr$Ke" role="2$L3a6">
+              <ref role="3cqZAo" node="13En2Fvr$K5" resolve="i" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="13En2Fvr$Kf" role="3cqZAp" />
+        <node concept="2Gpval" id="13En2Fvr$Kg" role="3cqZAp">
+          <node concept="2GrKxI" id="13En2Fvr$Kh" role="2Gsz3X">
+            <property role="TrG5h" value="crtStronglyConnectedComponent" />
+          </node>
+          <node concept="37vLTw" id="13En2Fvr$Ki" role="2GsD0m">
+            <ref role="3cqZAo" node="13En2Fvr$J2" resolve="listOfStronglyConnectedComponents" />
+          </node>
+          <node concept="3clFbS" id="13En2Fvr$Kj" role="2LFqv$">
+            <node concept="3clFbJ" id="13En2Fvr$Kk" role="3cqZAp">
+              <node concept="3eOSWO" id="13En2Fvr$Kl" role="3clFbw">
+                <node concept="37vLTw" id="13En2Fvr$Km" role="3uHU7w">
+                  <ref role="3cqZAo" node="13En2Fvr$IA" resolve="minLength" />
+                </node>
+                <node concept="2OqwBi" id="13En2Fvr$Kn" role="3uHU7B">
+                  <node concept="34oBXx" id="13En2Fvr$Ko" role="2OqNvi" />
+                  <node concept="2GrUjf" id="13En2Fvr$Kp" role="2Oq$k0">
+                    <ref role="2Gs0qQ" node="13En2Fvr$Kh" resolve="crtStronglyConnectedComponent" />
+                  </node>
+                </node>
+              </node>
+              <node concept="3clFbS" id="13En2Fvr$Kq" role="3clFbx">
+                <node concept="3clFbF" id="13En2Fvr$Kr" role="3cqZAp">
+                  <node concept="2OqwBi" id="13En2Fvr$Ks" role="3clFbG">
+                    <node concept="37vLTw" id="13En2Fvr$Kt" role="2Oq$k0">
+                      <ref role="3cqZAo" node="13En2Fvr$Iz" resolve="res" />
+                    </node>
+                    <node concept="TSZUe" id="13En2Fvr$Ku" role="2OqNvi">
+                      <node concept="3cpWs3" id="13En2Fvr$Kv" role="25WWJ7">
+                        <node concept="3cpWs3" id="13En2Fvr$Kw" role="3uHU7B">
+                          <node concept="3cpWs3" id="13En2Fvr$Kx" role="3uHU7B">
+                            <node concept="Xl_RD" id="13En2Fvr$Ky" role="3uHU7B">
+                              <property role="Xl_RC" value="Strongly connected component with length " />
+                            </node>
+                            <node concept="2OqwBi" id="13En2Fvr$Kz" role="3uHU7w">
+                              <node concept="2GrUjf" id="13En2Fvr$K$" role="2Oq$k0">
+                                <ref role="2Gs0qQ" node="13En2Fvr$Kh" resolve="crtStronglyConnectedComponent" />
+                              </node>
+                              <node concept="34oBXx" id="13En2Fvr$K_" role="2OqNvi" />
+                            </node>
+                          </node>
+                          <node concept="Xl_RD" id="13En2Fvr$KA" role="3uHU7w">
+                            <property role="Xl_RC" value=" found: " />
+                          </node>
+                        </node>
+                        <node concept="2OqwBi" id="13En2Fvr$KB" role="3uHU7w">
+                          <node concept="2S7cBI" id="13En2Fvr$KC" role="2OqNvi">
+                            <node concept="1bVj0M" id="13En2Fvr$KD" role="23t8la">
+                              <node concept="3clFbS" id="13En2Fvr$KE" role="1bW5cS">
+                                <node concept="3clFbF" id="13En2Fvr$KF" role="3cqZAp">
+                                  <node concept="2Sg_IR" id="13En2Fvr$KG" role="3clFbG">
+                                    <node concept="37vLTw" id="13En2Fvr$KH" role="2SgG2M">
+                                      <ref role="3cqZAo" node="13En2Fw8U7C" resolve="componentNameResolver" />
+                                    </node>
+                                    <node concept="37vLTw" id="13En2Fvr$KI" role="2SgHGx">
+                                      <ref role="3cqZAo" node="13En2Fvr$KJ" resolve="it" />
+                                    </node>
+                                  </node>
+                                </node>
+                              </node>
+                              <node concept="gl6BB" id="13En2Fvr$KJ" role="1bW2Oz">
+                                <property role="TrG5h" value="it" />
+                                <node concept="2jxLKc" id="13En2Fvr$KK" role="1tU5fm" />
+                              </node>
+                            </node>
+                            <node concept="1nlBCl" id="13En2Fvr$KL" role="2S7zOq">
+                              <property role="3clFbU" value="true" />
+                            </node>
+                          </node>
+                          <node concept="2GrUjf" id="13En2Fvr$KM" role="2Oq$k0">
+                            <ref role="2Gs0qQ" node="13En2Fvr$Kh" resolve="crtStronglyConnectedComponent" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3cqZAl" id="13En2Fvr$IG" role="3clF45" />
+      <node concept="37vLTG" id="13En2Fvr$Iw" role="3clF46">
+        <property role="TrG5h" value="components" />
+        <node concept="_YKpA" id="13En2Fvr$Ix" role="1tU5fm">
+          <node concept="16syzq" id="13En2Fvr$Iy" role="_ZDj9">
+            <ref role="16sUi3" node="13En2Fv6yo$" resolve="Component" />
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="13En2Fvr$Iz" role="3clF46">
+        <property role="TrG5h" value="res" />
+        <node concept="_YKpA" id="13En2Fvr$I$" role="1tU5fm">
+          <node concept="17QB3L" id="13En2Fvr$I_" role="_ZDj9" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="13En2Fvr$IA" role="3clF46">
+        <property role="TrG5h" value="minLength" />
+        <node concept="10Oyi0" id="13En2Fvr$IB" role="1tU5fm" />
+      </node>
+      <node concept="3Tm1VV" id="13En2FvrHYx" role="1B3o_S" />
+    </node>
+    <node concept="2tJIrI" id="13En2Fv5urt" role="jymVt" />
+    <node concept="3clFb_" id="13En2Fvu8h0" role="jymVt">
+      <property role="TrG5h" value="computeTooLargeCycles" />
+      <node concept="3clFbS" id="13En2Fvu8hb" role="3clF47">
+        <node concept="3cpWs8" id="13En2Fvu8hc" role="3cqZAp">
+          <node concept="3cpWsn" id="13En2Fvu8hd" role="3cpWs9">
+            <property role="TrG5h" value="allCycles" />
+            <node concept="2hMVRd" id="13En2Fvu8he" role="1tU5fm">
+              <node concept="3uibUv" id="13En2Fvu8hf" role="2hN53Y">
+                <ref role="3uigEE" to="33ny:~ArrayList" resolve="ArrayList" />
+                <node concept="16syzq" id="13En2FvGG_9" role="11_B2D">
+                  <ref role="16sUi3" node="13En2Fv6yo$" resolve="Component" />
+                </node>
+              </node>
+            </node>
+            <node concept="1rXfSq" id="13En2Fvu8hh" role="33vP2m">
+              <ref role="37wK5l" node="13En2FvxEE9" resolve="computeAllCycles" />
+              <node concept="37vLTw" id="13En2Fvu8hi" role="37wK5m">
+                <ref role="3cqZAo" node="13En2Fvu8h2" resolve="components" />
+              </node>
+              <node concept="10Nm6u" id="13En2FvG$P7" role="37wK5m" />
+              <node concept="3cmrfG" id="13En2Fvu8hk" role="37wK5m">
+                <property role="3cmrfH" value="-1" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="2Gpval" id="13En2Fvu8hl" role="3cqZAp">
+          <node concept="2GrKxI" id="13En2Fvu8hm" role="2Gsz3X">
+            <property role="TrG5h" value="crtCycle" />
+          </node>
+          <node concept="37vLTw" id="13En2Fvu8hn" role="2GsD0m">
+            <ref role="3cqZAo" node="13En2Fvu8hd" resolve="allCycles" />
+          </node>
+          <node concept="3clFbS" id="13En2Fvu8ho" role="2LFqv$">
+            <node concept="3clFbJ" id="13En2Fvu8hp" role="3cqZAp">
+              <node concept="3eOSWO" id="13En2Fvu8hq" role="3clFbw">
+                <node concept="2OqwBi" id="13En2Fvu8hr" role="3uHU7B">
+                  <node concept="liA8E" id="13En2Fvu8hs" role="2OqNvi">
+                    <ref role="37wK5l" to="33ny:~ArrayList.size()" resolve="size" />
+                  </node>
+                  <node concept="2GrUjf" id="13En2Fvu8ht" role="2Oq$k0">
+                    <ref role="2Gs0qQ" node="13En2Fvu8hm" resolve="crtCycle" />
+                  </node>
+                </node>
+                <node concept="37vLTw" id="13En2Fvu8hu" role="3uHU7w">
+                  <ref role="3cqZAo" node="13En2Fvu8h8" resolve="cycleLength" />
+                </node>
+              </node>
+              <node concept="3clFbS" id="13En2Fvu8hv" role="3clFbx">
+                <node concept="3cpWs8" id="13En2Fvu8hw" role="3cqZAp">
+                  <node concept="3cpWsn" id="13En2Fvu8hx" role="3cpWs9">
+                    <property role="TrG5h" value="msg" />
+                    <node concept="17QB3L" id="13En2Fvu8hy" role="1tU5fm" />
+                    <node concept="3cpWs3" id="13En2Fvu8hz" role="33vP2m">
+                      <node concept="3cpWs3" id="13En2Fvu8h$" role="3uHU7B">
+                        <node concept="3cpWs3" id="13En2Fvu8h_" role="3uHU7B">
+                          <node concept="Xl_RD" id="13En2Fvu8hA" role="3uHU7B">
+                            <property role="Xl_RC" value="Cyclic dependency with length " />
+                          </node>
+                          <node concept="2OqwBi" id="13En2Fvu8hB" role="3uHU7w">
+                            <node concept="2GrUjf" id="13En2Fvu8hC" role="2Oq$k0">
+                              <ref role="2Gs0qQ" node="13En2Fvu8hm" resolve="crtCycle" />
+                            </node>
+                            <node concept="liA8E" id="13En2Fvu8hD" role="2OqNvi">
+                              <ref role="37wK5l" to="33ny:~ArrayList.size()" resolve="size" />
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="Xl_RD" id="13En2Fvu8hE" role="3uHU7w">
+                          <property role="Xl_RC" value=" found: " />
+                        </node>
+                      </node>
+                      <node concept="1rXfSq" id="13En2Fvu8hF" role="3uHU7w">
+                        <ref role="37wK5l" node="13En2FvvjOA" resolve="formatCycle" />
+                        <node concept="2GrUjf" id="13En2Fvu8hG" role="37wK5m">
+                          <ref role="2Gs0qQ" node="13En2Fvu8hm" resolve="crtCycle" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="3clFbF" id="13En2Fvu8hH" role="3cqZAp">
+                  <node concept="2OqwBi" id="13En2Fvu8hI" role="3clFbG">
+                    <node concept="37vLTw" id="13En2Fvu8hJ" role="2Oq$k0">
+                      <ref role="3cqZAo" node="13En2Fvu8h5" resolve="res" />
+                    </node>
+                    <node concept="TSZUe" id="13En2Fvu8hK" role="2OqNvi">
+                      <node concept="37vLTw" id="13En2Fvu8hL" role="25WWJ7">
+                        <ref role="3cqZAo" node="13En2Fvu8hx" resolve="msg" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3cqZAl" id="13En2Fvu8ha" role="3clF45" />
+      <node concept="37vLTG" id="13En2Fvu8h2" role="3clF46">
+        <property role="TrG5h" value="components" />
+        <node concept="_YKpA" id="13En2Fvu8h3" role="1tU5fm">
+          <node concept="16syzq" id="13En2Fvu8h4" role="_ZDj9">
+            <ref role="16sUi3" node="13En2Fv6yo$" resolve="Component" />
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="13En2Fvu8h5" role="3clF46">
+        <property role="TrG5h" value="res" />
+        <node concept="_YKpA" id="13En2Fvu8h6" role="1tU5fm">
+          <node concept="17QB3L" id="13En2Fvu8h7" role="_ZDj9" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="13En2Fvu8h8" role="3clF46">
+        <property role="TrG5h" value="cycleLength" />
+        <node concept="10Oyi0" id="13En2Fvu8h9" role="1tU5fm" />
+      </node>
+      <node concept="3Tm1VV" id="13En2Fvu8hN" role="1B3o_S" />
+    </node>
+    <node concept="2tJIrI" id="13En2Fv5usf" role="jymVt" />
+    <node concept="3clFb_" id="13En2FvuLfD" role="jymVt">
+      <property role="TrG5h" value="computeCyclesWithSize" />
+      <node concept="3clFbS" id="13En2FvuLfS" role="3clF47">
+        <node concept="3cpWs8" id="13En2FvuLfT" role="3cqZAp">
+          <node concept="3cpWsn" id="13En2FvuLfU" role="3cpWs9">
+            <property role="TrG5h" value="allCycles" />
+            <node concept="2hMVRd" id="13En2FvuLfV" role="1tU5fm">
+              <node concept="3uibUv" id="13En2FvuLfW" role="2hN53Y">
+                <ref role="3uigEE" to="33ny:~ArrayList" resolve="ArrayList" />
+                <node concept="16syzq" id="13En2FvE9ju" role="11_B2D">
+                  <ref role="16sUi3" node="13En2Fv6yo$" resolve="Component" />
+                </node>
+              </node>
+            </node>
+            <node concept="1rXfSq" id="13En2FvuLfY" role="33vP2m">
+              <ref role="37wK5l" node="13En2FvxEE9" resolve="computeAllCycles" />
+              <node concept="37vLTw" id="13En2FvuLfZ" role="37wK5m">
+                <ref role="3cqZAo" node="13En2FvuLfF" resolve="components" />
+              </node>
+              <node concept="37vLTw" id="13En2FvuLg1" role="37wK5m">
+                <ref role="3cqZAo" node="13En2FvuLfL" resolve="option" />
+              </node>
+              <node concept="37vLTw" id="13En2FvHDyx" role="37wK5m">
+                <ref role="3cqZAo" node="13En2FvuLfN" resolve="cycleLength" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="2Gpval" id="13En2FvuLg2" role="3cqZAp">
+          <node concept="2GrKxI" id="13En2FvuLg3" role="2Gsz3X">
+            <property role="TrG5h" value="crtCycle" />
+          </node>
+          <node concept="37vLTw" id="13En2FvuLg4" role="2GsD0m">
+            <ref role="3cqZAo" node="13En2FvuLfU" resolve="allCycles" />
+          </node>
+          <node concept="3clFbS" id="13En2FvuLg5" role="2LFqv$">
+            <node concept="3cpWs8" id="13En2FvuLg6" role="3cqZAp">
+              <node concept="3cpWsn" id="13En2FvuLg7" role="3cpWs9">
+                <property role="TrG5h" value="msg" />
+                <node concept="17QB3L" id="13En2FvuLg8" role="1tU5fm" />
+                <node concept="3cpWs3" id="13En2FvuLg9" role="33vP2m">
+                  <node concept="3cpWs3" id="13En2FvuLga" role="3uHU7B">
+                    <node concept="3cpWs3" id="13En2FvuLgb" role="3uHU7B">
+                      <node concept="Xl_RD" id="13En2FvuLgc" role="3uHU7B">
+                        <property role="Xl_RC" value="Cyclic dependency with length " />
+                      </node>
+                      <node concept="2OqwBi" id="13En2FvuLgd" role="3uHU7w">
+                        <node concept="2GrUjf" id="13En2FvuLge" role="2Oq$k0">
+                          <ref role="2Gs0qQ" node="13En2FvuLg3" resolve="crtCycle" />
+                        </node>
+                        <node concept="liA8E" id="13En2FvuLgf" role="2OqNvi">
+                          <ref role="37wK5l" to="33ny:~ArrayList.size()" resolve="size" />
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="Xl_RD" id="13En2FvuLgg" role="3uHU7w">
+                      <property role="Xl_RC" value=" found: " />
+                    </node>
+                  </node>
+                  <node concept="1rXfSq" id="13En2FvuLgh" role="3uHU7w">
+                    <ref role="37wK5l" node="13En2FvvjOA" resolve="formatCycle" />
+                    <node concept="2GrUjf" id="13En2FvuLgi" role="37wK5m">
+                      <ref role="2Gs0qQ" node="13En2FvuLg3" resolve="crtCycle" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbF" id="13En2FvuLgj" role="3cqZAp">
+              <node concept="2OqwBi" id="13En2FvuLgk" role="3clFbG">
+                <node concept="37vLTw" id="13En2FvuLgl" role="2Oq$k0">
+                  <ref role="3cqZAo" node="13En2FvuLfI" resolve="res" />
+                </node>
+                <node concept="TSZUe" id="13En2FvuLgm" role="2OqNvi">
+                  <node concept="37vLTw" id="13En2FvuLgn" role="25WWJ7">
+                    <ref role="3cqZAo" node="13En2FvuLg7" resolve="msg" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3cqZAl" id="13En2FvuLfR" role="3clF45" />
+      <node concept="37vLTG" id="13En2FvuLfF" role="3clF46">
+        <property role="TrG5h" value="components" />
+        <node concept="_YKpA" id="13En2FvuLfG" role="1tU5fm">
+          <node concept="16syzq" id="13En2FvuLfH" role="_ZDj9">
+            <ref role="16sUi3" node="13En2Fv6yo$" resolve="Component" />
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="13En2FvuLfI" role="3clF46">
+        <property role="TrG5h" value="res" />
+        <node concept="_YKpA" id="13En2FvuLfJ" role="1tU5fm">
+          <node concept="17QB3L" id="13En2FvuLfK" role="_ZDj9" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="13En2FvuLfL" role="3clF46">
+        <property role="TrG5h" value="option" />
+        <node concept="3uibUv" id="13En2FvGUpd" role="1tU5fm">
+          <ref role="3uigEE" node="13En2FvhV7b" resolve="CyclicGenericDependenciesHelper.Option" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="13En2FvuLfN" role="3clF46">
+        <property role="TrG5h" value="cycleLength" />
+        <node concept="10Oyi0" id="13En2FvuLfO" role="1tU5fm" />
+      </node>
+      <node concept="3Tm1VV" id="13En2FvuLgp" role="1B3o_S" />
+    </node>
+    <node concept="2tJIrI" id="13En2Fv5usW" role="jymVt" />
+    <node concept="3clFb_" id="13En2FvvjOA" role="jymVt">
+      <property role="TrG5h" value="formatCycle" />
+      <node concept="3clFbS" id="13En2FvvjOC" role="3clF47">
+        <node concept="3cpWs8" id="13En2FvvjOD" role="3cqZAp">
+          <node concept="3cpWsn" id="13En2FvvjOE" role="3cpWs9">
+            <property role="TrG5h" value="firstComponent" />
+            <node concept="10Oyi0" id="13En2FvvjOF" role="1tU5fm" />
+            <node concept="3cmrfG" id="13En2FvvjOG" role="33vP2m">
+              <property role="3cmrfH" value="0" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="13En2FvvjOH" role="3cqZAp" />
+        <node concept="1Dw8fO" id="13En2FvvjOI" role="3cqZAp">
+          <node concept="3clFbS" id="13En2FvvjOJ" role="2LFqv$">
+            <node concept="3clFbJ" id="13En2FvvjOK" role="3cqZAp">
+              <node concept="3clFbS" id="13En2FvvjOL" role="3clFbx">
+                <node concept="3clFbF" id="13En2FvvjOM" role="3cqZAp">
+                  <node concept="37vLTI" id="13En2FvvjON" role="3clFbG">
+                    <node concept="37vLTw" id="13En2FvvjOO" role="37vLTx">
+                      <ref role="3cqZAo" node="13En2FvvjP3" resolve="i" />
+                    </node>
+                    <node concept="37vLTw" id="13En2FvvjOP" role="37vLTJ">
+                      <ref role="3cqZAo" node="13En2FvvjOE" resolve="firstComponent" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3eOSWO" id="13En2FvvjOQ" role="3clFbw">
+                <node concept="3cmrfG" id="13En2FvvjOR" role="3uHU7w">
+                  <property role="3cmrfH" value="0" />
+                </node>
+                <node concept="2OqwBi" id="13En2FvvjOS" role="3uHU7B">
+                  <node concept="37vLTw" id="13En2FvvjOT" role="2Oq$k0">
+                    <ref role="3cqZAo" node="13En2FvvVYi" resolve="componentComparator" />
+                  </node>
+                  <node concept="liA8E" id="13En2FvvjOU" role="2OqNvi">
+                    <ref role="37wK5l" to="33ny:~Comparator.compare(java.lang.Object,java.lang.Object)" resolve="compare" />
+                    <node concept="2OqwBi" id="13En2FvvjOV" role="37wK5m">
+                      <node concept="37vLTw" id="13En2FvvjOW" role="2Oq$k0">
+                        <ref role="3cqZAo" node="13En2FvvjPS" resolve="cycle" />
+                      </node>
+                      <node concept="liA8E" id="13En2FvvjOX" role="2OqNvi">
+                        <ref role="37wK5l" to="33ny:~ArrayList.get(int)" resolve="get" />
+                        <node concept="37vLTw" id="13En2FvvjOY" role="37wK5m">
+                          <ref role="3cqZAo" node="13En2FvvjOE" resolve="firstComponent" />
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="2OqwBi" id="13En2FvvjOZ" role="37wK5m">
+                      <node concept="37vLTw" id="13En2FvvjP0" role="2Oq$k0">
+                        <ref role="3cqZAo" node="13En2FvvjPS" resolve="cycle" />
+                      </node>
+                      <node concept="liA8E" id="13En2FvvjP1" role="2OqNvi">
+                        <ref role="37wK5l" to="33ny:~ArrayList.get(int)" resolve="get" />
+                        <node concept="37vLTw" id="13En2FvvjP2" role="37wK5m">
+                          <ref role="3cqZAo" node="13En2FvvjP3" resolve="i" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3cpWsn" id="13En2FvvjP3" role="1Duv9x">
+            <property role="TrG5h" value="i" />
+            <node concept="10Oyi0" id="13En2FvvjP4" role="1tU5fm" />
+            <node concept="3cmrfG" id="13En2FvvjP5" role="33vP2m">
+              <property role="3cmrfH" value="1" />
+            </node>
+          </node>
+          <node concept="3eOVzh" id="13En2FvvjP6" role="1Dwp0S">
+            <node concept="2OqwBi" id="13En2FvvjP7" role="3uHU7w">
+              <node concept="37vLTw" id="13En2FvvjP8" role="2Oq$k0">
+                <ref role="3cqZAo" node="13En2FvvjPS" resolve="cycle" />
+              </node>
+              <node concept="liA8E" id="13En2FvvjP9" role="2OqNvi">
+                <ref role="37wK5l" to="33ny:~ArrayList.size()" resolve="size" />
+              </node>
+            </node>
+            <node concept="37vLTw" id="13En2FvvjPa" role="3uHU7B">
+              <ref role="3cqZAo" node="13En2FvvjP3" resolve="i" />
+            </node>
+          </node>
+          <node concept="3uNrnE" id="13En2FvvjPb" role="1Dwrff">
+            <node concept="37vLTw" id="13En2FvvjPc" role="2$L3a6">
+              <ref role="3cqZAo" node="13En2FvvjP3" resolve="i" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="13En2FvvjPd" role="3cqZAp" />
+        <node concept="3cpWs8" id="13En2FvvjPe" role="3cqZAp">
+          <node concept="3cpWsn" id="13En2FvvjPf" role="3cpWs9">
+            <property role="TrG5h" value="firstAndAfter" />
+            <property role="3TUv4t" value="true" />
+            <node concept="A3Dl8" id="13En2FvvjPg" role="1tU5fm">
+              <node concept="16syzq" id="13En2FvvjPh" role="A3Ik2">
+                <ref role="16sUi3" node="13En2Fv6yo$" resolve="Component" />
+              </node>
+            </node>
+            <node concept="2OqwBi" id="13En2FvvjPi" role="33vP2m">
+              <node concept="37vLTw" id="13En2FvvjPj" role="2Oq$k0">
+                <ref role="3cqZAo" node="13En2FvvjPS" resolve="cycle" />
+              </node>
+              <node concept="liA8E" id="13En2FvvjPk" role="2OqNvi">
+                <ref role="37wK5l" to="33ny:~ArrayList.subList(int,int)" resolve="subList" />
+                <node concept="37vLTw" id="13En2FvvjPl" role="37wK5m">
+                  <ref role="3cqZAo" node="13En2FvvjOE" resolve="firstComponent" />
+                </node>
+                <node concept="2OqwBi" id="13En2FvvjPm" role="37wK5m">
+                  <node concept="37vLTw" id="13En2FvvjPn" role="2Oq$k0">
+                    <ref role="3cqZAo" node="13En2FvvjPS" resolve="cycle" />
+                  </node>
+                  <node concept="liA8E" id="13En2FvvjPo" role="2OqNvi">
+                    <ref role="37wK5l" to="33ny:~ArrayList.size()" resolve="size" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="13En2FvvjPp" role="3cqZAp">
+          <node concept="3cpWsn" id="13En2FvvjPq" role="3cpWs9">
+            <property role="TrG5h" value="beforeFirst" />
+            <property role="3TUv4t" value="true" />
+            <node concept="A3Dl8" id="13En2FvvjPr" role="1tU5fm">
+              <node concept="16syzq" id="13En2FvvjPs" role="A3Ik2">
+                <ref role="16sUi3" node="13En2Fv6yo$" resolve="Component" />
+              </node>
+            </node>
+            <node concept="2OqwBi" id="13En2FvvjPt" role="33vP2m">
+              <node concept="37vLTw" id="13En2FvvjPu" role="2Oq$k0">
+                <ref role="3cqZAo" node="13En2FvvjPS" resolve="cycle" />
+              </node>
+              <node concept="liA8E" id="13En2FvvjPv" role="2OqNvi">
+                <ref role="37wK5l" to="33ny:~ArrayList.subList(int,int)" resolve="subList" />
+                <node concept="3cmrfG" id="13En2FvvjPw" role="37wK5m">
+                  <property role="3cmrfH" value="0" />
+                </node>
+                <node concept="37vLTw" id="13En2FvvjPx" role="37wK5m">
+                  <ref role="3cqZAo" node="13En2FvvjOE" resolve="firstComponent" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="13En2FvvjPy" role="3cqZAp" />
+        <node concept="3cpWs6" id="13En2FvvjPz" role="3cqZAp">
+          <node concept="2OqwBi" id="13En2FvvjP$" role="3cqZAk">
+            <node concept="2OqwBi" id="13En2FvvjP_" role="2Oq$k0">
+              <node concept="1eOMI4" id="13En2FvvjPA" role="2Oq$k0">
+                <node concept="2OqwBi" id="13En2FvvjPB" role="1eOMHV">
+                  <node concept="37vLTw" id="13En2FvvjPC" role="2Oq$k0">
+                    <ref role="3cqZAo" node="13En2FvvjPf" resolve="firstAndAfter" />
+                  </node>
+                  <node concept="3QWeyG" id="13En2FvvjPD" role="2OqNvi">
+                    <node concept="37vLTw" id="13En2FvvjPE" role="576Qk">
+                      <ref role="3cqZAo" node="13En2FvvjPq" resolve="beforeFirst" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3$u5V9" id="13En2FvvjPF" role="2OqNvi">
+                <node concept="1bVj0M" id="13En2FvvjPG" role="23t8la">
+                  <node concept="3clFbS" id="13En2FvvjPH" role="1bW5cS">
+                    <node concept="3clFbF" id="13En2FvvjPI" role="3cqZAp">
+                      <node concept="2OqwBi" id="13En2FvvjPJ" role="3clFbG">
+                        <node concept="37vLTw" id="13En2FvvjPK" role="2Oq$k0">
+                          <ref role="3cqZAo" node="13En2FvvjPM" resolve="it" />
+                        </node>
+                        <node concept="liA8E" id="13En2FvvjPL" role="2OqNvi">
+                          <ref role="37wK5l" to="wyt6:~Object.toString()" resolve="toString" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="gl6BB" id="13En2FvvjPM" role="1bW2Oz">
+                    <property role="TrG5h" value="it" />
+                    <node concept="2jxLKc" id="13En2FvvjPN" role="1tU5fm" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3uJxvA" id="13En2FvvjPO" role="2OqNvi">
+              <node concept="Xl_RD" id="13En2FvvjPP" role="3uJOhx">
+                <property role="Xl_RC" value=", " />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="17QB3L" id="13En2FvvjPR" role="3clF45" />
+      <node concept="37vLTG" id="13En2FvvjPS" role="3clF46">
+        <property role="TrG5h" value="cycle" />
+        <node concept="3uibUv" id="13En2FvvjPT" role="1tU5fm">
+          <ref role="3uigEE" to="33ny:~ArrayList" resolve="ArrayList" />
+          <node concept="16syzq" id="13En2FvvjPU" role="11_B2D">
+            <ref role="16sUi3" node="13En2Fv6yo$" resolve="Component" />
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm6S6" id="13En2FvvjPQ" role="1B3o_S" />
+      <node concept="P$JXv" id="13En2FvvjQf" role="lGtFl">
+        <node concept="TZ5HA" id="13En2FvvjQg" role="TZ5H$">
+          <node concept="1dT_AC" id="13En2FvvjQh" role="1dT_Ay">
+            <property role="1dT_AB" value="Format " />
+          </node>
+          <node concept="1dT_AA" id="13En2FvvjQi" role="1dT_Ay">
+            <node concept="VVOAv" id="13En2FvvjQj" role="qph3F">
+              <node concept="TZ5HA" id="13En2FvvjQk" role="2Xj1qM">
+                <node concept="1dT_AC" id="13En2FvvjQl" role="1dT_Ay">
+                  <property role="1dT_AB" value="cycle" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="1dT_AC" id="13En2FvvjQm" role="1dT_Ay">
+            <property role="1dT_AB" value=" deterministically." />
+          </node>
+        </node>
+        <node concept="TZ5HA" id="13En2FvvjQn" role="TZ5H$">
+          <node concept="1dT_AC" id="13En2FvvjQo" role="1dT_Ay">
+            <property role="1dT_AB" value="" />
+          </node>
+        </node>
+        <node concept="TZ5HA" id="13En2FvvjQp" role="TZ5H$">
+          <node concept="1dT_AC" id="13En2FvvjQq" role="1dT_Ay">
+            <property role="1dT_AB" value="Determinism is implemented by starting from the component whose reference comes first in alphabetical order." />
+          </node>
+        </node>
+        <node concept="TUZQ0" id="13En2FvvjQr" role="3nqlJM">
+          <property role="TUZQ4" value="cycle to format" />
+          <node concept="zr_55" id="13En2FvvjQs" role="zr_5Q">
+            <ref role="zr_51" node="13En2FvvjPS" resolve="cycle" />
+          </node>
+        </node>
+        <node concept="x79VA" id="13En2FvvjQt" role="3nqlJM">
+          <property role="x79VB" value="cycle deterministically formatted as text" />
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="13En2Fv5uv6" role="jymVt" />
+    <node concept="3clFb_" id="13En2FvxEE9" role="jymVt">
+      <property role="TrG5h" value="computeAllCycles" />
+      <node concept="3clFbS" id="13En2FvxEEb" role="3clF47">
+        <node concept="3cpWs8" id="13En2FvxEEc" role="3cqZAp">
+          <node concept="3cpWsn" id="13En2FvxEEd" role="3cpWs9">
+            <property role="TrG5h" value="component2DirectDependencies" />
+            <node concept="3rvAFt" id="13En2FvxEEe" role="1tU5fm">
+              <node concept="16syzq" id="13En2FvxEEf" role="3rvQeY">
+                <ref role="16sUi3" node="13En2Fv6yo$" resolve="Component" />
+              </node>
+              <node concept="2hMVRd" id="13En2FvxEEg" role="3rvSg0">
+                <node concept="16syzq" id="13En2FvxEEh" role="2hN53Y">
+                  <ref role="16sUi3" node="13En2Fv6yo$" resolve="Component" />
+                </node>
+              </node>
+            </node>
+            <node concept="1rXfSq" id="13En2FvD4bV" role="33vP2m">
+              <ref role="37wK5l" node="13En2FvyssI" resolve="computeDirectComponentDependencies" />
+              <node concept="37vLTw" id="13En2FvDdfF" role="37wK5m">
+                <ref role="3cqZAo" node="13En2FvxEFK" resolve="components" />
+              </node>
+              <node concept="37vLTw" id="13En2FvGaLn" role="37wK5m">
+                <ref role="3cqZAo" node="13En2FvFAy4" resolve="option" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="13En2FvxEEm" role="3cqZAp">
+          <node concept="3cpWsn" id="13En2FvxEEn" role="3cpWs9">
+            <property role="TrG5h" value="component2IndirectDependencies" />
+            <node concept="3rvAFt" id="13En2FvxEEo" role="1tU5fm">
+              <node concept="16syzq" id="13En2FvxEEp" role="3rvQeY">
+                <ref role="16sUi3" node="13En2Fv6yo$" resolve="Component" />
+              </node>
+              <node concept="2hMVRd" id="13En2FvxEEq" role="3rvSg0">
+                <node concept="16syzq" id="13En2FvxEEr" role="2hN53Y">
+                  <ref role="16sUi3" node="13En2Fv6yo$" resolve="Component" />
+                </node>
+              </node>
+            </node>
+            <node concept="1rXfSq" id="13En2FvxEEs" role="33vP2m">
+              <ref role="37wK5l" node="13En2FvA768" resolve="computeIndirectDependencies" />
+              <node concept="37vLTw" id="13En2FvxEEt" role="37wK5m">
+                <ref role="3cqZAo" node="13En2FvxEEd" resolve="component2DirectDependencies" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="13En2FvxEEu" role="3cqZAp" />
+        <node concept="3cpWs8" id="13En2FvxEEv" role="3cqZAp">
+          <node concept="3cpWsn" id="13En2FvxEEw" role="3cpWs9">
+            <property role="TrG5h" value="allCycles" />
+            <node concept="2hMVRd" id="13En2FvxEEx" role="1tU5fm">
+              <node concept="3uibUv" id="13En2FvxEEy" role="2hN53Y">
+                <ref role="3uigEE" to="33ny:~ArrayList" resolve="ArrayList" />
+                <node concept="16syzq" id="13En2FvxEEz" role="11_B2D">
+                  <ref role="16sUi3" node="13En2Fv6yo$" resolve="Component" />
+                </node>
+              </node>
+            </node>
+            <node concept="2ShNRf" id="13En2FvxEE$" role="33vP2m">
+              <node concept="2i4dXS" id="13En2FvxEE_" role="2ShVmc">
+                <node concept="3uibUv" id="13En2FvxEEA" role="HW$YZ">
+                  <ref role="3uigEE" to="33ny:~ArrayList" resolve="ArrayList" />
+                  <node concept="16syzq" id="13En2FvxEEB" role="11_B2D">
+                    <ref role="16sUi3" node="13En2Fv6yo$" resolve="Component" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="13En2FvxEEC" role="3cqZAp">
+          <node concept="3cpWsn" id="13En2FvxEED" role="3cpWs9">
+            <property role="TrG5h" value="componentsForWhichAllCyclesHaveBeenFound" />
+            <node concept="2hMVRd" id="13En2FvxEEE" role="1tU5fm">
+              <node concept="16syzq" id="13En2FvxEEF" role="2hN53Y">
+                <ref role="16sUi3" node="13En2Fv6yo$" resolve="Component" />
+              </node>
+            </node>
+            <node concept="2ShNRf" id="13En2FvxEEG" role="33vP2m">
+              <node concept="2i4dXS" id="13En2FvxEEH" role="2ShVmc">
+                <node concept="16syzq" id="13En2FvxEEI" role="HW$YZ">
+                  <ref role="16sUi3" node="13En2Fv6yo$" resolve="Component" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="2Gpval" id="13En2FvxEEJ" role="3cqZAp">
+          <node concept="2GrKxI" id="13En2FvxEEK" role="2Gsz3X">
+            <property role="TrG5h" value="component" />
+          </node>
+          <node concept="2OqwBi" id="13En2FvxEEL" role="2GsD0m">
+            <node concept="37vLTw" id="13En2FvxEEM" role="2Oq$k0">
+              <ref role="3cqZAo" node="13En2FvxEEd" resolve="component2DirectDependencies" />
+            </node>
+            <node concept="3lbrtF" id="13En2FvxEEN" role="2OqNvi" />
+          </node>
+          <node concept="3clFbS" id="13En2FvxEEO" role="2LFqv$">
+            <node concept="3clFbJ" id="13En2FvxEEP" role="3cqZAp">
+              <node concept="3clFbS" id="13En2FvxEEQ" role="3clFbx">
+                <node concept="3SKdUt" id="13En2FvxEER" role="3cqZAp">
+                  <node concept="1PaTwC" id="13En2FvxEES" role="1aUNEU">
+                    <node concept="3oM_SD" id="13En2FvxEET" role="1PaTwD">
+                      <property role="3oM_SC" value="this" />
+                    </node>
+                    <node concept="3oM_SD" id="13En2FvxEEU" role="1PaTwD">
+                      <property role="3oM_SC" value="component" />
+                    </node>
+                    <node concept="3oM_SD" id="13En2FvxEEV" role="1PaTwD">
+                      <property role="3oM_SC" value="depends" />
+                    </node>
+                    <node concept="3oM_SD" id="13En2FvxEEW" role="1PaTwD">
+                      <property role="3oM_SC" value="on" />
+                    </node>
+                    <node concept="3oM_SD" id="13En2FvxEEX" role="1PaTwD">
+                      <property role="3oM_SC" value="itself" />
+                    </node>
+                    <node concept="3oM_SD" id="13En2FvxEEY" role="1PaTwD">
+                      <property role="3oM_SC" value="indirectly," />
+                    </node>
+                    <node concept="3oM_SD" id="13En2FvxEEZ" role="1PaTwD">
+                      <property role="3oM_SC" value="so" />
+                    </node>
+                    <node concept="3oM_SD" id="13En2FvxEF0" role="1PaTwD">
+                      <property role="3oM_SC" value="it" />
+                    </node>
+                    <node concept="3oM_SD" id="13En2FvxEF1" role="1PaTwD">
+                      <property role="3oM_SC" value="is" />
+                    </node>
+                    <node concept="3oM_SD" id="13En2FvxEF2" role="1PaTwD">
+                      <property role="3oM_SC" value="involved" />
+                    </node>
+                    <node concept="3oM_SD" id="13En2FvxEF3" role="1PaTwD">
+                      <property role="3oM_SC" value="at" />
+                    </node>
+                    <node concept="3oM_SD" id="13En2FvxEF4" role="1PaTwD">
+                      <property role="3oM_SC" value="least" />
+                    </node>
+                    <node concept="3oM_SD" id="13En2FvxEF5" role="1PaTwD">
+                      <property role="3oM_SC" value="in" />
+                    </node>
+                    <node concept="3oM_SD" id="13En2FvxEF6" role="1PaTwD">
+                      <property role="3oM_SC" value="one" />
+                    </node>
+                    <node concept="3oM_SD" id="13En2FvxEF7" role="1PaTwD">
+                      <property role="3oM_SC" value="cycle" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="3cpWs8" id="13En2FvxEF8" role="3cqZAp">
+                  <node concept="3cpWsn" id="13En2FvxEF9" role="3cpWs9">
+                    <property role="TrG5h" value="crtPath" />
+                    <node concept="2ShNRf" id="13En2FvxEFa" role="33vP2m">
+                      <node concept="Tc6Ow" id="13En2FvxEFb" role="2ShVmc">
+                        <node concept="16syzq" id="13En2FvxEFc" role="HW$YZ">
+                          <ref role="16sUi3" node="13En2Fv6yo$" resolve="Component" />
+                        </node>
+                        <node concept="2GrUjf" id="13En2FvxEFd" role="HW$Y0">
+                          <ref role="2Gs0qQ" node="13En2FvxEEK" resolve="component" />
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="_YKpA" id="13En2FvxEFe" role="1tU5fm">
+                      <node concept="16syzq" id="13En2FvxEFf" role="_ZDj9">
+                        <ref role="16sUi3" node="13En2Fv6yo$" resolve="Component" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="3cpWs8" id="13En2FvxEFg" role="3cqZAp">
+                  <node concept="3cpWsn" id="13En2FvxEFh" role="3cpWs9">
+                    <property role="TrG5h" value="alreadyVisited" />
+                    <node concept="2hMVRd" id="13En2FvxEFi" role="1tU5fm">
+                      <node concept="16syzq" id="13En2FvxEFj" role="2hN53Y">
+                        <ref role="16sUi3" node="13En2Fv6yo$" resolve="Component" />
+                      </node>
+                    </node>
+                    <node concept="2ShNRf" id="13En2FvxEFk" role="33vP2m">
+                      <node concept="2i4dXS" id="13En2FvxEFl" role="2ShVmc">
+                        <node concept="16syzq" id="13En2FvxEFm" role="HW$YZ">
+                          <ref role="16sUi3" node="13En2Fv6yo$" resolve="Component" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="3clFbF" id="13En2FvBbU3" role="3cqZAp">
+                  <node concept="1rXfSq" id="13En2FvBbU1" role="3clFbG">
+                    <ref role="37wK5l" node="13En2FvzOPz" resolve="computeTransitiveClosure" />
+                    <node concept="37vLTw" id="13En2FvBkxI" role="37wK5m">
+                      <ref role="3cqZAo" node="13En2FvxEEd" resolve="component2DirectDependencies" />
+                    </node>
+                    <node concept="37vLTw" id="13En2FvBvW2" role="37wK5m">
+                      <ref role="3cqZAo" node="13En2FvxEEn" resolve="component2IndirectDependencies" />
+                    </node>
+                    <node concept="2GrUjf" id="13En2FvBBLh" role="37wK5m">
+                      <ref role="2Gs0qQ" node="13En2FvxEEK" resolve="component" />
+                    </node>
+                    <node concept="2GrUjf" id="13En2FvBO3l" role="37wK5m">
+                      <ref role="2Gs0qQ" node="13En2FvxEEK" resolve="component" />
+                    </node>
+                    <node concept="37vLTw" id="13En2FvBVTm" role="37wK5m">
+                      <ref role="3cqZAo" node="13En2FvxEF9" resolve="crtPath" />
+                    </node>
+                    <node concept="37vLTw" id="13En2FvCcwR" role="37wK5m">
+                      <ref role="3cqZAo" node="13En2FvxEFh" resolve="alreadyVisited" />
+                    </node>
+                    <node concept="37vLTw" id="13En2FvCsKX" role="37wK5m">
+                      <ref role="3cqZAo" node="13En2FvxEED" resolve="modulesForWhichAllCyclesHaveBeenFound" />
+                    </node>
+                    <node concept="37vLTw" id="13En2FvC_p$" role="37wK5m">
+                      <ref role="3cqZAo" node="13En2FvxEEw" resolve="allCycles" />
+                    </node>
+                    <node concept="37vLTw" id="13En2FvCP18" role="37wK5m">
+                      <ref role="3cqZAo" node="13En2FvxEFS" resolve="cycleSize" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="2OqwBi" id="13En2FvxEFy" role="3clFbw">
+                <node concept="3EllGN" id="13En2FvxEFz" role="2Oq$k0">
+                  <node concept="2GrUjf" id="13En2FvxEF$" role="3ElVtu">
+                    <ref role="2Gs0qQ" node="13En2FvxEEK" resolve="component" />
+                  </node>
+                  <node concept="37vLTw" id="13En2FvxEF_" role="3ElQJh">
+                    <ref role="3cqZAo" node="13En2FvxEEn" resolve="component2IndirectDependencies" />
+                  </node>
+                </node>
+                <node concept="3JPx81" id="13En2FvxEFA" role="2OqNvi">
+                  <node concept="2GrUjf" id="13En2FvxEFB" role="25WWJ7">
+                    <ref role="2Gs0qQ" node="13En2FvxEEK" resolve="component" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbF" id="13En2FvxEFC" role="3cqZAp">
+              <node concept="2OqwBi" id="13En2FvxEFD" role="3clFbG">
+                <node concept="37vLTw" id="13En2FvxEFE" role="2Oq$k0">
+                  <ref role="3cqZAo" node="13En2FvxEED" resolve="modulesForWhichAllCyclesHaveBeenFound" />
+                </node>
+                <node concept="TSZUe" id="13En2FvxEFF" role="2OqNvi">
+                  <node concept="2GrUjf" id="13En2FvxEFG" role="25WWJ7">
+                    <ref role="2Gs0qQ" node="13En2FvxEEK" resolve="component" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="13En2FvxEFH" role="3cqZAp" />
+        <node concept="3cpWs6" id="13En2FvxEFI" role="3cqZAp">
+          <node concept="37vLTw" id="13En2FvxEFJ" role="3cqZAk">
+            <ref role="3cqZAo" node="13En2FvxEEw" resolve="allCycles" />
+          </node>
+        </node>
+      </node>
+      <node concept="2hMVRd" id="13En2FvxEFN" role="3clF45">
+        <node concept="3uibUv" id="13En2FvxEFO" role="2hN53Y">
+          <ref role="3uigEE" to="33ny:~ArrayList" resolve="ArrayList" />
+          <node concept="16syzq" id="13En2FvxEFP" role="11_B2D">
+            <ref role="16sUi3" node="13En2Fv6yo$" resolve="Component" />
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="13En2FvxEFK" role="3clF46">
+        <property role="TrG5h" value="components" />
+        <node concept="_YKpA" id="13En2FvxEFL" role="1tU5fm">
+          <node concept="16syzq" id="13En2FvxEFM" role="_ZDj9">
+            <ref role="16sUi3" node="13En2Fv6yo$" resolve="Component" />
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="13En2FvFAy4" role="3clF46">
+        <property role="TrG5h" value="option" />
+        <node concept="3uibUv" id="13En2FvFJev" role="1tU5fm">
+          <ref role="3uigEE" node="13En2FvhV7b" resolve="CyclicGenericDependenciesHelper.Option" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="13En2FvxEFS" role="3clF46">
+        <property role="TrG5h" value="cycleSize" />
+        <node concept="10Oyi0" id="13En2FvxEFT" role="1tU5fm" />
+      </node>
+      <node concept="3Tm1VV" id="13En2FvxEFU" role="1B3o_S" />
+    </node>
+    <node concept="2tJIrI" id="13En2Fv5uwR" role="jymVt" />
+    <node concept="3clFb_" id="13En2FvyssI" role="jymVt">
+      <property role="TrG5h" value="computeDirectComponentDependencies" />
+      <node concept="3clFbS" id="13En2FvyssR" role="3clF47">
+        <node concept="3cpWs8" id="13En2FvyssS" role="3cqZAp">
+          <node concept="3cpWsn" id="13En2FvyssT" role="3cpWs9">
+            <property role="TrG5h" value="component2DirectDependencies" />
+            <node concept="3rvAFt" id="13En2FvyssU" role="1tU5fm">
+              <node concept="16syzq" id="13En2FvyssV" role="3rvQeY">
+                <ref role="16sUi3" node="13En2Fv6yo$" resolve="Component" />
+              </node>
+              <node concept="2hMVRd" id="13En2FvyssW" role="3rvSg0">
+                <node concept="16syzq" id="13En2FvyssX" role="2hN53Y">
+                  <ref role="16sUi3" node="13En2Fv6yo$" resolve="Component" />
+                </node>
+              </node>
+            </node>
+            <node concept="2ShNRf" id="13En2FvyssY" role="33vP2m">
+              <node concept="3rGOSV" id="13En2FvyssZ" role="2ShVmc">
+                <node concept="16syzq" id="13En2Fvyst0" role="3rHrn6">
+                  <ref role="16sUi3" node="13En2Fv6yo$" resolve="Component" />
+                </node>
+                <node concept="2hMVRd" id="13En2Fvyst1" role="3rHtpV">
+                  <node concept="16syzq" id="13En2Fvyst2" role="2hN53Y">
+                    <ref role="16sUi3" node="13En2Fv6yo$" resolve="Component" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="2Gpval" id="13En2Fvyst3" role="3cqZAp">
+          <node concept="2GrKxI" id="13En2Fvyst4" role="2Gsz3X">
+            <property role="TrG5h" value="component" />
+          </node>
+          <node concept="37vLTw" id="13En2Fvyst5" role="2GsD0m">
+            <ref role="3cqZAo" node="13En2FvyssO" resolve="components" />
+          </node>
+          <node concept="3clFbS" id="13En2Fvyst6" role="2LFqv$">
+            <node concept="3cpWs8" id="13En2Fvyst7" role="3cqZAp">
+              <node concept="3cpWsn" id="13En2Fvyst8" role="3cpWs9">
+                <property role="TrG5h" value="currentDependencies" />
+                <node concept="2hMVRd" id="13En2Fvyst9" role="1tU5fm">
+                  <node concept="16syzq" id="13En2Fvysta" role="2hN53Y">
+                    <ref role="16sUi3" node="13En2Fv6yo$" resolve="Component" />
+                  </node>
+                </node>
+                <node concept="2ShNRf" id="13En2Fvystb" role="33vP2m">
+                  <node concept="2i4dXS" id="13En2Fvystc" role="2ShVmc">
+                    <node concept="16syzq" id="13En2Fvystd" role="HW$YZ">
+                      <ref role="16sUi3" node="13En2Fv6yo$" resolve="Component" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbF" id="13En2Fvyste" role="3cqZAp">
+              <node concept="2OqwBi" id="13En2Fvystf" role="3clFbG">
+                <node concept="37vLTw" id="13En2Fvystg" role="2Oq$k0">
+                  <ref role="3cqZAo" node="13En2Fvyst8" resolve="currentDependencies" />
+                </node>
+                <node concept="X8dFx" id="13En2Fvysth" role="2OqNvi">
+                  <node concept="2Sg_IR" id="13En2Fvysti" role="25WWJ7">
+                    <node concept="37vLTw" id="13En2Fvystj" role="2SgG2M">
+                      <ref role="3cqZAo" node="13En2FvqIXu" resolve="dependencyResolver" />
+                    </node>
+                    <node concept="37vLTw" id="13En2Fw2siP" role="2SgHGx">
+                      <ref role="3cqZAo" node="13En2FvyssO" resolve="components" />
+                    </node>
+                    <node concept="2GrUjf" id="13En2Fvystk" role="2SgHGx">
+                      <ref role="2Gs0qQ" node="13En2Fvyst4" resolve="component" />
+                    </node>
+                    <node concept="37vLTw" id="13En2FvGpci" role="2SgHGx">
+                      <ref role="3cqZAo" node="13En2FvEi6z" resolve="option" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbH" id="13En2Fvystl" role="3cqZAp" />
+            <node concept="3clFbF" id="13En2Fvystm" role="3cqZAp">
+              <node concept="37vLTI" id="13En2Fvystn" role="3clFbG">
+                <node concept="37vLTw" id="13En2Fvysto" role="37vLTx">
+                  <ref role="3cqZAo" node="13En2Fvyst8" resolve="currentDependencies" />
+                </node>
+                <node concept="3EllGN" id="13En2Fvystp" role="37vLTJ">
+                  <node concept="2GrUjf" id="13En2Fvystq" role="3ElVtu">
+                    <ref role="2Gs0qQ" node="13En2Fvyst4" resolve="component" />
+                  </node>
+                  <node concept="37vLTw" id="13En2Fvystr" role="3ElQJh">
+                    <ref role="3cqZAo" node="13En2FvyssT" resolve="component2DirectDependencies" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs6" id="13En2Fvysts" role="3cqZAp">
+          <node concept="37vLTw" id="13En2Fvystt" role="3cqZAk">
+            <ref role="3cqZAo" node="13En2FvyssT" resolve="component2DirectDependencies" />
+          </node>
+        </node>
+      </node>
+      <node concept="3rvAFt" id="13En2FvyssK" role="3clF45">
+        <node concept="16syzq" id="13En2FvyssL" role="3rvQeY">
+          <ref role="16sUi3" node="13En2Fv6yo$" resolve="Component" />
+        </node>
+        <node concept="2hMVRd" id="13En2FvyssM" role="3rvSg0">
+          <node concept="16syzq" id="13En2FvyssN" role="2hN53Y">
+            <ref role="16sUi3" node="13En2Fv6yo$" resolve="Component" />
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="13En2FvyssO" role="3clF46">
+        <property role="TrG5h" value="components" />
+        <node concept="_YKpA" id="13En2FvyssP" role="1tU5fm">
+          <node concept="16syzq" id="13En2FvyssQ" role="_ZDj9">
+            <ref role="16sUi3" node="13En2Fv6yo$" resolve="Component" />
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="13En2FvEi6z" role="3clF46">
+        <property role="TrG5h" value="option" />
+        <node concept="3uibUv" id="13En2FvEpgy" role="1tU5fm">
+          <ref role="3uigEE" node="13En2FvhV7b" resolve="CyclicGenericDependenciesHelper.Option" />
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="13En2Fv5uys" role="jymVt" />
+    <node concept="3clFb_" id="13En2FvzOPz" role="jymVt">
+      <property role="TrG5h" value="computeTransitiveClosure" />
+      <node concept="3clFbS" id="13En2FvzOQ0" role="3clF47">
+        <node concept="3cpWs8" id="13En2FvzOQ1" role="3cqZAp">
+          <node concept="3cpWsn" id="13En2FvzOQ2" role="3cpWs9">
+            <property role="TrG5h" value="myDependencies" />
+            <node concept="2hMVRd" id="13En2FvzOQ3" role="1tU5fm">
+              <node concept="16syzq" id="13En2FvzOQ4" role="2hN53Y">
+                <ref role="16sUi3" node="13En2FvzOSd" resolve="Component" />
+              </node>
+            </node>
+            <node concept="3EllGN" id="13En2FvzOQ5" role="33vP2m">
+              <node concept="37vLTw" id="13En2FvzOQ6" role="3ElQJh">
+                <ref role="3cqZAo" node="13En2FvzOP_" resolve="component2Dependencies" />
+              </node>
+              <node concept="37vLTw" id="13En2FvzOQ7" role="3ElVtu">
+                <ref role="3cqZAo" node="13En2FvzOPL" resolve="crtComponent" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="13En2FvzOQ8" role="3cqZAp" />
+        <node concept="3clFbJ" id="13En2FvzOQ9" role="3cqZAp">
+          <node concept="3clFbS" id="13En2FvzOQa" role="3clFbx">
+            <node concept="3cpWs6" id="13En2FvzOQb" role="3cqZAp" />
+          </node>
+          <node concept="3clFbC" id="13En2FvzOQc" role="3clFbw">
+            <node concept="2OqwBi" id="13En2FvzOQd" role="3uHU7B">
+              <node concept="37vLTw" id="13En2FvzOQe" role="2Oq$k0">
+                <ref role="3cqZAo" node="13En2FvzOPN" resolve="crtPath" />
+              </node>
+              <node concept="34oBXx" id="13En2FvzOQf" role="2OqNvi" />
+            </node>
+            <node concept="3cpWs3" id="13En2FvzOQg" role="3uHU7w">
+              <node concept="3cmrfG" id="13En2FvzOQh" role="3uHU7w">
+                <property role="3cmrfH" value="1" />
+              </node>
+              <node concept="37vLTw" id="13En2FvzOQi" role="3uHU7B">
+                <ref role="3cqZAo" node="13En2FvzOS6" resolve="cycleSize" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="13En2FvzOQj" role="3cqZAp" />
+        <node concept="1DcWWT" id="13En2FvzOQk" role="3cqZAp">
+          <node concept="3clFbS" id="13En2FvzOQl" role="2LFqv$">
+            <node concept="3clFbJ" id="13En2FvzOQm" role="3cqZAp">
+              <node concept="3clFbS" id="13En2FvzOQn" role="3clFbx">
+                <node concept="3N13vt" id="13En2FvzOQo" role="3cqZAp" />
+              </node>
+              <node concept="3clFbC" id="13En2FvzOQp" role="3clFbw">
+                <node concept="37vLTw" id="13En2FvzOQq" role="3uHU7w">
+                  <ref role="3cqZAo" node="13En2FvzOPL" resolve="crtComponent" />
+                </node>
+                <node concept="37vLTw" id="13En2FvzOQr" role="3uHU7B">
+                  <ref role="3cqZAo" node="13En2FvzOS2" resolve="d" />
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbJ" id="13En2FvzOQs" role="3cqZAp">
+              <node concept="2OqwBi" id="13En2FvzOQt" role="3clFbw">
+                <node concept="3S9uib" id="13En2FvzOQu" role="2Oq$k0">
+                  <node concept="37vLTw" id="13En2FvzOQv" role="3S9DZi">
+                    <ref role="3cqZAo" node="13En2FvzOPQ" resolve="alreadyVisitedComponents" />
+                  </node>
+                </node>
+                <node concept="liA8E" id="13En2FvzOQw" role="2OqNvi">
+                  <ref role="37wK5l" to="33ny:~Set.contains(java.lang.Object)" resolve="contains" />
+                  <node concept="37vLTw" id="13En2FvzOQx" role="37wK5m">
+                    <ref role="3cqZAo" node="13En2FvzOS2" resolve="d" />
+                  </node>
+                </node>
+              </node>
+              <node concept="3clFbS" id="13En2FvzOQy" role="3clFbx">
+                <node concept="3N13vt" id="13En2FvzOQz" role="3cqZAp" />
+              </node>
+            </node>
+            <node concept="3cpWs8" id="13En2FvzOQ$" role="3cqZAp">
+              <node concept="3cpWsn" id="13En2FvzOQ_" role="3cpWs9">
+                <property role="TrG5h" value="myIndirectDependencies" />
+                <node concept="3uibUv" id="13En2FvzOQA" role="1tU5fm">
+                  <ref role="3uigEE" to="33ny:~Set" resolve="Set" />
+                  <node concept="16syzq" id="13En2FvzOQB" role="11_B2D">
+                    <ref role="16sUi3" node="13En2FvzOSd" resolve="Component" />
+                  </node>
+                </node>
+                <node concept="2OqwBi" id="13En2FvzOQC" role="33vP2m">
+                  <node concept="3S9uib" id="13En2FvzOQD" role="2Oq$k0">
+                    <node concept="37vLTw" id="13En2FvzOQE" role="3S9DZi">
+                      <ref role="3cqZAo" node="13En2FvzOPE" resolve="component2IndirectDependencies" />
+                    </node>
+                  </node>
+                  <node concept="liA8E" id="13En2FvzOQF" role="2OqNvi">
+                    <ref role="37wK5l" to="33ny:~Map.get(java.lang.Object)" resolve="get" />
+                    <node concept="37vLTw" id="13En2FvzOQG" role="37wK5m">
+                      <ref role="3cqZAo" node="13En2FvzOS2" resolve="d" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbJ" id="13En2FvzOQH" role="3cqZAp">
+              <node concept="3clFbS" id="13En2FvzOQI" role="3clFbx">
+                <node concept="3N13vt" id="13En2FvzOQJ" role="3cqZAp" />
+              </node>
+              <node concept="3fqX7Q" id="13En2FvzOQK" role="3clFbw">
+                <node concept="2OqwBi" id="13En2FvzOQL" role="3fr31v">
+                  <node concept="liA8E" id="13En2FvzOQM" role="2OqNvi">
+                    <ref role="37wK5l" to="33ny:~Set.contains(java.lang.Object)" resolve="contains" />
+                    <node concept="37vLTw" id="13En2FvzOQN" role="37wK5m">
+                      <ref role="3cqZAo" node="13En2FvzOPJ" resolve="seed" />
+                    </node>
+                  </node>
+                  <node concept="37vLTw" id="13En2FvzOQO" role="2Oq$k0">
+                    <ref role="3cqZAo" node="13En2FvzOQ_" resolve="myIndirectDependencies" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbJ" id="13En2FvzOQP" role="3cqZAp">
+              <node concept="3clFbS" id="13En2FvzOQQ" role="3clFbx">
+                <node concept="3N13vt" id="13En2FvzOQR" role="3cqZAp" />
+              </node>
+              <node concept="3fqX7Q" id="13En2FvzOQS" role="3clFbw">
+                <node concept="2OqwBi" id="13En2FvzOQT" role="3fr31v">
+                  <node concept="liA8E" id="13En2FvzOQU" role="2OqNvi">
+                    <ref role="37wK5l" to="33ny:~Set.contains(java.lang.Object)" resolve="contains" />
+                    <node concept="37vLTw" id="13En2FvzOQV" role="37wK5m">
+                      <ref role="3cqZAo" node="13En2FvzOS2" resolve="d" />
+                    </node>
+                  </node>
+                  <node concept="37vLTw" id="13En2FvzOQW" role="2Oq$k0">
+                    <ref role="3cqZAo" node="13En2FvzOQ_" resolve="myIndirectDependencies" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbJ" id="13En2FvzOQX" role="3cqZAp">
+              <node concept="3clFbS" id="13En2FvzOQY" role="3clFbx">
+                <node concept="3N13vt" id="13En2FvzOQZ" role="3cqZAp" />
+              </node>
+              <node concept="2OqwBi" id="13En2FvzOR0" role="3clFbw">
+                <node concept="3S9uib" id="13En2FvzOR1" role="2Oq$k0">
+                  <node concept="37vLTw" id="13En2FvzOR2" role="3S9DZi">
+                    <ref role="3cqZAo" node="13En2FvzOPT" resolve="componentsForWhichAllCyclesHaveBeenFound" />
+                  </node>
+                </node>
+                <node concept="liA8E" id="13En2FvzOR3" role="2OqNvi">
+                  <ref role="37wK5l" to="33ny:~Set.contains(java.lang.Object)" resolve="contains" />
+                  <node concept="37vLTw" id="13En2FvzOR4" role="37wK5m">
+                    <ref role="3cqZAo" node="13En2FvzOS2" resolve="d" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbJ" id="13En2FvzOR5" role="3cqZAp">
+              <node concept="3clFbS" id="13En2FvzOR6" role="3clFbx">
+                <node concept="3clFbJ" id="13En2FvzOR7" role="3cqZAp">
+                  <node concept="3clFbS" id="13En2FvzOR8" role="3clFbx">
+                    <node concept="3clFbF" id="13En2FvzOR9" role="3cqZAp">
+                      <node concept="2OqwBi" id="13En2FvzORa" role="3clFbG">
+                        <node concept="37vLTw" id="13En2FvzORb" role="2Oq$k0">
+                          <ref role="3cqZAo" node="13En2FvzOPW" resolve="allCycles" />
+                        </node>
+                        <node concept="TSZUe" id="13En2FvzORc" role="2OqNvi">
+                          <node concept="2ShNRf" id="13En2FvzORd" role="25WWJ7">
+                            <node concept="1pGfFk" id="13En2FvzORe" role="2ShVmc">
+                              <property role="373rjd" value="true" />
+                              <ref role="37wK5l" to="33ny:~ArrayList.&lt;init&gt;(java.util.Collection)" resolve="ArrayList" />
+                              <node concept="16syzq" id="13En2FvzORf" role="1pMfVU">
+                                <ref role="16sUi3" node="13En2FvzOSd" resolve="Component" />
+                              </node>
+                              <node concept="37vLTw" id="13En2FvzORg" role="37wK5m">
+                                <ref role="3cqZAo" node="13En2FvzOPN" resolve="crtPath" />
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="22lmx$" id="13En2FvzORh" role="3clFbw">
+                    <node concept="3clFbC" id="13En2FvzORi" role="3uHU7B">
+                      <node concept="37vLTw" id="13En2FvzORj" role="3uHU7B">
+                        <ref role="3cqZAo" node="13En2FvzOS6" resolve="cycleSize" />
+                      </node>
+                      <node concept="3cmrfG" id="13En2FvzORk" role="3uHU7w">
+                        <property role="3cmrfH" value="-1" />
+                      </node>
+                    </node>
+                    <node concept="3clFbC" id="13En2FvzORl" role="3uHU7w">
+                      <node concept="37vLTw" id="13En2FvzORm" role="3uHU7w">
+                        <ref role="3cqZAo" node="13En2FvzOS6" resolve="cycleSize" />
+                      </node>
+                      <node concept="2OqwBi" id="13En2FvzORn" role="3uHU7B">
+                        <node concept="37vLTw" id="13En2FvzORo" role="2Oq$k0">
+                          <ref role="3cqZAo" node="13En2FvzOPN" resolve="crtPath" />
+                        </node>
+                        <node concept="34oBXx" id="13En2FvzORp" role="2OqNvi" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="3N13vt" id="13En2FvzORq" role="3cqZAp" />
+              </node>
+              <node concept="3clFbC" id="13En2FvzORr" role="3clFbw">
+                <node concept="37vLTw" id="13En2FvzORs" role="3uHU7w">
+                  <ref role="3cqZAo" node="13En2FvzOS2" resolve="d" />
+                </node>
+                <node concept="37vLTw" id="13En2FvzORt" role="3uHU7B">
+                  <ref role="3cqZAo" node="13En2FvzOPJ" resolve="seed" />
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbH" id="13En2FvzORu" role="3cqZAp" />
+            <node concept="3clFbF" id="13En2FvzORv" role="3cqZAp">
+              <node concept="2OqwBi" id="13En2FvzORw" role="3clFbG">
+                <node concept="3S9uib" id="13En2FvzORx" role="2Oq$k0">
+                  <node concept="37vLTw" id="13En2FvzORy" role="3S9DZi">
+                    <ref role="3cqZAo" node="13En2FvzOPN" resolve="crtPath" />
+                  </node>
+                </node>
+                <node concept="liA8E" id="13En2FvzORz" role="2OqNvi">
+                  <ref role="37wK5l" to="33ny:~List.add(java.lang.Object)" resolve="add" />
+                  <node concept="37vLTw" id="13En2FvzOR$" role="37wK5m">
+                    <ref role="3cqZAo" node="13En2FvzOS2" resolve="d" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbF" id="13En2FvzOR_" role="3cqZAp">
+              <node concept="2OqwBi" id="13En2FvzORA" role="3clFbG">
+                <node concept="3S9uib" id="13En2FvzORB" role="2Oq$k0">
+                  <node concept="37vLTw" id="13En2FvzORC" role="3S9DZi">
+                    <ref role="3cqZAo" node="13En2FvzOPQ" resolve="alreadyVisitedComponents" />
+                  </node>
+                </node>
+                <node concept="liA8E" id="13En2FvzORD" role="2OqNvi">
+                  <ref role="37wK5l" to="33ny:~Set.add(java.lang.Object)" resolve="add" />
+                  <node concept="37vLTw" id="13En2FvzORE" role="37wK5m">
+                    <ref role="3cqZAo" node="13En2FvzOS2" resolve="d" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbF" id="13En2Fv$e6t" role="3cqZAp">
+              <node concept="1rXfSq" id="13En2Fv$e6r" role="3clFbG">
+                <ref role="37wK5l" node="13En2FvzOPz" resolve="computeTransitiveClosure" />
+                <node concept="37vLTw" id="13En2Fv$nNI" role="37wK5m">
+                  <ref role="3cqZAo" node="13En2FvzOP_" resolve="component2Dependencies" />
+                </node>
+                <node concept="37vLTw" id="13En2Fv$z88" role="37wK5m">
+                  <ref role="3cqZAo" node="13En2FvzOPE" resolve="component2IndirectDependencies" />
+                </node>
+                <node concept="37vLTw" id="13En2Fv$Fl7" role="37wK5m">
+                  <ref role="3cqZAo" node="13En2FvzOPJ" resolve="seed" />
+                </node>
+                <node concept="37vLTw" id="13En2Fv$QhO" role="37wK5m">
+                  <ref role="3cqZAo" node="13En2FvzOS2" resolve="d" />
+                </node>
+                <node concept="37vLTw" id="13En2Fv$Y3w" role="37wK5m">
+                  <ref role="3cqZAo" node="13En2FvzOPN" resolve="crtPath" />
+                </node>
+                <node concept="37vLTw" id="13En2Fv_f6z" role="37wK5m">
+                  <ref role="3cqZAo" node="13En2FvzOPQ" resolve="alreadyVisitedComponents" />
+                </node>
+                <node concept="37vLTw" id="13En2Fv_u_l" role="37wK5m">
+                  <ref role="3cqZAo" node="13En2FvzOPT" resolve="componentsForWhichAllCyclesHaveBeenFound" />
+                </node>
+                <node concept="37vLTw" id="13En2Fv_An8" role="37wK5m">
+                  <ref role="3cqZAo" node="13En2FvzOPW" resolve="allCycles" />
+                </node>
+                <node concept="37vLTw" id="13En2Fv_Rp5" role="37wK5m">
+                  <ref role="3cqZAo" node="13En2FvzOS6" resolve="cycleSize" />
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbF" id="13En2FvzORQ" role="3cqZAp">
+              <node concept="2OqwBi" id="13En2FvzORR" role="3clFbG">
+                <node concept="3S9uib" id="13En2FvzORS" role="2Oq$k0">
+                  <node concept="37vLTw" id="13En2FvzORT" role="3S9DZi">
+                    <ref role="3cqZAo" node="13En2FvzOPN" resolve="crtPath" />
+                  </node>
+                </node>
+                <node concept="liA8E" id="13En2FvzORU" role="2OqNvi">
+                  <ref role="37wK5l" to="33ny:~List.remove(java.lang.Object)" resolve="remove" />
+                  <node concept="37vLTw" id="13En2FvzORV" role="37wK5m">
+                    <ref role="3cqZAo" node="13En2FvzOS2" resolve="d" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbF" id="13En2FvzORW" role="3cqZAp">
+              <node concept="2OqwBi" id="13En2FvzORX" role="3clFbG">
+                <node concept="3S9uib" id="13En2FvzORY" role="2Oq$k0">
+                  <node concept="37vLTw" id="13En2FvzORZ" role="3S9DZi">
+                    <ref role="3cqZAo" node="13En2FvzOPQ" resolve="alreadyVisitedComponents" />
+                  </node>
+                </node>
+                <node concept="liA8E" id="13En2FvzOS0" role="2OqNvi">
+                  <ref role="37wK5l" to="33ny:~Set.remove(java.lang.Object)" resolve="remove" />
+                  <node concept="37vLTw" id="13En2FvzOS1" role="37wK5m">
+                    <ref role="3cqZAo" node="13En2FvzOS2" resolve="d" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3cpWsn" id="13En2FvzOS2" role="1Duv9x">
+            <property role="TrG5h" value="d" />
+            <node concept="16syzq" id="13En2FvzOS3" role="1tU5fm">
+              <ref role="16sUi3" node="13En2FvzOSd" resolve="Component" />
+            </node>
+          </node>
+          <node concept="37vLTw" id="13En2FvzOS4" role="1DdaDG">
+            <ref role="3cqZAo" node="13En2FvzOQ2" resolve="myDependencies" />
+          </node>
+        </node>
+      </node>
+      <node concept="3cqZAl" id="13En2FvzOS5" role="3clF45" />
+      <node concept="37vLTG" id="13En2FvzOP_" role="3clF46">
+        <property role="TrG5h" value="component2Dependencies" />
+        <node concept="3rvAFt" id="13En2FvzOPA" role="1tU5fm">
+          <node concept="16syzq" id="13En2FvzOPB" role="3rvQeY">
+            <ref role="16sUi3" node="13En2FvzOSd" resolve="Component" />
+          </node>
+          <node concept="2hMVRd" id="13En2FvzOPC" role="3rvSg0">
+            <node concept="16syzq" id="13En2FvzOPD" role="2hN53Y">
+              <ref role="16sUi3" node="13En2FvzOSd" resolve="Component" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="13En2FvzOPE" role="3clF46">
+        <property role="TrG5h" value="component2IndirectDependencies" />
+        <node concept="3rvAFt" id="13En2FvzOPF" role="1tU5fm">
+          <node concept="16syzq" id="13En2FvzOPG" role="3rvQeY">
+            <ref role="16sUi3" node="13En2FvzOSd" resolve="Component" />
+          </node>
+          <node concept="2hMVRd" id="13En2FvzOPH" role="3rvSg0">
+            <node concept="16syzq" id="13En2FvzOPI" role="2hN53Y">
+              <ref role="16sUi3" node="13En2FvzOSd" resolve="Component" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="13En2FvzOPJ" role="3clF46">
+        <property role="TrG5h" value="seed" />
+        <node concept="16syzq" id="13En2FvzOPK" role="1tU5fm">
+          <ref role="16sUi3" node="13En2FvzOSd" resolve="Component" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="13En2FvzOPL" role="3clF46">
+        <property role="TrG5h" value="crtComponent" />
+        <node concept="16syzq" id="13En2FvzOPM" role="1tU5fm">
+          <ref role="16sUi3" node="13En2FvzOSd" resolve="Component" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="13En2FvzOPN" role="3clF46">
+        <property role="TrG5h" value="crtPath" />
+        <node concept="_YKpA" id="13En2FvzOPO" role="1tU5fm">
+          <node concept="16syzq" id="13En2FvzOPP" role="_ZDj9">
+            <ref role="16sUi3" node="13En2FvzOSd" resolve="Component" />
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="13En2FvzOPQ" role="3clF46">
+        <property role="TrG5h" value="alreadyVisitedComponents" />
+        <node concept="2hMVRd" id="13En2FvzOPR" role="1tU5fm">
+          <node concept="16syzq" id="13En2FvzOPS" role="2hN53Y">
+            <ref role="16sUi3" node="13En2FvzOSd" resolve="Component" />
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="13En2FvzOPT" role="3clF46">
+        <property role="TrG5h" value="componentsForWhichAllCyclesHaveBeenFound" />
+        <node concept="2hMVRd" id="13En2FvzOPU" role="1tU5fm">
+          <node concept="16syzq" id="13En2FvzOPV" role="2hN53Y">
+            <ref role="16sUi3" node="13En2FvzOSd" resolve="Component" />
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="13En2FvzOPW" role="3clF46">
+        <property role="TrG5h" value="allCycles" />
+        <node concept="2hMVRd" id="13En2FvzOPX" role="1tU5fm">
+          <node concept="3uibUv" id="13En2FvzOPY" role="2hN53Y">
+            <ref role="3uigEE" to="33ny:~ArrayList" resolve="ArrayList" />
+            <node concept="16syzq" id="13En2FvzOPZ" role="11_B2D">
+              <ref role="16sUi3" node="13En2FvzOSd" resolve="Component" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="13En2FvzOS6" role="3clF46">
+        <property role="TrG5h" value="cycleSize" />
+        <node concept="10Oyi0" id="13En2FvzOS7" role="1tU5fm" />
+      </node>
+      <node concept="16euLQ" id="13En2FvzOSd" role="16eVyc">
+        <property role="TrG5h" value="Component" />
+      </node>
+      <node concept="P$JXv" id="13En2FvzOSf" role="lGtFl">
+        <node concept="TZ5HA" id="13En2FvzOSg" role="TZ5H$">
+          <node concept="1dT_AC" id="13En2FvzOSh" role="1dT_Ay" />
+        </node>
+        <node concept="TUZQ0" id="13En2FvzOSi" role="3nqlJM">
+          <property role="TUZQ4" value="is -1 if all cycles need to be computed, or a positive value if only cycles with a certain size have to be computed" />
+          <node concept="zr_55" id="13En2FvzOSj" role="zr_5Q">
+            <ref role="zr_51" node="13En2FvzOP_" resolve="component2Dependencies" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="13En2Fv5u_6" role="jymVt" />
+    <node concept="3clFb_" id="13En2FvA768" role="jymVt">
+      <property role="TrG5h" value="computeIndirectDependencies" />
+      <node concept="3clFbS" id="13En2FvA76f" role="3clF47">
+        <node concept="3cpWs8" id="13En2FvA76g" role="3cqZAp">
+          <node concept="3cpWsn" id="13En2FvA76h" role="3cpWs9">
+            <property role="TrG5h" value="component2IndirectDependencies" />
+            <node concept="3rvAFt" id="13En2FvA76i" role="1tU5fm">
+              <node concept="16syzq" id="13En2FvA76j" role="3rvQeY">
+                <ref role="16sUi3" node="13En2Fv6yo$" resolve="Component" />
+              </node>
+              <node concept="2hMVRd" id="13En2FvA76k" role="3rvSg0">
+                <node concept="16syzq" id="13En2FvA76l" role="2hN53Y">
+                  <ref role="16sUi3" node="13En2Fv6yo$" resolve="Component" />
+                </node>
+              </node>
+            </node>
+            <node concept="2ShNRf" id="13En2FvA76m" role="33vP2m">
+              <node concept="3rGOSV" id="13En2FvA76n" role="2ShVmc">
+                <node concept="16syzq" id="13En2FvA76o" role="3rHrn6">
+                  <ref role="16sUi3" node="13En2Fv6yo$" resolve="Component" />
+                </node>
+                <node concept="2hMVRd" id="13En2FvA76p" role="3rHtpV">
+                  <node concept="16syzq" id="13En2FvA76q" role="2hN53Y">
+                    <ref role="16sUi3" node="13En2Fv6yo$" resolve="Component" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="13En2FvA76r" role="3cqZAp">
+          <node concept="2OqwBi" id="13En2FvA76s" role="3clFbG">
+            <node concept="37vLTw" id="13En2FvA76t" role="2Oq$k0">
+              <ref role="3cqZAo" node="13En2FvA76a" resolve="component2DirectDependencies" />
+            </node>
+            <node concept="2es0OD" id="13En2FvA76u" role="2OqNvi">
+              <node concept="1bVj0M" id="13En2FvA76v" role="23t8la">
+                <node concept="3clFbS" id="13En2FvA76w" role="1bW5cS">
+                  <node concept="3clFbF" id="13En2FvA76x" role="3cqZAp">
+                    <node concept="37vLTI" id="13En2FvA76y" role="3clFbG">
+                      <node concept="2ShNRf" id="13En2FvA76z" role="37vLTx">
+                        <node concept="2i4dXS" id="13En2FvA76$" role="2ShVmc">
+                          <node concept="16syzq" id="13En2FvA76_" role="HW$YZ">
+                            <ref role="16sUi3" node="13En2Fv6yo$" resolve="Component" />
+                          </node>
+                          <node concept="2OqwBi" id="13En2FvA76A" role="I$8f6">
+                            <node concept="37vLTw" id="13En2FvA76B" role="2Oq$k0">
+                              <ref role="3cqZAo" node="13En2FvA76I" resolve="it" />
+                            </node>
+                            <node concept="3AV6Ez" id="13En2FvA76C" role="2OqNvi" />
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="3EllGN" id="13En2FvA76D" role="37vLTJ">
+                        <node concept="2OqwBi" id="13En2FvA76E" role="3ElVtu">
+                          <node concept="37vLTw" id="13En2FvA76F" role="2Oq$k0">
+                            <ref role="3cqZAo" node="13En2FvA76I" resolve="it" />
+                          </node>
+                          <node concept="3AY5_j" id="13En2FvA76G" role="2OqNvi" />
+                        </node>
+                        <node concept="37vLTw" id="13En2FvA76H" role="3ElQJh">
+                          <ref role="3cqZAo" node="13En2FvA76h" resolve="component2IndirectDependencies" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="gl6BB" id="13En2FvA76I" role="1bW2Oz">
+                  <property role="TrG5h" value="it" />
+                  <node concept="2jxLKc" id="13En2FvA76J" role="1tU5fm" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="13En2FvA76K" role="3cqZAp" />
+        <node concept="3cpWs8" id="13En2FvA76L" role="3cqZAp">
+          <node concept="3cpWsn" id="13En2FvA76M" role="3cpWs9">
+            <property role="TrG5h" value="changesRegistered" />
+            <node concept="10P_77" id="13En2FvA76N" role="1tU5fm" />
+            <node concept="3clFbT" id="13En2FvA76O" role="33vP2m">
+              <property role="3clFbU" value="true" />
+            </node>
+          </node>
+        </node>
+        <node concept="2$JKZl" id="13En2FvA76P" role="3cqZAp">
+          <node concept="3clFbS" id="13En2FvA76Q" role="2LFqv$">
+            <node concept="3clFbF" id="13En2FvA76R" role="3cqZAp">
+              <node concept="37vLTI" id="13En2FvA76S" role="3clFbG">
+                <node concept="3clFbT" id="13En2FvA76T" role="37vLTx" />
+                <node concept="37vLTw" id="13En2FvA76U" role="37vLTJ">
+                  <ref role="3cqZAo" node="13En2FvA76M" resolve="changesRegistered" />
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbH" id="13En2FvA76V" role="3cqZAp" />
+            <node concept="2Gpval" id="13En2FvA76W" role="3cqZAp">
+              <node concept="2GrKxI" id="13En2FvA76X" role="2Gsz3X">
+                <property role="TrG5h" value="crtComponent" />
+              </node>
+              <node concept="2OqwBi" id="13En2FvA76Y" role="2GsD0m">
+                <node concept="37vLTw" id="13En2FvA76Z" role="2Oq$k0">
+                  <ref role="3cqZAo" node="13En2FvA76h" resolve="component2IndirectDependencies" />
+                </node>
+                <node concept="3lbrtF" id="13En2FvA770" role="2OqNvi" />
+              </node>
+              <node concept="3clFbS" id="13En2FvA771" role="2LFqv$">
+                <node concept="3cpWs8" id="13En2FvA772" role="3cqZAp">
+                  <node concept="3cpWsn" id="13En2FvA773" role="3cpWs9">
+                    <property role="TrG5h" value="newDependencies" />
+                    <node concept="2hMVRd" id="13En2FvA774" role="1tU5fm">
+                      <node concept="16syzq" id="13En2FvA775" role="2hN53Y">
+                        <ref role="16sUi3" node="13En2Fv6yo$" resolve="Component" />
+                      </node>
+                    </node>
+                    <node concept="2ShNRf" id="13En2FvA776" role="33vP2m">
+                      <node concept="2i4dXS" id="13En2FvA777" role="2ShVmc">
+                        <node concept="16syzq" id="13En2FvA778" role="HW$YZ">
+                          <ref role="16sUi3" node="13En2Fv6yo$" resolve="Component" />
+                        </node>
+                        <node concept="3EllGN" id="13En2FvA779" role="I$8f6">
+                          <node concept="2GrUjf" id="13En2FvA77a" role="3ElVtu">
+                            <ref role="2Gs0qQ" node="13En2FvA76X" resolve="crtComponent" />
+                          </node>
+                          <node concept="37vLTw" id="13En2FvA77b" role="3ElQJh">
+                            <ref role="3cqZAo" node="13En2FvA76h" resolve="component2IndirectDependencies" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="2Gpval" id="13En2FvA77c" role="3cqZAp">
+                  <node concept="2GrKxI" id="13En2FvA77d" role="2Gsz3X">
+                    <property role="TrG5h" value="crtDep" />
+                  </node>
+                  <node concept="3EllGN" id="13En2FvA77e" role="2GsD0m">
+                    <node concept="2GrUjf" id="13En2FvA77f" role="3ElVtu">
+                      <ref role="2Gs0qQ" node="13En2FvA76X" resolve="crtComponent" />
+                    </node>
+                    <node concept="37vLTw" id="13En2FvA77g" role="3ElQJh">
+                      <ref role="3cqZAo" node="13En2FvA76h" resolve="component2IndirectDependencies" />
+                    </node>
+                  </node>
+                  <node concept="3clFbS" id="13En2FvA77h" role="2LFqv$">
+                    <node concept="2Gpval" id="13En2FvA77i" role="3cqZAp">
+                      <node concept="2GrKxI" id="13En2FvA77j" role="2Gsz3X">
+                        <property role="TrG5h" value="crtIndirectDependency" />
+                      </node>
+                      <node concept="3clFbS" id="13En2FvA77k" role="2LFqv$">
+                        <node concept="3clFbJ" id="13En2FvA77l" role="3cqZAp">
+                          <node concept="3fqX7Q" id="13En2FvA77m" role="3clFbw">
+                            <node concept="2OqwBi" id="13En2FvA77n" role="3fr31v">
+                              <node concept="37vLTw" id="13En2FvA77o" role="2Oq$k0">
+                                <ref role="3cqZAo" node="13En2FvA773" resolve="newDependencies" />
+                              </node>
+                              <node concept="3JPx81" id="13En2FvA77p" role="2OqNvi">
+                                <node concept="2GrUjf" id="13En2FvA77q" role="25WWJ7">
+                                  <ref role="2Gs0qQ" node="13En2FvA77j" resolve="crtIndirectDependency" />
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                          <node concept="3clFbS" id="13En2FvA77r" role="3clFbx">
+                            <node concept="3clFbF" id="13En2FvA77s" role="3cqZAp">
+                              <node concept="37vLTI" id="13En2FvA77t" role="3clFbG">
+                                <node concept="3clFbT" id="13En2FvA77u" role="37vLTx">
+                                  <property role="3clFbU" value="true" />
+                                </node>
+                                <node concept="37vLTw" id="13En2FvA77v" role="37vLTJ">
+                                  <ref role="3cqZAo" node="13En2FvA76M" resolve="changesRegistered" />
+                                </node>
+                              </node>
+                            </node>
+                            <node concept="3clFbF" id="13En2FvA77w" role="3cqZAp">
+                              <node concept="2OqwBi" id="13En2FvA77x" role="3clFbG">
+                                <node concept="37vLTw" id="13En2FvA77y" role="2Oq$k0">
+                                  <ref role="3cqZAo" node="13En2FvA773" resolve="newDependencies" />
+                                </node>
+                                <node concept="TSZUe" id="13En2FvA77z" role="2OqNvi">
+                                  <node concept="2GrUjf" id="13En2FvA77$" role="25WWJ7">
+                                    <ref role="2Gs0qQ" node="13En2FvA77j" resolve="crtIndirectDependency" />
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="3EllGN" id="13En2FvA77_" role="2GsD0m">
+                        <node concept="2GrUjf" id="13En2FvA77A" role="3ElVtu">
+                          <ref role="2Gs0qQ" node="13En2FvA77d" resolve="crtDep" />
+                        </node>
+                        <node concept="37vLTw" id="13En2FvA77B" role="3ElQJh">
+                          <ref role="3cqZAo" node="13En2FvA76h" resolve="component2IndirectDependencies" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="3clFbF" id="13En2FvA77C" role="3cqZAp">
+                  <node concept="37vLTI" id="13En2FvA77D" role="3clFbG">
+                    <node concept="37vLTw" id="13En2FvA77E" role="37vLTx">
+                      <ref role="3cqZAo" node="13En2FvA773" resolve="newDependencies" />
+                    </node>
+                    <node concept="3EllGN" id="13En2FvA77F" role="37vLTJ">
+                      <node concept="2GrUjf" id="13En2FvA77G" role="3ElVtu">
+                        <ref role="2Gs0qQ" node="13En2FvA76X" resolve="crtComponent" />
+                      </node>
+                      <node concept="37vLTw" id="13En2FvA77H" role="3ElQJh">
+                        <ref role="3cqZAo" node="13En2FvA76h" resolve="component2IndirectDependencies" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="37vLTw" id="13En2FvA77I" role="2$JKZa">
+            <ref role="3cqZAo" node="13En2FvA76M" resolve="changesRegistered" />
+          </node>
+        </node>
+        <node concept="3clFbH" id="13En2FvA77J" role="3cqZAp" />
+        <node concept="3clFbF" id="13En2FvA77K" role="3cqZAp">
+          <node concept="37vLTw" id="13En2FvA77L" role="3clFbG">
+            <ref role="3cqZAo" node="13En2FvA76h" resolve="component2IndirectDependencies" />
+          </node>
+        </node>
+      </node>
+      <node concept="3rvAFt" id="13En2FvA77M" role="3clF45">
+        <node concept="16syzq" id="13En2FvA77N" role="3rvQeY">
+          <ref role="16sUi3" node="13En2Fv6yo$" resolve="Component" />
+        </node>
+        <node concept="2hMVRd" id="13En2FvA77O" role="3rvSg0">
+          <node concept="16syzq" id="13En2FvA77P" role="2hN53Y">
+            <ref role="16sUi3" node="13En2Fv6yo$" resolve="Component" />
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="13En2FvA76a" role="3clF46">
+        <property role="TrG5h" value="component2DirectDependencies" />
+        <node concept="3rvAFt" id="13En2FvA76b" role="1tU5fm">
+          <node concept="16syzq" id="13En2FvA76c" role="3rvQeY">
+            <ref role="16sUi3" node="13En2Fv6yo$" resolve="Component" />
+          </node>
+          <node concept="2hMVRd" id="13En2FvA76d" role="3rvSg0">
+            <node concept="16syzq" id="13En2FvA76e" role="2hN53Y">
+              <ref role="16sUi3" node="13En2Fv6yo$" resolve="Component" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="P$JXv" id="13En2FvA77V" role="lGtFl">
+        <node concept="TZ5HA" id="13En2FvA77W" role="TZ5H$">
+          <node concept="1dT_AC" id="13En2FvA77X" role="1dT_Ay">
+            <property role="1dT_AB" value="Returns a map from a component to all its direct and indirect dependencies." />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="3Tm1VV" id="13En2Fv5uAT" role="1B3o_S" />
+    <node concept="16euLQ" id="13En2Fv6yo$" role="16eVyc">
+      <property role="TrG5h" value="Component" />
     </node>
   </node>
 </model>

--- a/code/languages/org.mpsqa.lint/solutions/org.mpsqa.lint.mps_lang.linters_library/models/org.mpsqa.lint.mps_lang.linters_library.typesystem_aspect.mps
+++ b/code/languages/org.mpsqa.lint/solutions/org.mpsqa.lint.mps_lang.linters_library/models/org.mpsqa.lint.mps_lang.linters_library.typesystem_aspect.mps
@@ -31,43 +31,43 @@
   </imports>
   <registry>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
-      <concept id="1215693861676" name="jetbrains.mps.baseLanguage.structure.BaseAssignmentExpression" flags="ng" index="d038R">
+      <concept id="1215693861676" name="jetbrains.mps.baseLanguage.structure.BaseAssignmentExpression" flags="nn" index="d038R">
         <child id="1068498886297" name="rValue" index="37vLTx" />
         <child id="1068498886295" name="lValue" index="37vLTJ" />
       </concept>
-      <concept id="1202948039474" name="jetbrains.mps.baseLanguage.structure.InstanceMethodCallOperation" flags="ng" index="liA8E" />
+      <concept id="1202948039474" name="jetbrains.mps.baseLanguage.structure.InstanceMethodCallOperation" flags="nn" index="liA8E" />
       <concept id="8118189177080264853" name="jetbrains.mps.baseLanguage.structure.AlternativeType" flags="ig" index="nSUau">
         <child id="8118189177080264854" name="alternative" index="nSUat" />
       </concept>
-      <concept id="1465982738277781862" name="jetbrains.mps.baseLanguage.structure.PlaceholderMember" flags="ng" index="2tJIrI" />
-      <concept id="1154032098014" name="jetbrains.mps.baseLanguage.structure.AbstractLoopStatement" flags="ng" index="2LF5Ji">
+      <concept id="1465982738277781862" name="jetbrains.mps.baseLanguage.structure.PlaceholderMember" flags="nn" index="2tJIrI" />
+      <concept id="1154032098014" name="jetbrains.mps.baseLanguage.structure.AbstractLoopStatement" flags="nn" index="2LF5Ji">
         <child id="1154032183016" name="body" index="2LFqv$" />
       </concept>
-      <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="ng" index="2OqwBi">
+      <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
         <child id="1197027771414" name="operand" index="2Oq$k0" />
         <child id="1197027833540" name="operation" index="2OqNvi" />
       </concept>
-      <concept id="1145552977093" name="jetbrains.mps.baseLanguage.structure.GenericNewExpression" flags="ng" index="2ShNRf">
+      <concept id="1145552977093" name="jetbrains.mps.baseLanguage.structure.GenericNewExpression" flags="nn" index="2ShNRf">
         <child id="1145553007750" name="creator" index="2ShVmc" />
       </concept>
-      <concept id="1137021947720" name="jetbrains.mps.baseLanguage.structure.ConceptFunction" flags="ig" index="2VMwT0">
+      <concept id="1137021947720" name="jetbrains.mps.baseLanguage.structure.ConceptFunction" flags="in" index="2VMwT0">
         <child id="1137022507850" name="body" index="2VODD2" />
       </concept>
-      <concept id="1070475926800" name="jetbrains.mps.baseLanguage.structure.StringLiteral" flags="ng" index="Xl_RD">
+      <concept id="1070475926800" name="jetbrains.mps.baseLanguage.structure.StringLiteral" flags="nn" index="Xl_RD">
         <property id="1070475926801" name="value" index="Xl_RC" />
       </concept>
       <concept id="4952749571008284462" name="jetbrains.mps.baseLanguage.structure.CatchVariable" flags="ng" index="XOnhg" />
       <concept id="1081236700938" name="jetbrains.mps.baseLanguage.structure.StaticMethodDeclaration" flags="ig" index="2YIFZL" />
-      <concept id="1081236700937" name="jetbrains.mps.baseLanguage.structure.StaticMethodCall" flags="ng" index="2YIFZM">
+      <concept id="1081236700937" name="jetbrains.mps.baseLanguage.structure.StaticMethodCall" flags="nn" index="2YIFZM">
         <reference id="1144433194310" name="classConcept" index="1Pybhc" />
       </concept>
-      <concept id="1081256982272" name="jetbrains.mps.baseLanguage.structure.InstanceOfExpression" flags="ng" index="2ZW3vV">
+      <concept id="1081256982272" name="jetbrains.mps.baseLanguage.structure.InstanceOfExpression" flags="nn" index="2ZW3vV">
         <child id="1081256993305" name="classType" index="2ZW6by" />
         <child id="1081256993304" name="leftExpression" index="2ZW6bz" />
       </concept>
-      <concept id="1070534058343" name="jetbrains.mps.baseLanguage.structure.NullLiteral" flags="ng" index="10Nm6u" />
-      <concept id="1070534370425" name="jetbrains.mps.baseLanguage.structure.IntegerType" flags="ig" index="10Oyi0" />
-      <concept id="1070534934090" name="jetbrains.mps.baseLanguage.structure.CastExpression" flags="ng" index="10QFUN">
+      <concept id="1070534058343" name="jetbrains.mps.baseLanguage.structure.NullLiteral" flags="nn" index="10Nm6u" />
+      <concept id="1070534370425" name="jetbrains.mps.baseLanguage.structure.IntegerType" flags="in" index="10Oyi0" />
+      <concept id="1070534934090" name="jetbrains.mps.baseLanguage.structure.CastExpression" flags="nn" index="10QFUN">
         <child id="1070534934091" name="type" index="10QFUM" />
         <child id="1070534934092" name="expression" index="10QFUP" />
       </concept>
@@ -78,12 +78,12 @@
       <concept id="1513279640923991009" name="jetbrains.mps.baseLanguage.structure.IGenericClassCreator" flags="ngI" index="366HgL">
         <property id="1513279640906337053" name="inferTypeParams" index="373rjd" />
       </concept>
-      <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="ng" index="37vLTw">
+      <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
         <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
       </concept>
       <concept id="1068498886292" name="jetbrains.mps.baseLanguage.structure.ParameterDeclaration" flags="ir" index="37vLTG" />
-      <concept id="1068498886294" name="jetbrains.mps.baseLanguage.structure.AssignmentExpression" flags="ng" index="37vLTI" />
-      <concept id="1225271177708" name="jetbrains.mps.baseLanguage.structure.StringType" flags="ig" index="17QB3L" />
+      <concept id="1068498886294" name="jetbrains.mps.baseLanguage.structure.AssignmentExpression" flags="nn" index="37vLTI" />
+      <concept id="1225271177708" name="jetbrains.mps.baseLanguage.structure.StringType" flags="in" index="17QB3L" />
       <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
         <child id="5680397130376446158" name="type" index="1tU5fm" />
       </concept>
@@ -92,44 +92,44 @@
         <child id="1068580123134" name="parameter" index="3clF46" />
         <child id="1068580123135" name="body" index="3clF47" />
       </concept>
-      <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="ng" index="3clFbF">
+      <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
         <child id="1068580123156" name="expression" index="3clFbG" />
       </concept>
-      <concept id="1068580123157" name="jetbrains.mps.baseLanguage.structure.Statement" flags="ng" index="3clFbH" />
-      <concept id="1068580123159" name="jetbrains.mps.baseLanguage.structure.IfStatement" flags="ng" index="3clFbJ">
+      <concept id="1068580123157" name="jetbrains.mps.baseLanguage.structure.Statement" flags="nn" index="3clFbH" />
+      <concept id="1068580123159" name="jetbrains.mps.baseLanguage.structure.IfStatement" flags="nn" index="3clFbJ">
         <child id="1068580123160" name="condition" index="3clFbw" />
         <child id="1068580123161" name="ifTrue" index="3clFbx" />
       </concept>
-      <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sg" stub="5293379017992965193" index="3clFbS">
+      <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
         <child id="1068581517665" name="statement" index="3cqZAp" />
       </concept>
-      <concept id="1068580320020" name="jetbrains.mps.baseLanguage.structure.IntegerConstant" flags="ng" index="3cmrfG">
+      <concept id="1068580320020" name="jetbrains.mps.baseLanguage.structure.IntegerConstant" flags="nn" index="3cmrfG">
         <property id="1068580320021" name="value" index="3cmrfH" />
       </concept>
-      <concept id="1068581242875" name="jetbrains.mps.baseLanguage.structure.PlusExpression" flags="ng" index="3cpWs3" />
-      <concept id="1068581242878" name="jetbrains.mps.baseLanguage.structure.ReturnStatement" flags="ng" index="3cpWs6">
+      <concept id="1068581242875" name="jetbrains.mps.baseLanguage.structure.PlusExpression" flags="nn" index="3cpWs3" />
+      <concept id="1068581242878" name="jetbrains.mps.baseLanguage.structure.ReturnStatement" flags="nn" index="3cpWs6">
         <child id="1068581517676" name="expression" index="3cqZAk" />
       </concept>
-      <concept id="1068581242864" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclarationStatement" flags="ng" index="3cpWs8">
+      <concept id="1068581242864" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclarationStatement" flags="nn" index="3cpWs8">
         <child id="1068581242865" name="localVariableDeclaration" index="3cpWs9" />
       </concept>
       <concept id="1068581242863" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclaration" flags="nr" index="3cpWsn" />
-      <concept id="1079359253375" name="jetbrains.mps.baseLanguage.structure.ParenthesizedExpression" flags="ng" index="1eOMI4">
+      <concept id="1079359253375" name="jetbrains.mps.baseLanguage.structure.ParenthesizedExpression" flags="nn" index="1eOMI4">
         <child id="1079359253376" name="expression" index="1eOMHV" />
       </concept>
       <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ngI" index="1ndlxa">
         <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
         <child id="1068499141038" name="actualArgument" index="37wK5m" />
       </concept>
-      <concept id="1212685548494" name="jetbrains.mps.baseLanguage.structure.ClassCreator" flags="ng" index="1pGfFk" />
+      <concept id="1212685548494" name="jetbrains.mps.baseLanguage.structure.ClassCreator" flags="nn" index="1pGfFk" />
       <concept id="1107461130800" name="jetbrains.mps.baseLanguage.structure.Classifier" flags="ng" index="3pOWGL">
         <child id="5375687026011219971" name="member" index="jymVt" unordered="true" />
       </concept>
-      <concept id="1107535904670" name="jetbrains.mps.baseLanguage.structure.ClassifierType" flags="ig" index="3uibUv">
+      <concept id="1107535904670" name="jetbrains.mps.baseLanguage.structure.ClassifierType" flags="in" index="3uibUv">
         <reference id="1107535924139" name="classifier" index="3uigEE" />
         <child id="1109201940907" name="parameter" index="11_B2D" />
       </concept>
-      <concept id="1081773326031" name="jetbrains.mps.baseLanguage.structure.BinaryOperation" flags="ng" index="3uHJSO">
+      <concept id="1081773326031" name="jetbrains.mps.baseLanguage.structure.BinaryOperation" flags="nn" index="3uHJSO">
         <child id="1081773367579" name="rightExpression" index="3uHU7w" />
         <child id="1081773367580" name="leftExpression" index="3uHU7B" />
       </concept>
@@ -140,14 +140,14 @@
       <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ngI" index="1B3ioH">
         <child id="1178549979242" name="visibility" index="1B3o_S" />
       </concept>
-      <concept id="5351203823916750322" name="jetbrains.mps.baseLanguage.structure.TryUniversalStatement" flags="ng" index="3J1_TO">
+      <concept id="5351203823916750322" name="jetbrains.mps.baseLanguage.structure.TryUniversalStatement" flags="nn" index="3J1_TO">
         <child id="8276990574886367510" name="catchClause" index="1zxBo5" />
         <child id="8276990574886367508" name="body" index="1zxBo7" />
       </concept>
-      <concept id="6329021646629104954" name="jetbrains.mps.baseLanguage.structure.SingleLineComment" flags="ng" index="3SKdUt">
+      <concept id="6329021646629104954" name="jetbrains.mps.baseLanguage.structure.SingleLineComment" flags="nn" index="3SKdUt">
         <child id="8356039341262087992" name="line" index="1aUNEU" />
       </concept>
-      <concept id="1146644602865" name="jetbrains.mps.baseLanguage.structure.PublicVisibility" flags="ng" index="3Tm1VV" />
+      <concept id="1146644602865" name="jetbrains.mps.baseLanguage.structure.PublicVisibility" flags="nn" index="3Tm1VV" />
     </language>
     <language id="40ab19e9-751a-4433-b645-0e65160e58a0" name="org.mpsqa.lint.generic">
       <concept id="7741759128795038157" name="org.mpsqa.lint.generic.structure.CheckableScriptParameter" flags="ng" index="2j1K4_">
@@ -178,7 +178,7 @@
         <reference id="1166049300910" name="conceptDeclaration" index="1XX52x" />
       </concept>
       <concept id="2940128608222714821" name="org.mpsqa.lint.generic.structure.NodeCheckingFunction" flags="ig" index="1JQnix" />
-      <concept id="2940128608222714486" name="org.mpsqa.lint.generic.structure.ConceptFunctionParameter_Node" flags="ng" index="1JQnki" />
+      <concept id="2940128608222714486" name="org.mpsqa.lint.generic.structure.ConceptFunctionParameter_Node" flags="nn" index="1JQnki" />
       <concept id="2555875871752198907" name="org.mpsqa.lint.generic.structure.ConceptFunctionParameter_MPSProject" flags="ng" index="1MG55F" />
       <concept id="2555875871751836213" name="org.mpsqa.lint.generic.structure.CheckableScript" flags="ng" index="1MIHA_">
         <child id="7741759128795038158" name="additionalParameters" index="2j1K4A" />
@@ -191,29 +191,29 @@
       <concept id="1204834851141" name="jetbrains.mps.lang.smodel.structure.PoundExpression" flags="ng" index="25Kdxt">
         <child id="1204834868751" name="expression" index="25KhWn" />
       </concept>
-      <concept id="1177026924588" name="jetbrains.mps.lang.smodel.structure.RefConcept_Reference" flags="ng" index="chp4Y">
+      <concept id="1177026924588" name="jetbrains.mps.lang.smodel.structure.RefConcept_Reference" flags="nn" index="chp4Y">
         <reference id="1177026940964" name="conceptDeclaration" index="cht4Q" />
       </concept>
-      <concept id="7453996997717780434" name="jetbrains.mps.lang.smodel.structure.Node_GetSConceptOperation" flags="ng" index="2yIwOk" />
-      <concept id="1143226024141" name="jetbrains.mps.lang.smodel.structure.SModelType" flags="ig" index="H_c77" />
-      <concept id="1145404486709" name="jetbrains.mps.lang.smodel.structure.SemanticDowncastExpression" flags="ng" index="2JrnkZ">
+      <concept id="7453996997717780434" name="jetbrains.mps.lang.smodel.structure.Node_GetSConceptOperation" flags="nn" index="2yIwOk" />
+      <concept id="1143226024141" name="jetbrains.mps.lang.smodel.structure.SModelType" flags="in" index="H_c77" />
+      <concept id="1145404486709" name="jetbrains.mps.lang.smodel.structure.SemanticDowncastExpression" flags="nn" index="2JrnkZ">
         <child id="1145404616321" name="leftExpression" index="2JrQYb" />
       </concept>
-      <concept id="1212008292747" name="jetbrains.mps.lang.smodel.structure.Model_GetLongNameOperation" flags="ng" index="LkI2h" />
-      <concept id="1171315804604" name="jetbrains.mps.lang.smodel.structure.Model_RootsOperation" flags="ng" index="2RRcyG">
+      <concept id="1212008292747" name="jetbrains.mps.lang.smodel.structure.Model_GetLongNameOperation" flags="nn" index="LkI2h" />
+      <concept id="1171315804604" name="jetbrains.mps.lang.smodel.structure.Model_RootsOperation" flags="nn" index="2RRcyG">
         <child id="6750920497477046361" name="conceptArgument" index="3MHsoP" />
       </concept>
-      <concept id="6995935425733782641" name="jetbrains.mps.lang.smodel.structure.Model_GetModule" flags="ng" index="13u695" />
-      <concept id="1138055754698" name="jetbrains.mps.lang.smodel.structure.SNodeType" flags="ig" index="3Tqbb2">
+      <concept id="6995935425733782641" name="jetbrains.mps.lang.smodel.structure.Model_GetModule" flags="nn" index="13u695" />
+      <concept id="1138055754698" name="jetbrains.mps.lang.smodel.structure.SNodeType" flags="in" index="3Tqbb2">
         <reference id="1138405853777" name="concept" index="ehGHo" />
       </concept>
-      <concept id="1138056022639" name="jetbrains.mps.lang.smodel.structure.SPropertyAccess" flags="ng" index="3TrcHB">
+      <concept id="1138056022639" name="jetbrains.mps.lang.smodel.structure.SPropertyAccess" flags="nn" index="3TrcHB">
         <reference id="1138056395725" name="property" index="3TsBF5" />
       </concept>
-      <concept id="1138056143562" name="jetbrains.mps.lang.smodel.structure.SLinkAccess" flags="ng" index="3TrEf2">
+      <concept id="1138056143562" name="jetbrains.mps.lang.smodel.structure.SLinkAccess" flags="nn" index="3TrEf2">
         <reference id="1138056516764" name="link" index="3Tt5mk" />
       </concept>
-      <concept id="1138056282393" name="jetbrains.mps.lang.smodel.structure.SLinkListAccess" flags="ng" index="3Tsc0h">
+      <concept id="1138056282393" name="jetbrains.mps.lang.smodel.structure.SLinkListAccess" flags="nn" index="3Tsc0h">
         <reference id="1138056546658" name="link" index="3TtcxE" />
       </concept>
     </language>
@@ -227,16 +227,16 @@
       <concept id="5106752179536586436" name="jetbrains.mps.lang.text.structure.IndentedPoint" flags="ngI" index="2RT3b8">
         <property id="5106752179536586491" name="indentation" index="2RT3bR" />
       </concept>
-      <concept id="155656958578482948" name="jetbrains.mps.lang.text.structure.Word" flags="ng" index="3oM_SD">
+      <concept id="155656958578482948" name="jetbrains.mps.lang.text.structure.Word" flags="nn" index="3oM_SD">
         <property id="155656958578482949" name="value" index="3oM_SC" />
         <property id="6328114375520539774" name="bold" index="1X82S1" />
         <property id="6328114375520539796" name="underlined" index="1X82VF" />
         <property id="6328114375520539777" name="italic" index="1X82VY" />
       </concept>
-      <concept id="2535923850359206929" name="jetbrains.mps.lang.text.structure.Text" flags="ng" index="1Pa9Pv">
+      <concept id="2535923850359206929" name="jetbrains.mps.lang.text.structure.Text" flags="nn" index="1Pa9Pv">
         <child id="2535923850359210936" name="lines" index="1PaQFQ" />
       </concept>
-      <concept id="2535923850359271782" name="jetbrains.mps.lang.text.structure.Line" flags="ng" index="1PaTwC">
+      <concept id="2535923850359271782" name="jetbrains.mps.lang.text.structure.Line" flags="nn" index="1PaTwC">
         <child id="2535923850359271783" name="elements" index="1PaTwD" />
       </concept>
     </language>
@@ -255,33 +255,33 @@
       </concept>
     </language>
     <language id="83888646-71ce-4f1c-9c53-c54016f6ad4f" name="jetbrains.mps.baseLanguage.collections">
-      <concept id="540871147943773365" name="jetbrains.mps.baseLanguage.collections.structure.SingleArgumentSequenceOperation" flags="ng" index="25WWJ4">
+      <concept id="540871147943773365" name="jetbrains.mps.baseLanguage.collections.structure.SingleArgumentSequenceOperation" flags="nn" index="25WWJ4">
         <child id="540871147943773366" name="argument" index="25WWJ7" />
       </concept>
-      <concept id="1151688443754" name="jetbrains.mps.baseLanguage.collections.structure.ListType" flags="ig" index="_YKpA">
+      <concept id="1151688443754" name="jetbrains.mps.baseLanguage.collections.structure.ListType" flags="in" index="_YKpA">
         <child id="1151688676805" name="elementType" index="_ZDj9" />
       </concept>
-      <concept id="1151702311717" name="jetbrains.mps.baseLanguage.collections.structure.ToListOperation" flags="ng" index="ANE8D" />
-      <concept id="1153943597977" name="jetbrains.mps.baseLanguage.collections.structure.ForEachStatement" flags="ng" index="2Gpval">
+      <concept id="1151702311717" name="jetbrains.mps.baseLanguage.collections.structure.ToListOperation" flags="nn" index="ANE8D" />
+      <concept id="1153943597977" name="jetbrains.mps.baseLanguage.collections.structure.ForEachStatement" flags="nn" index="2Gpval">
         <child id="1153944400369" name="variable" index="2Gsz3X" />
         <child id="1153944424730" name="inputSequence" index="2GsD0m" />
       </concept>
       <concept id="1153944193378" name="jetbrains.mps.baseLanguage.collections.structure.ForEachVariable" flags="nr" index="2GrKxI" />
-      <concept id="1153944233411" name="jetbrains.mps.baseLanguage.collections.structure.ForEachVariableReference" flags="ng" index="2GrUjf">
+      <concept id="1153944233411" name="jetbrains.mps.baseLanguage.collections.structure.ForEachVariableReference" flags="nn" index="2GrUjf">
         <reference id="1153944258490" name="variable" index="2Gs0qQ" />
       </concept>
-      <concept id="1237721394592" name="jetbrains.mps.baseLanguage.collections.structure.AbstractContainerCreator" flags="ng" index="HWqM0">
+      <concept id="1237721394592" name="jetbrains.mps.baseLanguage.collections.structure.AbstractContainerCreator" flags="nn" index="HWqM0">
         <child id="1237721435807" name="elementType" index="HW$YZ" />
       </concept>
-      <concept id="1227008614712" name="jetbrains.mps.baseLanguage.collections.structure.LinkedListCreator" flags="ng" index="2Jqq0_" />
-      <concept id="1160600644654" name="jetbrains.mps.baseLanguage.collections.structure.ListCreatorWithInit" flags="ng" index="Tc6Ow" />
-      <concept id="1160612413312" name="jetbrains.mps.baseLanguage.collections.structure.AddElementOperation" flags="ng" index="TSZUe" />
-      <concept id="1160666733551" name="jetbrains.mps.baseLanguage.collections.structure.AddAllElementsOperation" flags="ng" index="X8dFx" />
-      <concept id="1162935959151" name="jetbrains.mps.baseLanguage.collections.structure.GetSizeOperation" flags="ng" index="34oBXx" />
-      <concept id="1167380149909" name="jetbrains.mps.baseLanguage.collections.structure.RemoveElementOperation" flags="ng" index="3dhRuq" />
-      <concept id="1165530316231" name="jetbrains.mps.baseLanguage.collections.structure.IsEmptyOperation" flags="ng" index="1v1jN8" />
-      <concept id="7125221305512719026" name="jetbrains.mps.baseLanguage.collections.structure.CollectionType" flags="ig" index="3vKaQO" />
-      <concept id="5686963296372573083" name="jetbrains.mps.baseLanguage.collections.structure.AbstractContainerType" flags="ig" index="3O5elB">
+      <concept id="1227008614712" name="jetbrains.mps.baseLanguage.collections.structure.LinkedListCreator" flags="nn" index="2Jqq0_" />
+      <concept id="1160600644654" name="jetbrains.mps.baseLanguage.collections.structure.ListCreatorWithInit" flags="nn" index="Tc6Ow" />
+      <concept id="1160612413312" name="jetbrains.mps.baseLanguage.collections.structure.AddElementOperation" flags="nn" index="TSZUe" />
+      <concept id="1160666733551" name="jetbrains.mps.baseLanguage.collections.structure.AddAllElementsOperation" flags="nn" index="X8dFx" />
+      <concept id="1162935959151" name="jetbrains.mps.baseLanguage.collections.structure.GetSizeOperation" flags="nn" index="34oBXx" />
+      <concept id="1167380149909" name="jetbrains.mps.baseLanguage.collections.structure.RemoveElementOperation" flags="nn" index="3dhRuq" />
+      <concept id="1165530316231" name="jetbrains.mps.baseLanguage.collections.structure.IsEmptyOperation" flags="nn" index="1v1jN8" />
+      <concept id="7125221305512719026" name="jetbrains.mps.baseLanguage.collections.structure.CollectionType" flags="in" index="3vKaQO" />
+      <concept id="5686963296372573083" name="jetbrains.mps.baseLanguage.collections.structure.AbstractContainerType" flags="in" index="3O5elB">
         <child id="5686963296372573084" name="elementType" index="3O5elw" />
       </concept>
     </language>

--- a/code/languages/org.mpsqa.lint/solutions/org.mpsqa.lint.mps_lang.linters_library/models/org.mpsqa.lint.mps_lang.linters_library.typesystem_aspect.mps
+++ b/code/languages/org.mpsqa.lint/solutions/org.mpsqa.lint.mps_lang.linters_library/models/org.mpsqa.lint.mps_lang.linters_library.typesystem_aspect.mps
@@ -23,8 +23,6 @@
     <import index="j8aq" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.module(MPS.Core/)" />
     <import index="z1c3" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.project(MPS.Core/)" />
     <import index="tpee" ref="r:00000000-0000-4000-0000-011c895902ca(jetbrains.mps.baseLanguage.structure)" />
-    <import index="tpce" ref="r:00000000-0000-4000-0000-011c89590292(jetbrains.mps.lang.structure.structure)" />
-    <import index="tpcn" ref="r:00000000-0000-4000-0000-011c8959028b(jetbrains.mps.lang.structure.behavior)" />
     <import index="w1kc" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.smodel(MPS.Core/)" />
     <import index="evo" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.newTypesystem.context(MPS.Core/)" />
     <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" implicit="true" />
@@ -33,43 +31,43 @@
   </imports>
   <registry>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
-      <concept id="1215693861676" name="jetbrains.mps.baseLanguage.structure.BaseAssignmentExpression" flags="nn" index="d038R">
+      <concept id="1215693861676" name="jetbrains.mps.baseLanguage.structure.BaseAssignmentExpression" flags="ng" index="d038R">
         <child id="1068498886297" name="rValue" index="37vLTx" />
         <child id="1068498886295" name="lValue" index="37vLTJ" />
       </concept>
-      <concept id="1202948039474" name="jetbrains.mps.baseLanguage.structure.InstanceMethodCallOperation" flags="nn" index="liA8E" />
+      <concept id="1202948039474" name="jetbrains.mps.baseLanguage.structure.InstanceMethodCallOperation" flags="ng" index="liA8E" />
       <concept id="8118189177080264853" name="jetbrains.mps.baseLanguage.structure.AlternativeType" flags="ig" index="nSUau">
         <child id="8118189177080264854" name="alternative" index="nSUat" />
       </concept>
-      <concept id="1465982738277781862" name="jetbrains.mps.baseLanguage.structure.PlaceholderMember" flags="nn" index="2tJIrI" />
-      <concept id="1154032098014" name="jetbrains.mps.baseLanguage.structure.AbstractLoopStatement" flags="nn" index="2LF5Ji">
+      <concept id="1465982738277781862" name="jetbrains.mps.baseLanguage.structure.PlaceholderMember" flags="ng" index="2tJIrI" />
+      <concept id="1154032098014" name="jetbrains.mps.baseLanguage.structure.AbstractLoopStatement" flags="ng" index="2LF5Ji">
         <child id="1154032183016" name="body" index="2LFqv$" />
       </concept>
-      <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
+      <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="ng" index="2OqwBi">
         <child id="1197027771414" name="operand" index="2Oq$k0" />
         <child id="1197027833540" name="operation" index="2OqNvi" />
       </concept>
-      <concept id="1145552977093" name="jetbrains.mps.baseLanguage.structure.GenericNewExpression" flags="nn" index="2ShNRf">
+      <concept id="1145552977093" name="jetbrains.mps.baseLanguage.structure.GenericNewExpression" flags="ng" index="2ShNRf">
         <child id="1145553007750" name="creator" index="2ShVmc" />
       </concept>
-      <concept id="1137021947720" name="jetbrains.mps.baseLanguage.structure.ConceptFunction" flags="in" index="2VMwT0">
+      <concept id="1137021947720" name="jetbrains.mps.baseLanguage.structure.ConceptFunction" flags="ig" index="2VMwT0">
         <child id="1137022507850" name="body" index="2VODD2" />
       </concept>
-      <concept id="1070475926800" name="jetbrains.mps.baseLanguage.structure.StringLiteral" flags="nn" index="Xl_RD">
+      <concept id="1070475926800" name="jetbrains.mps.baseLanguage.structure.StringLiteral" flags="ng" index="Xl_RD">
         <property id="1070475926801" name="value" index="Xl_RC" />
       </concept>
       <concept id="4952749571008284462" name="jetbrains.mps.baseLanguage.structure.CatchVariable" flags="ng" index="XOnhg" />
       <concept id="1081236700938" name="jetbrains.mps.baseLanguage.structure.StaticMethodDeclaration" flags="ig" index="2YIFZL" />
-      <concept id="1081236700937" name="jetbrains.mps.baseLanguage.structure.StaticMethodCall" flags="nn" index="2YIFZM">
+      <concept id="1081236700937" name="jetbrains.mps.baseLanguage.structure.StaticMethodCall" flags="ng" index="2YIFZM">
         <reference id="1144433194310" name="classConcept" index="1Pybhc" />
       </concept>
-      <concept id="1081256982272" name="jetbrains.mps.baseLanguage.structure.InstanceOfExpression" flags="nn" index="2ZW3vV">
+      <concept id="1081256982272" name="jetbrains.mps.baseLanguage.structure.InstanceOfExpression" flags="ng" index="2ZW3vV">
         <child id="1081256993305" name="classType" index="2ZW6by" />
         <child id="1081256993304" name="leftExpression" index="2ZW6bz" />
       </concept>
-      <concept id="1070534058343" name="jetbrains.mps.baseLanguage.structure.NullLiteral" flags="nn" index="10Nm6u" />
-      <concept id="1070534370425" name="jetbrains.mps.baseLanguage.structure.IntegerType" flags="in" index="10Oyi0" />
-      <concept id="1070534934090" name="jetbrains.mps.baseLanguage.structure.CastExpression" flags="nn" index="10QFUN">
+      <concept id="1070534058343" name="jetbrains.mps.baseLanguage.structure.NullLiteral" flags="ng" index="10Nm6u" />
+      <concept id="1070534370425" name="jetbrains.mps.baseLanguage.structure.IntegerType" flags="ig" index="10Oyi0" />
+      <concept id="1070534934090" name="jetbrains.mps.baseLanguage.structure.CastExpression" flags="ng" index="10QFUN">
         <child id="1070534934091" name="type" index="10QFUM" />
         <child id="1070534934092" name="expression" index="10QFUP" />
       </concept>
@@ -80,12 +78,12 @@
       <concept id="1513279640923991009" name="jetbrains.mps.baseLanguage.structure.IGenericClassCreator" flags="ngI" index="366HgL">
         <property id="1513279640906337053" name="inferTypeParams" index="373rjd" />
       </concept>
-      <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
+      <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="ng" index="37vLTw">
         <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
       </concept>
       <concept id="1068498886292" name="jetbrains.mps.baseLanguage.structure.ParameterDeclaration" flags="ir" index="37vLTG" />
-      <concept id="1068498886294" name="jetbrains.mps.baseLanguage.structure.AssignmentExpression" flags="nn" index="37vLTI" />
-      <concept id="1225271177708" name="jetbrains.mps.baseLanguage.structure.StringType" flags="in" index="17QB3L" />
+      <concept id="1068498886294" name="jetbrains.mps.baseLanguage.structure.AssignmentExpression" flags="ng" index="37vLTI" />
+      <concept id="1225271177708" name="jetbrains.mps.baseLanguage.structure.StringType" flags="ig" index="17QB3L" />
       <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
         <child id="5680397130376446158" name="type" index="1tU5fm" />
       </concept>
@@ -94,44 +92,44 @@
         <child id="1068580123134" name="parameter" index="3clF46" />
         <child id="1068580123135" name="body" index="3clF47" />
       </concept>
-      <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
+      <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="ng" index="3clFbF">
         <child id="1068580123156" name="expression" index="3clFbG" />
       </concept>
-      <concept id="1068580123157" name="jetbrains.mps.baseLanguage.structure.Statement" flags="nn" index="3clFbH" />
-      <concept id="1068580123159" name="jetbrains.mps.baseLanguage.structure.IfStatement" flags="nn" index="3clFbJ">
+      <concept id="1068580123157" name="jetbrains.mps.baseLanguage.structure.Statement" flags="ng" index="3clFbH" />
+      <concept id="1068580123159" name="jetbrains.mps.baseLanguage.structure.IfStatement" flags="ng" index="3clFbJ">
         <child id="1068580123160" name="condition" index="3clFbw" />
         <child id="1068580123161" name="ifTrue" index="3clFbx" />
       </concept>
-      <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
+      <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sg" stub="5293379017992965193" index="3clFbS">
         <child id="1068581517665" name="statement" index="3cqZAp" />
       </concept>
-      <concept id="1068580320020" name="jetbrains.mps.baseLanguage.structure.IntegerConstant" flags="nn" index="3cmrfG">
+      <concept id="1068580320020" name="jetbrains.mps.baseLanguage.structure.IntegerConstant" flags="ng" index="3cmrfG">
         <property id="1068580320021" name="value" index="3cmrfH" />
       </concept>
-      <concept id="1068581242875" name="jetbrains.mps.baseLanguage.structure.PlusExpression" flags="nn" index="3cpWs3" />
-      <concept id="1068581242878" name="jetbrains.mps.baseLanguage.structure.ReturnStatement" flags="nn" index="3cpWs6">
+      <concept id="1068581242875" name="jetbrains.mps.baseLanguage.structure.PlusExpression" flags="ng" index="3cpWs3" />
+      <concept id="1068581242878" name="jetbrains.mps.baseLanguage.structure.ReturnStatement" flags="ng" index="3cpWs6">
         <child id="1068581517676" name="expression" index="3cqZAk" />
       </concept>
-      <concept id="1068581242864" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclarationStatement" flags="nn" index="3cpWs8">
+      <concept id="1068581242864" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclarationStatement" flags="ng" index="3cpWs8">
         <child id="1068581242865" name="localVariableDeclaration" index="3cpWs9" />
       </concept>
       <concept id="1068581242863" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclaration" flags="nr" index="3cpWsn" />
-      <concept id="1079359253375" name="jetbrains.mps.baseLanguage.structure.ParenthesizedExpression" flags="nn" index="1eOMI4">
+      <concept id="1079359253375" name="jetbrains.mps.baseLanguage.structure.ParenthesizedExpression" flags="ng" index="1eOMI4">
         <child id="1079359253376" name="expression" index="1eOMHV" />
       </concept>
       <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ngI" index="1ndlxa">
         <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
         <child id="1068499141038" name="actualArgument" index="37wK5m" />
       </concept>
-      <concept id="1212685548494" name="jetbrains.mps.baseLanguage.structure.ClassCreator" flags="nn" index="1pGfFk" />
+      <concept id="1212685548494" name="jetbrains.mps.baseLanguage.structure.ClassCreator" flags="ng" index="1pGfFk" />
       <concept id="1107461130800" name="jetbrains.mps.baseLanguage.structure.Classifier" flags="ng" index="3pOWGL">
         <child id="5375687026011219971" name="member" index="jymVt" unordered="true" />
       </concept>
-      <concept id="1107535904670" name="jetbrains.mps.baseLanguage.structure.ClassifierType" flags="in" index="3uibUv">
+      <concept id="1107535904670" name="jetbrains.mps.baseLanguage.structure.ClassifierType" flags="ig" index="3uibUv">
         <reference id="1107535924139" name="classifier" index="3uigEE" />
         <child id="1109201940907" name="parameter" index="11_B2D" />
       </concept>
-      <concept id="1081773326031" name="jetbrains.mps.baseLanguage.structure.BinaryOperation" flags="nn" index="3uHJSO">
+      <concept id="1081773326031" name="jetbrains.mps.baseLanguage.structure.BinaryOperation" flags="ng" index="3uHJSO">
         <child id="1081773367579" name="rightExpression" index="3uHU7w" />
         <child id="1081773367580" name="leftExpression" index="3uHU7B" />
       </concept>
@@ -142,14 +140,14 @@
       <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ngI" index="1B3ioH">
         <child id="1178549979242" name="visibility" index="1B3o_S" />
       </concept>
-      <concept id="5351203823916750322" name="jetbrains.mps.baseLanguage.structure.TryUniversalStatement" flags="nn" index="3J1_TO">
+      <concept id="5351203823916750322" name="jetbrains.mps.baseLanguage.structure.TryUniversalStatement" flags="ng" index="3J1_TO">
         <child id="8276990574886367510" name="catchClause" index="1zxBo5" />
         <child id="8276990574886367508" name="body" index="1zxBo7" />
       </concept>
-      <concept id="6329021646629104954" name="jetbrains.mps.baseLanguage.structure.SingleLineComment" flags="nn" index="3SKdUt">
+      <concept id="6329021646629104954" name="jetbrains.mps.baseLanguage.structure.SingleLineComment" flags="ng" index="3SKdUt">
         <child id="8356039341262087992" name="line" index="1aUNEU" />
       </concept>
-      <concept id="1146644602865" name="jetbrains.mps.baseLanguage.structure.PublicVisibility" flags="nn" index="3Tm1VV" />
+      <concept id="1146644602865" name="jetbrains.mps.baseLanguage.structure.PublicVisibility" flags="ng" index="3Tm1VV" />
     </language>
     <language id="40ab19e9-751a-4433-b645-0e65160e58a0" name="org.mpsqa.lint.generic">
       <concept id="7741759128795038157" name="org.mpsqa.lint.generic.structure.CheckableScriptParameter" flags="ng" index="2j1K4_">
@@ -180,7 +178,7 @@
         <reference id="1166049300910" name="conceptDeclaration" index="1XX52x" />
       </concept>
       <concept id="2940128608222714821" name="org.mpsqa.lint.generic.structure.NodeCheckingFunction" flags="ig" index="1JQnix" />
-      <concept id="2940128608222714486" name="org.mpsqa.lint.generic.structure.ConceptFunctionParameter_Node" flags="nn" index="1JQnki" />
+      <concept id="2940128608222714486" name="org.mpsqa.lint.generic.structure.ConceptFunctionParameter_Node" flags="ng" index="1JQnki" />
       <concept id="2555875871752198907" name="org.mpsqa.lint.generic.structure.ConceptFunctionParameter_MPSProject" flags="ng" index="1MG55F" />
       <concept id="2555875871751836213" name="org.mpsqa.lint.generic.structure.CheckableScript" flags="ng" index="1MIHA_">
         <child id="7741759128795038158" name="additionalParameters" index="2j1K4A" />
@@ -193,29 +191,29 @@
       <concept id="1204834851141" name="jetbrains.mps.lang.smodel.structure.PoundExpression" flags="ng" index="25Kdxt">
         <child id="1204834868751" name="expression" index="25KhWn" />
       </concept>
-      <concept id="1177026924588" name="jetbrains.mps.lang.smodel.structure.RefConcept_Reference" flags="nn" index="chp4Y">
+      <concept id="1177026924588" name="jetbrains.mps.lang.smodel.structure.RefConcept_Reference" flags="ng" index="chp4Y">
         <reference id="1177026940964" name="conceptDeclaration" index="cht4Q" />
       </concept>
-      <concept id="7453996997717780434" name="jetbrains.mps.lang.smodel.structure.Node_GetSConceptOperation" flags="nn" index="2yIwOk" />
-      <concept id="1143226024141" name="jetbrains.mps.lang.smodel.structure.SModelType" flags="in" index="H_c77" />
-      <concept id="1145404486709" name="jetbrains.mps.lang.smodel.structure.SemanticDowncastExpression" flags="nn" index="2JrnkZ">
+      <concept id="7453996997717780434" name="jetbrains.mps.lang.smodel.structure.Node_GetSConceptOperation" flags="ng" index="2yIwOk" />
+      <concept id="1143226024141" name="jetbrains.mps.lang.smodel.structure.SModelType" flags="ig" index="H_c77" />
+      <concept id="1145404486709" name="jetbrains.mps.lang.smodel.structure.SemanticDowncastExpression" flags="ng" index="2JrnkZ">
         <child id="1145404616321" name="leftExpression" index="2JrQYb" />
       </concept>
-      <concept id="1212008292747" name="jetbrains.mps.lang.smodel.structure.Model_GetLongNameOperation" flags="nn" index="LkI2h" />
-      <concept id="1171315804604" name="jetbrains.mps.lang.smodel.structure.Model_RootsOperation" flags="nn" index="2RRcyG">
+      <concept id="1212008292747" name="jetbrains.mps.lang.smodel.structure.Model_GetLongNameOperation" flags="ng" index="LkI2h" />
+      <concept id="1171315804604" name="jetbrains.mps.lang.smodel.structure.Model_RootsOperation" flags="ng" index="2RRcyG">
         <child id="6750920497477046361" name="conceptArgument" index="3MHsoP" />
       </concept>
-      <concept id="6995935425733782641" name="jetbrains.mps.lang.smodel.structure.Model_GetModule" flags="nn" index="13u695" />
-      <concept id="1138055754698" name="jetbrains.mps.lang.smodel.structure.SNodeType" flags="in" index="3Tqbb2">
+      <concept id="6995935425733782641" name="jetbrains.mps.lang.smodel.structure.Model_GetModule" flags="ng" index="13u695" />
+      <concept id="1138055754698" name="jetbrains.mps.lang.smodel.structure.SNodeType" flags="ig" index="3Tqbb2">
         <reference id="1138405853777" name="concept" index="ehGHo" />
       </concept>
-      <concept id="1138056022639" name="jetbrains.mps.lang.smodel.structure.SPropertyAccess" flags="nn" index="3TrcHB">
+      <concept id="1138056022639" name="jetbrains.mps.lang.smodel.structure.SPropertyAccess" flags="ng" index="3TrcHB">
         <reference id="1138056395725" name="property" index="3TsBF5" />
       </concept>
-      <concept id="1138056143562" name="jetbrains.mps.lang.smodel.structure.SLinkAccess" flags="nn" index="3TrEf2">
+      <concept id="1138056143562" name="jetbrains.mps.lang.smodel.structure.SLinkAccess" flags="ng" index="3TrEf2">
         <reference id="1138056516764" name="link" index="3Tt5mk" />
       </concept>
-      <concept id="1138056282393" name="jetbrains.mps.lang.smodel.structure.SLinkListAccess" flags="nn" index="3Tsc0h">
+      <concept id="1138056282393" name="jetbrains.mps.lang.smodel.structure.SLinkListAccess" flags="ng" index="3Tsc0h">
         <reference id="1138056546658" name="link" index="3TtcxE" />
       </concept>
     </language>
@@ -229,16 +227,16 @@
       <concept id="5106752179536586436" name="jetbrains.mps.lang.text.structure.IndentedPoint" flags="ngI" index="2RT3b8">
         <property id="5106752179536586491" name="indentation" index="2RT3bR" />
       </concept>
-      <concept id="155656958578482948" name="jetbrains.mps.lang.text.structure.Word" flags="nn" index="3oM_SD">
+      <concept id="155656958578482948" name="jetbrains.mps.lang.text.structure.Word" flags="ng" index="3oM_SD">
         <property id="155656958578482949" name="value" index="3oM_SC" />
         <property id="6328114375520539774" name="bold" index="1X82S1" />
         <property id="6328114375520539796" name="underlined" index="1X82VF" />
         <property id="6328114375520539777" name="italic" index="1X82VY" />
       </concept>
-      <concept id="2535923850359206929" name="jetbrains.mps.lang.text.structure.Text" flags="nn" index="1Pa9Pv">
+      <concept id="2535923850359206929" name="jetbrains.mps.lang.text.structure.Text" flags="ng" index="1Pa9Pv">
         <child id="2535923850359210936" name="lines" index="1PaQFQ" />
       </concept>
-      <concept id="2535923850359271782" name="jetbrains.mps.lang.text.structure.Line" flags="nn" index="1PaTwC">
+      <concept id="2535923850359271782" name="jetbrains.mps.lang.text.structure.Line" flags="ng" index="1PaTwC">
         <child id="2535923850359271783" name="elements" index="1PaTwD" />
       </concept>
     </language>
@@ -257,33 +255,33 @@
       </concept>
     </language>
     <language id="83888646-71ce-4f1c-9c53-c54016f6ad4f" name="jetbrains.mps.baseLanguage.collections">
-      <concept id="540871147943773365" name="jetbrains.mps.baseLanguage.collections.structure.SingleArgumentSequenceOperation" flags="nn" index="25WWJ4">
+      <concept id="540871147943773365" name="jetbrains.mps.baseLanguage.collections.structure.SingleArgumentSequenceOperation" flags="ng" index="25WWJ4">
         <child id="540871147943773366" name="argument" index="25WWJ7" />
       </concept>
-      <concept id="1151688443754" name="jetbrains.mps.baseLanguage.collections.structure.ListType" flags="in" index="_YKpA">
+      <concept id="1151688443754" name="jetbrains.mps.baseLanguage.collections.structure.ListType" flags="ig" index="_YKpA">
         <child id="1151688676805" name="elementType" index="_ZDj9" />
       </concept>
-      <concept id="1151702311717" name="jetbrains.mps.baseLanguage.collections.structure.ToListOperation" flags="nn" index="ANE8D" />
-      <concept id="1153943597977" name="jetbrains.mps.baseLanguage.collections.structure.ForEachStatement" flags="nn" index="2Gpval">
+      <concept id="1151702311717" name="jetbrains.mps.baseLanguage.collections.structure.ToListOperation" flags="ng" index="ANE8D" />
+      <concept id="1153943597977" name="jetbrains.mps.baseLanguage.collections.structure.ForEachStatement" flags="ng" index="2Gpval">
         <child id="1153944400369" name="variable" index="2Gsz3X" />
         <child id="1153944424730" name="inputSequence" index="2GsD0m" />
       </concept>
       <concept id="1153944193378" name="jetbrains.mps.baseLanguage.collections.structure.ForEachVariable" flags="nr" index="2GrKxI" />
-      <concept id="1153944233411" name="jetbrains.mps.baseLanguage.collections.structure.ForEachVariableReference" flags="nn" index="2GrUjf">
+      <concept id="1153944233411" name="jetbrains.mps.baseLanguage.collections.structure.ForEachVariableReference" flags="ng" index="2GrUjf">
         <reference id="1153944258490" name="variable" index="2Gs0qQ" />
       </concept>
-      <concept id="1237721394592" name="jetbrains.mps.baseLanguage.collections.structure.AbstractContainerCreator" flags="nn" index="HWqM0">
+      <concept id="1237721394592" name="jetbrains.mps.baseLanguage.collections.structure.AbstractContainerCreator" flags="ng" index="HWqM0">
         <child id="1237721435807" name="elementType" index="HW$YZ" />
       </concept>
-      <concept id="1227008614712" name="jetbrains.mps.baseLanguage.collections.structure.LinkedListCreator" flags="nn" index="2Jqq0_" />
-      <concept id="1160600644654" name="jetbrains.mps.baseLanguage.collections.structure.ListCreatorWithInit" flags="nn" index="Tc6Ow" />
-      <concept id="1160612413312" name="jetbrains.mps.baseLanguage.collections.structure.AddElementOperation" flags="nn" index="TSZUe" />
-      <concept id="1160666733551" name="jetbrains.mps.baseLanguage.collections.structure.AddAllElementsOperation" flags="nn" index="X8dFx" />
-      <concept id="1162935959151" name="jetbrains.mps.baseLanguage.collections.structure.GetSizeOperation" flags="nn" index="34oBXx" />
-      <concept id="1167380149909" name="jetbrains.mps.baseLanguage.collections.structure.RemoveElementOperation" flags="nn" index="3dhRuq" />
-      <concept id="1165530316231" name="jetbrains.mps.baseLanguage.collections.structure.IsEmptyOperation" flags="nn" index="1v1jN8" />
-      <concept id="7125221305512719026" name="jetbrains.mps.baseLanguage.collections.structure.CollectionType" flags="in" index="3vKaQO" />
-      <concept id="5686963296372573083" name="jetbrains.mps.baseLanguage.collections.structure.AbstractContainerType" flags="in" index="3O5elB">
+      <concept id="1227008614712" name="jetbrains.mps.baseLanguage.collections.structure.LinkedListCreator" flags="ng" index="2Jqq0_" />
+      <concept id="1160600644654" name="jetbrains.mps.baseLanguage.collections.structure.ListCreatorWithInit" flags="ng" index="Tc6Ow" />
+      <concept id="1160612413312" name="jetbrains.mps.baseLanguage.collections.structure.AddElementOperation" flags="ng" index="TSZUe" />
+      <concept id="1160666733551" name="jetbrains.mps.baseLanguage.collections.structure.AddAllElementsOperation" flags="ng" index="X8dFx" />
+      <concept id="1162935959151" name="jetbrains.mps.baseLanguage.collections.structure.GetSizeOperation" flags="ng" index="34oBXx" />
+      <concept id="1167380149909" name="jetbrains.mps.baseLanguage.collections.structure.RemoveElementOperation" flags="ng" index="3dhRuq" />
+      <concept id="1165530316231" name="jetbrains.mps.baseLanguage.collections.structure.IsEmptyOperation" flags="ng" index="1v1jN8" />
+      <concept id="7125221305512719026" name="jetbrains.mps.baseLanguage.collections.structure.CollectionType" flags="ig" index="3vKaQO" />
+      <concept id="5686963296372573083" name="jetbrains.mps.baseLanguage.collections.structure.AbstractContainerType" flags="ig" index="3O5elB">
         <child id="5686963296372573084" name="elementType" index="3O5elw" />
       </concept>
     </language>


### PR DESCRIPTION
With the new class [CyclicGenericDependenciesHelper](http://127.0.0.1:63320/node?ref=r%3Acadc46fc-2365-43d7-bda1-08e980cf970d%28org.mpsqa.lint.generic.linters_library.modules%29%2F1218887988358276682), one could check for any kind of cycles, e.g., cycles between chunks or models.

I also fixed the build script to get the MPS Gradle plugin in an easier way so that new users just have to execute the Gradle wrapper to build and download the project.